### PR TITLE
Fixes #35: Background image CSS and workflow authentication for DD deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,8 +42,8 @@ jobs:
           rsync -a --delete site/ dd/
 
       - name: Commit and push changes
+        working-directory: ./dd
         run: |
-          cd dd
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
@@ -51,5 +51,7 @@ jobs:
             echo "No changes to publish."
           else
             git commit -m "Update Data Distillery site from GKC docs"
+            # Update remote to use DD_PAT for authentication
+            git remote set-url origin https://x-access-token:${{ secrets.DD_PAT }}@github.com/skybristol/dd.git
             git push origin main
           fi

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,13 @@
+/* Background Image */
+body {
+    background-image: url('../img/Laphroaig10YO.jpeg');
+    background-attachment: fixed;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    filter: brightness(0.2);
+}
+
 /* Mermaid Diagram Font Sizing */
 .mermaid svg text {
     font-size: 18px !important;


### PR DESCRIPTION
Reapplies missing changes from issue33 merge:
- Adds background image (Laphroaig10YO.jpeg) with 80% brightness fade
- Mermaid diagram font sizing CSS (18px)
- Fixes GitHub Actions workflow to use DD_PAT token for authentication when pushing to skybristol/dd repository

This ensures the docs build and deploy workflow can properly authenticate and push to the Data Distillery root site.