### PR TITLE
Fix Wikidata mash filtering and authentication issues

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -206,7 +206,7 @@ class TestWikiverseAuth:
         token_response.json.return_value = {
             "query": {"tokens": {"csrftoken": "csrf_test_token"}}
         }
-        mock_session.get.return_value = token_response
+        mock_session.post.return_value = token_response
 
         auth = WikiverseAuth(username="testuser@testbot", password="testpass")
         auth._logged_in = True  # Simulate logged in state

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 """Tests for the GKC CLI."""
 
+import argparse
 import json
 
 from gkc import cli
+from gkc.mash import ClaimSummary, WikidataTemplate
 
 
 class FakeWikiverseAuth:
@@ -75,3 +77,56 @@ def test_osm_status_json(monkeypatch, capsys):
     data = json.loads(output)
     assert data["command"] == "auth.osm.status"
     assert data["ok"] is True
+
+
+def test_mash_qid_json_include_exclude(monkeypatch, capsys):
+    """Mash JSON output respects include/exclude property filters."""
+
+    class FakeWikidataLoader:
+        def load(self, qid):
+            return WikidataTemplate(
+                qid=qid,
+                labels={"en": "Test"},
+                descriptions={"en": "Test"},
+                aliases={},
+                claims=[
+                    ClaimSummary(
+                        property_id="P31", value="Q5", qualifiers=[], references=[]
+                    ),
+                    ClaimSummary(
+                        property_id="P21",
+                        value="Q6581097",
+                        qualifiers=[],
+                        references=[],
+                    ),
+                ],
+                entity_data={
+                    "id": qid,
+                    "claims": {
+                        "P31": [{"mainsnak": {}}],
+                        "P21": [{"mainsnak": {}}],
+                    },
+                },
+            )
+
+    monkeypatch.setattr(cli, "WikidataLoader", FakeWikidataLoader)
+
+    args = argparse.Namespace(
+        qid="Q42",
+        output="json",
+        mash_mode="update",
+        include_properties="P31,P21",
+        exclude_properties="P21",
+        exclude_qualifiers=False,
+        exclude_references=False,
+        include_entity_labels=True,
+        command_path="mash.qid",
+    )
+
+    result = cli._handle_mash_qid(args)
+    output = capsys.readouterr().out.strip()
+    data = json.loads(output)
+
+    assert result["ok"] is True
+    assert "P31" in data["claims"]
+    assert "P21" not in data["claims"]

--- a/tests/test_mash_formatters.py
+++ b/tests/test_mash_formatters.py
@@ -14,6 +14,7 @@ def test_qsv1_formatter_new_item():
         claims=[
             ClaimSummary(property_id="P31", value="Q5", qualifiers=[], references=[]),
         ],
+        entity_data={"claims": {}},
     )
 
     formatter = QSV1Formatter()
@@ -43,6 +44,7 @@ def test_qsv1_formatter_exclude_properties():
                 property_id="P21", value="Q6581097", qualifiers=[], references=[]
             ),
         ],
+        entity_data={"claims": {}},
     )
 
     formatter = QSV1Formatter(exclude_properties=["P31"])
@@ -65,6 +67,7 @@ def test_qsv1_formatter_with_entity_labels():
                 property_id="P21", value="Q6581097", qualifiers=[], references=[]
             ),
         ],
+        entity_data={"claims": {}},
     )
 
     entity_labels = {
@@ -107,6 +110,7 @@ def test_qsv1_formatter_with_qualifiers_and_labels():
                 references=[],
             ),
         ],
+        entity_data={"claims": {}},
     )
 
     entity_labels = {
@@ -143,6 +147,7 @@ def test_qsv1_formatter_without_entity_labels():
         claims=[
             ClaimSummary(property_id="P31", value="Q5", qualifiers=[], references=[]),
         ],
+        entity_data={"claims": {}},
     )
 
     # No entity_labels provided
@@ -170,6 +175,7 @@ def test_qsv1_formatter_with_string_values():
                 property_id="P1476", value='"Test Title"', qualifiers=[], references=[]
             ),
         ],
+        entity_data={"claims": {}},
     )
 
     entity_labels = {
@@ -198,6 +204,7 @@ def test_qsv1_formatter_existing_item():
         claims=[
             ClaimSummary(property_id="P31", value="Q5", qualifiers=[], references=[]),
         ],
+        entity_data={"claims": {}},
     )
 
     entity_labels = {
@@ -235,6 +242,7 @@ def test_qsv1_formatter_with_date_precision():
                 value_metadata={"precision": 11},
             ),
         ],
+        entity_data={"claims": {}},
     )
 
     entity_labels = {
@@ -276,6 +284,7 @@ def test_qsv1_formatter_with_qualifier_date_precision():
                 references=[],
             ),
         ],
+        entity_data={"claims": {}},
     )
 
     entity_labels = {


### PR DESCRIPTION
This commit addresses two main issues:

1. **Mash module: Round-trip safe JSON output and enhanced filtering**
   - Added `entity_data` field to WikidataTemplate to preserve raw API response
   - Changed `to_dict()` to return round-trip safe entity JSON for updates
   - Added `to_simple_dict()` for compact claim-centric view
   - Extended `filter_properties()` to support both include and exclude lists
   - Fixed `filter_languages()` to apply to entity_data for round-trip output
   - Updated `filter_qualifiers()` and `filter_references()` to mutate raw entity JSON
   - Added `--include-properties` CLI flag to `gkc mash qid`
   - Updated tests to verify round-trip behavior and filter application
   - Enhanced documentation with examples of filtering and JSON export

2. **Authentication: Fixed CSRF token retrieval for write operations**
   - Changed `get_csrf_token()` from GET to POST for reliable session handling
   - Added cookie verification after successful login
   - Added `test_authentication()` diagnostic method
   - Enhanced documentation to clarify that tokens must be used with auth.session
   - Fixed test_auth.py to mock POST instead of GET for token requests
   - Updated AUTH_FIX_SUMMARY.md with session cookie requirements

The mash changes enable users to load Wikidata items, filter to specific properties and languages, and export round-trip safe JSON for updates. The auth changes ensure CSRF tokens work correctly for write operations by maintaining proper session state.

Resolves #65