### PR TITLE
feat(mash): wire apihighlimits into WikibaseLoader entity_batch_size

### DIFF
--- a/gkc/mash/core.py
+++ b/gkc/mash/core.py
@@ -1148,12 +1148,17 @@ class WikibaseLoader:
         user_agent: Optional[str] = None,
         api_url: str = "https://www.wikidata.org/w/api.php",
         api_client: Optional[WikibaseApiClient] = None,
+        auth: Optional[Any] = None,
     ):
         """Initialize the loader.
 
         Args:
             user_agent: Custom user agent for Wikidata requests.
                        If not provided, a default GKC user agent is used.
+            api_client: Optional pre-configured WikibaseApiClient.
+            auth: Optional WikiverseAuth instance. When provided and the
+                authenticated user has the ``apihighlimits`` right, batch
+                requests are made in chunks of 500 instead of 50.
         """
 
         if user_agent is None:
@@ -1165,6 +1170,12 @@ class WikibaseLoader:
             api_url=api_url,
             user_agent=user_agent,
         )
+        has_high_limits = (
+            auth is not None
+            and callable(getattr(auth, "has_api_high_limits", None))
+            and auth.has_api_high_limits()
+        )
+        self.entity_batch_size: int = 500 if has_high_limits else 50
 
     def load_item(self, qid: str) -> WikibaseItemTemplate:
         """Load a Wikidata item and return it as a template.
@@ -1239,10 +1250,8 @@ class WikibaseLoader:
 
         result: dict[str, WikibaseItemTemplate] = {}
 
-        # Process in batches of 50 (wbgetentities limit)
-        batch_size = 50
-        for i in range(0, len(qids), batch_size):
-            batch = qids[i : i + batch_size]
+        for i in range(0, len(qids), self.entity_batch_size):
+            batch = qids[i : i + self.entity_batch_size]
             batch_results = self._fetch_entities_batch(batch)
 
             # Build templates for each successfully fetched entity

--- a/tests/test_mash.py
+++ b/tests/test_mash.py
@@ -641,6 +641,65 @@ def test_wikidata_loader_load_items_empty():
     assert result == {}
 
 
+def test_wikibase_loader_default_batch_size_without_auth():
+    """WikibaseLoader defaults to a batch size of 50 when no auth is provided."""
+    loader = WikibaseLoader()
+    assert loader.entity_batch_size == 50
+
+
+def test_wikibase_loader_default_batch_size_with_no_high_limits():
+    """WikibaseLoader stays at 50 when auth is present but apihighlimits is absent."""
+    fake_auth = type("FakeAuth", (), {"has_api_high_limits": lambda self: False})()
+    loader = WikibaseLoader(auth=fake_auth)
+    assert loader.entity_batch_size == 50
+
+
+def test_wikibase_loader_high_batch_size_with_apihighlimits():
+    """WikibaseLoader uses 500 when auth reports apihighlimits is present."""
+    fake_auth = type("FakeAuth", (), {"has_api_high_limits": lambda self: True})()
+    loader = WikibaseLoader(auth=fake_auth)
+    assert loader.entity_batch_size == 500
+
+
+def test_wikibase_loader_batch_size_safe_with_auth_none_method():
+    """WikibaseLoader falls back to 50 when auth object lacks has_api_high_limits."""
+
+    class NoMethodAuth:
+        pass
+
+    loader = WikibaseLoader(auth=NoMethodAuth())
+    assert loader.entity_batch_size == 50
+
+
+def test_wikibase_loader_load_items_respects_batch_size(monkeypatch):
+    """load_items batches calls according to entity_batch_size."""
+    from unittest.mock import MagicMock
+
+    fake_auth = type("FakeAuth", (), {"has_api_high_limits": lambda self: True})()
+    loader = WikibaseLoader(auth=fake_auth)
+    assert loader.entity_batch_size == 500
+
+    calls = []
+
+    def fake_fetch(entity_ids):
+        calls.append(len(entity_ids))
+        return {
+            eid: {"id": eid, "labels": {}, "claims": {}, "type": "item"}
+            for eid in entity_ids
+        }
+
+    monkeypatch.setattr(loader, "_fetch_entities_batch", fake_fetch)
+    monkeypatch.setattr(loader, "_build_template", lambda qid, data: MagicMock())
+
+    qids = [f"Q{i}" for i in range(600)]
+    loader.load_items(qids)
+
+    # With batch_size=500, 600 items should produce two batches: 500 and 100
+    assert len(calls) == 2
+    assert calls[0] == 500
+    assert calls[1] == 100
+
+
 def test_wikipedia_template_initialization():
     """Test creating a Wikipedia template."""
     template = WikipediaTemplate(


### PR DESCRIPTION
## Summary

Follows on from #137 (merged). That PR added `has_api_high_limits()` to `WikiverseAuth`, but the result was never used to change actual API behavior. This PR wires it in.

### Changes

**`gkc/mash/core.py`**
- `WikibaseLoader.__init__` accepts a new optional `auth` parameter (any object with a `has_api_high_limits()` method — duck-typed, no hard import)
- Sets `self.entity_batch_size = 500` if `auth.has_api_high_limits()` is truthy, otherwise `50`
- `load_items` uses `self.entity_batch_size` instead of the previous hardcoded `50`

**`tests/test_mash.py`**
- 5 new tests covering: no auth (→ 50), auth without high limits (→ 50), auth with high limits (→ 500), auth object missing the method (→ 50 safely), and end-to-end batch count verification (600 QIDs → 2 batches)

### Closes

Part of issue #136.