### PR TITLE
feat(wikibase): add SPARQL-driven cache builder module

### DIFF
--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -37,6 +37,7 @@ from gkc.spirit_safe import (
     validate_packet_structure,
 )
 from gkc.wikibase import (
+    build_wikibase_cache,
     build_wikibase_write_plan,
     execute_wikibase_write_plan,
     export_profile_graph_to_entity_cache,
@@ -921,6 +922,58 @@ def _build_parser() -> argparse.ArgumentParser:
     wikibase_profile_to_cache.set_defaults(
         handler=_handle_wikibase_profile_to_cache,
         command_path="wikibase.profile-to-cache",
+    )
+
+    wikibase_cache_builder = wikibase_subparsers.add_parser(
+        "cache-builder",
+        help=(
+            "Build and reconcile per-entity cache files from SPARQL-derived "
+            "profile-linked identifiers"
+        ),
+    )
+    wikibase_cache_builder.add_argument(
+        "--cache-dir",
+        required=True,
+        help="Directory containing per-entity cache files",
+    )
+    wikibase_cache_builder.add_argument(
+        "--api-url",
+        help="Override the Data Distillery API URL (default: DD_WB_API_URL env var)",
+    )
+    wikibase_cache_builder.add_argument(
+        "--sparql-endpoint",
+        default=runtime_config.sparql_endpoint,
+        help=(
+            "SPARQL endpoint URL "
+            "(default: DD_WB_SPARQL_ENDPOINT env var or Wikidata Query Service)"
+        ),
+    )
+    wikibase_cache_builder.add_argument(
+        "--wikibase-base-uri",
+        default="https://datadistillery.wikibase.cloud",
+        help="Wikibase base URI used to identify local Q/P IDs",
+    )
+    wikibase_cache_builder.add_argument(
+        "--profile-class-id",
+        default="Q3",
+        help="Profile class item ID used as SPARQL root classifier (default: Q3)",
+    )
+    wikibase_cache_builder.add_argument(
+        "--source-endpoint",
+        help="Optional source endpoint label recorded in cache metadata",
+    )
+    wikibase_cache_builder.add_argument(
+        "--workflow-mode",
+        default="cache-builder",
+        help="Workflow mode label stored in cache metadata",
+    )
+    wikibase_cache_builder.add_argument(
+        "--output",
+        help="Optional output path for cache build summary JSON",
+    )
+    wikibase_cache_builder.set_defaults(
+        handler=_handle_wikibase_cache_builder,
+        command_path="wikibase.cache-builder",
     )
 
     wikibase_check_for_revisions = wikibase_subparsers.add_parser(
@@ -2842,6 +2895,91 @@ def _handle_wikibase_profile_to_cache(args: argparse.Namespace) -> dict[str, Any
                 "✓ Profile-to-cache export complete: "
                 f"{len(export_result.written_ids)} cached, "
                 f"{len(export_result.skipped_ids)} skipped"
+            ),
+            "details": details,
+        }
+    except Exception as exc:
+        raise CLIError(str(exc)) from exc
+
+
+def _handle_wikibase_cache_builder(args: argparse.Namespace) -> dict[str, Any]:
+    """Run SPARQL-driven full cache build and reconciliation."""
+    runtime_config = get_wikibase_runtime_config()
+    api_url = args.api_url or runtime_config.api_url
+
+    summary_output = args.output
+    if not summary_output:
+        summary_output = str(
+            Path(args.cache_dir).parent / "refresh" / "last_run_summary.json"
+        )
+
+    auth: Optional[WikiverseAuth] = None
+    auth_mode = "anonymous"
+    auth_warning: Optional[str] = None
+
+    runtime_has_creds = bool(runtime_config.username and runtime_config.password)
+    if runtime_has_creds:
+        candidate = WikiverseAuth(
+            username=runtime_config.username,
+            password=runtime_config.password,
+            interactive=False,
+            api_url=api_url,
+        )
+        if candidate.is_authenticated():
+            try:
+                candidate.login()
+                auth = candidate
+                auth_mode = "authenticated"
+            except AuthenticationError as exc:
+                auth_warning = (
+                    "Authentication failed; continuing anonymously for cache build: "
+                    f"{exc}"
+                )
+
+    try:
+        build_result = build_wikibase_cache(
+            sparql_endpoint=args.sparql_endpoint,
+            api_url=api_url,
+            cache_dir=args.cache_dir,
+            wikibase_base_uri=args.wikibase_base_uri,
+            profile_class_id=args.profile_class_id,
+            source_endpoint=args.source_endpoint,
+            workflow_mode=args.workflow_mode,
+            summary_output=summary_output,
+            auth=auth,
+        )
+
+        details: dict[str, Any] = {
+            "api_url": api_url,
+            "sparql_endpoint": args.sparql_endpoint,
+            "wikibase_base_uri": args.wikibase_base_uri,
+            "profile_class_id": args.profile_class_id,
+            "cache_dir": build_result.cache_dir,
+            "summary_path": build_result.summary_path,
+            "auth_mode": auth_mode,
+            "queried_count": len(build_result.queried_ids),
+            "fetched_count": len(build_result.fetched_ids),
+            "written_count": len(build_result.written_ids),
+            "new_count": len(build_result.new_ids),
+            "changed_count": len(build_result.changed_ids),
+            "unchanged_count": len(build_result.unchanged_ids),
+            "deleted_count": len(build_result.deleted_ids),
+            "missing_count": len(build_result.missing_ids),
+            "new_ids_preview": build_result.new_ids[:20],
+            "changed_ids_preview": build_result.changed_ids[:20],
+            "deleted_ids_preview": build_result.deleted_ids[:20],
+            "missing_ids_preview": build_result.missing_ids[:20],
+        }
+        if auth_warning:
+            details["auth_warning"] = auth_warning
+
+        return {
+            "command": args.command_path,
+            "ok": True,
+            "message": (
+                "✓ Wikibase cache build complete: "
+                f"{len(build_result.written_ids)} written, "
+                f"{len(build_result.deleted_ids)} deleted"
             ),
             "details": details,
         }

--- a/gkc/mash/core.py
+++ b/gkc/mash/core.py
@@ -1221,11 +1221,29 @@ class WikibaseLoader:
         """
         return self.load_item(qid)
 
+    def load_entities_raw(self, entity_ids: list[str]) -> dict[str, dict[str, Any]]:
+        """Load raw entity JSON in wbgetentities-sized batches.
+
+        Uses ``self.entity_batch_size`` so authenticated sessions with
+        ``apihighlimits`` can fetch 500 entities per request.
+        """
+        if not entity_ids:
+            return {}
+
+        result: dict[str, dict[str, Any]] = {}
+
+        for i in range(0, len(entity_ids), self.entity_batch_size):
+            batch = entity_ids[i : i + self.entity_batch_size]
+            batch_results = self._fetch_entities_batch(batch)
+            result.update(batch_results)
+
+        return result
+
     def load_items(self, qids: list[str]) -> dict[str, WikibaseItemTemplate]:
         """Load multiple Wikidata items in batch and return them as templates.
 
-        Uses the wbgetentities API to efficiently fetch multiple items in batches
-        of 50. Handles partial failures gracefully.
+        Uses the wbgetentities API to efficiently fetch multiple items in
+        ``self.entity_batch_size`` chunks. Handles partial failures gracefully.
 
         Args:
             qids: List of Wikidata item IDs (e.g., ['Q42', 'Q5']).
@@ -1249,19 +1267,16 @@ class WikibaseLoader:
             return {}
 
         result: dict[str, WikibaseItemTemplate] = {}
+        batch_results = self.load_entities_raw(qids)
 
-        for i in range(0, len(qids), self.entity_batch_size):
-            batch = qids[i : i + self.entity_batch_size]
-            batch_results = self._fetch_entities_batch(batch)
-
-            # Build templates for each successfully fetched entity
-            for qid, entity_data in batch_results.items():
-                try:
-                    template = self._build_template(qid, entity_data)
-                    result[qid] = template
-                except Exception:
-                    # Skip items that fail to parse
-                    continue
+        # Build templates for each successfully fetched entity
+        for qid, entity_data in batch_results.items():
+            try:
+                template = self._build_template(qid, entity_data)
+                result[qid] = template
+            except Exception:
+                # Skip items that fail to parse
+                continue
 
         return result
 

--- a/gkc/wikibase/__init__.py
+++ b/gkc/wikibase/__init__.py
@@ -4,6 +4,12 @@ Scope: Wikibase-first ProfilesV2 support, including live ontology snapshots
 for semantic resolution, write plan orchestration, and legacy foundation workflows.
 """
 
+from gkc.wikibase.cache import (
+    WikibaseCacheBuildResult,
+    build_entity_profile_identifiers_sparql_query,
+    build_wikibase_cache,
+    extract_entity_profile_identifiers,
+)
 from gkc.wikibase.ontology import (
     DDOntologyIndex,
     DDProfileCacheExportResult,
@@ -30,8 +36,12 @@ __all__ = [
     "DDOntologyIndex",
     "DDProfileCacheExportResult",
     "DDProfileGraph",
+    "WikibaseCacheBuildResult",
     "build_discovery_sparql_query",
     "build_profile_ids_sparql_query",
+    "build_entity_profile_identifiers_sparql_query",
+    "build_wikibase_cache",
+    "extract_entity_profile_identifiers",
     "export_profile_graph_to_entity_cache",
     "fetch_ontology_index",
     "fetch_profile_graph",

--- a/gkc/wikibase/cache.py
+++ b/gkc/wikibase/cache.py
@@ -1,0 +1,265 @@
+"""SPARQL-driven entity cache builder for Data Distillery Wikibase.
+
+This module builds and reconciles SpiritSafe-style entity cache artifacts from
+one authoritative path:
+
+1. Run profile-rooted traversal SPARQL to discover QID/PID identifiers.
+2. Fetch raw entity JSON via WikibaseLoader in API-sized batches.
+3. Reconcile cache directory content to exactly match discovered identifiers.
+4. Produce a deterministic summary payload (optionally written to disk).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any, Optional
+
+from gkc.auth import WikiverseAuth
+from gkc.mash import WikibaseLoader
+from gkc.sparql import SPARQLQuery
+
+_ENTITY_ID_PATTERN = re.compile(r"^[QP]\d+$")
+
+
+@dataclass(frozen=True)
+class WikibaseCacheBuildResult:
+    """Result of a full SPARQL-driven cache build and reconciliation."""
+
+    cache_dir: str
+    summary_path: Optional[str]
+    queried_ids: list[str] = field(default_factory=list)
+    fetched_ids: list[str] = field(default_factory=list)
+    written_ids: list[str] = field(default_factory=list)
+    new_ids: list[str] = field(default_factory=list)
+    changed_ids: list[str] = field(default_factory=list)
+    unchanged_ids: list[str] = field(default_factory=list)
+    deleted_ids: list[str] = field(default_factory=list)
+    missing_ids: list[str] = field(default_factory=list)
+    fetched_at: str = ""
+
+
+def build_entity_profile_identifiers_sparql_query(
+    wikibase_base_uri: str = "https://datadistillery.wikibase.cloud",
+    profile_class_id: str = "Q3",
+) -> str:
+    """Build SPARQL query used to derive profile-linked DD entity identifiers."""
+    base_uri = wikibase_base_uri.rstrip("/")
+    return f"""PREFIX wd: <{base_uri}/entity/>
+PREFIX wdt: <{base_uri}/prop/direct/>
+
+SELECT ?s ?p ?o WHERE {{
+    ?root wdt:P1 wd:{profile_class_id} .
+    ?root (wdt:P1|wdt:P2)* ?s .
+    ?s ?p ?o .
+    FILTER(isIRI(?s) && isIRI(?p) && isIRI(?o))
+    FILTER( !STRSTARTS(STR(?o), \"{base_uri}/entity/statement/\") )
+}}"""
+
+
+def extract_entity_profile_identifiers(
+    rows: list[dict[str, Any]],
+    wikibase_base_uri: str = "https://datadistillery.wikibase.cloud",
+) -> list[str]:
+    """Extract sorted unique local Q/P identifiers from traversal SPARQL rows."""
+    base_uri = wikibase_base_uri.rstrip("/")
+    found: set[str] = set()
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        for field_name in ("s", "p", "o"):
+            uri = _extract_binding_value(row.get(field_name))
+            entity_id = _extract_local_entity_id(uri, base_uri)
+            if entity_id:
+                found.add(entity_id)
+
+    return sorted(found)
+
+
+def build_wikibase_cache(
+    *,
+    sparql_endpoint: str,
+    api_url: str,
+    cache_dir: str | Path,
+    wikibase_base_uri: str = "https://datadistillery.wikibase.cloud",
+    profile_class_id: str = "Q3",
+    source_endpoint: Optional[str] = None,
+    workflow_mode: str = "cache-builder",
+    summary_output: Optional[str | Path] = None,
+    loader: Optional[WikibaseLoader] = None,
+    auth: Optional[WikiverseAuth] = None,
+) -> WikibaseCacheBuildResult:
+    """Build and reconcile entity cache using SPARQL-derived QID/PID identifiers."""
+    query = build_entity_profile_identifiers_sparql_query(
+        wikibase_base_uri=wikibase_base_uri,
+        profile_class_id=profile_class_id,
+    )
+    rows = _run_sparql(sparql_endpoint, query)
+    discovered_ids = extract_entity_profile_identifiers(rows, wikibase_base_uri)
+
+    active_loader = loader or WikibaseLoader(api_url=api_url, auth=auth)
+    fetched_entities = active_loader.load_entities_raw(discovered_ids)
+
+    cache_path = Path(cache_dir)
+    cache_path.mkdir(parents=True, exist_ok=True)
+
+    fetched_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    extractor_version = _get_installed_gkc_version()
+
+    new_ids: list[str] = []
+    changed_ids: list[str] = []
+    unchanged_ids: list[str] = []
+    written_ids: list[str] = []
+    missing_ids: list[str] = []
+
+    for entity_id in discovered_ids:
+        entity_data = fetched_entities.get(entity_id)
+        if not isinstance(entity_data, dict) or not entity_data:
+            missing_ids.append(entity_id)
+            continue
+
+        out_file = cache_path / f"{entity_id}.json"
+        existing_entity = _read_existing_entity_payload(out_file)
+
+        if existing_entity is None:
+            new_ids.append(entity_id)
+        elif existing_entity == entity_data:
+            unchanged_ids.append(entity_id)
+        else:
+            changed_ids.append(entity_id)
+
+        payload_doc = {
+            "entity_id": entity_id,
+            "entity": entity_data,
+            "metadata": {
+                "source_endpoint": source_endpoint or api_url,
+                "workflow_mode": workflow_mode,
+                "profile_entry_ids": [],
+                "graph_fetched_at": fetched_at,
+                "cache_exported_at": fetched_at,
+                "extractor": "gkc.wikibase.cache.build_wikibase_cache",
+                "extractor_version": extractor_version,
+            },
+        }
+        out_file.write_text(json.dumps(payload_doc, indent=2), encoding="utf-8")
+        written_ids.append(entity_id)
+
+    discovered_set = set(discovered_ids)
+    deleted_ids: list[str] = []
+    for existing_path in cache_path.glob("*.json"):
+        match = _ENTITY_ID_PATTERN.fullmatch(existing_path.stem)
+        if match and existing_path.stem not in discovered_set:
+            existing_path.unlink()
+            deleted_ids.append(existing_path.stem)
+
+    summary_payload = {
+        "metadata": {
+            "source_endpoint": source_endpoint or api_url,
+            "sparql_endpoint": sparql_endpoint,
+            "wikibase_base_uri": wikibase_base_uri.rstrip("/"),
+            "profile_class_id": profile_class_id,
+            "workflow_mode": workflow_mode,
+            "fetched_at": fetched_at,
+            "cache_dir": str(cache_path.resolve()),
+        },
+        "summary": {
+            "queried_count": len(discovered_ids),
+            "fetched_count": len(fetched_entities),
+            "written_count": len(written_ids),
+            "new_count": len(new_ids),
+            "changed_count": len(changed_ids),
+            "unchanged_count": len(unchanged_ids),
+            "missing_count": len(missing_ids),
+            "deleted_count": len(deleted_ids),
+        },
+        "queried_ids": discovered_ids,
+        "fetched_ids": sorted(fetched_entities.keys()),
+        "written_ids": sorted(written_ids),
+        "new_ids": sorted(new_ids),
+        "changed_ids": sorted(changed_ids),
+        "unchanged_ids": sorted(unchanged_ids),
+        "missing_ids": sorted(missing_ids),
+        "deleted_ids": sorted(deleted_ids),
+    }
+
+    summary_path: Optional[str] = None
+    if summary_output:
+        summary_file = Path(summary_output)
+        summary_file.parent.mkdir(parents=True, exist_ok=True)
+        summary_file.write_text(json.dumps(summary_payload, indent=2), encoding="utf-8")
+        summary_path = str(summary_file.resolve())
+
+    return WikibaseCacheBuildResult(
+        cache_dir=str(cache_path.resolve()),
+        summary_path=summary_path,
+        queried_ids=summary_payload["queried_ids"],
+        fetched_ids=summary_payload["fetched_ids"],
+        written_ids=summary_payload["written_ids"],
+        new_ids=summary_payload["new_ids"],
+        changed_ids=summary_payload["changed_ids"],
+        unchanged_ids=summary_payload["unchanged_ids"],
+        deleted_ids=summary_payload["deleted_ids"],
+        missing_ids=summary_payload["missing_ids"],
+        fetched_at=fetched_at,
+    )
+
+
+def _extract_binding_value(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        nested = value.get("value")
+        return nested if isinstance(nested, str) else None
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _extract_local_entity_id(uri: Optional[str], base_uri: str) -> Optional[str]:
+    if not uri or not uri.startswith(base_uri):
+        return None
+    if f"{base_uri}/entity/statement/" in uri:
+        return None
+
+    candidate = uri.rstrip("/").split("/")[-1]
+    if _ENTITY_ID_PATTERN.fullmatch(candidate):
+        return candidate
+    return None
+
+
+def _run_sparql(sparql_endpoint: str, query: str) -> list[dict[str, Any]]:
+    executor = SPARQLQuery(endpoint=sparql_endpoint)
+    try:
+        return executor.to_dict_list(query)
+    except Exception:
+        raw = executor.query(query, format="json", raw=True)
+        parsed: dict[str, Any] = json.loads(raw)
+        bindings = parsed.get("results", {}).get("bindings", [])
+        return bindings if isinstance(bindings, list) else []
+
+
+def _read_existing_entity_payload(file_path: Path) -> Optional[dict[str, Any]]:
+    if not file_path.exists():
+        return None
+    try:
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+    if isinstance(payload, dict):
+        entity = payload.get("entity")
+        if isinstance(entity, dict):
+            return entity
+    return {}
+
+
+def _get_installed_gkc_version() -> str:
+    try:
+        return importlib_metadata.version("gkc")
+    except Exception:
+        return "unknown"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,6 +262,53 @@ def test_wikibase_check_for_revisions_json(monkeypatch, capsys, tmp_path):
     assert data["details"]["deleted_count"] == 1
 
 
+def test_wikibase_cache_builder_json(monkeypatch, capsys, tmp_path):
+    """wikibase cache-builder returns reconciliation summary in JSON mode."""
+
+    class FakeRuntimeConfig:
+        api_url = "https://datadistillery.wikibase.cloud/w/api.php"
+        sparql_endpoint = "https://datadistillery.wikibase.cloud/query/sparql"
+        username = None
+        password = None
+
+    class FakeBuildResult:
+        cache_dir = str(tmp_path / "cache" / "entities")
+        summary_path = str(tmp_path / "cache" / "refresh" / "last_run_summary.json")
+        queried_ids = ["P1", "Q10", "Q3"]
+        fetched_ids = ["P1", "Q10", "Q3"]
+        written_ids = ["P1", "Q10", "Q3"]
+        new_ids = ["Q10"]
+        changed_ids = ["Q3"]
+        unchanged_ids = ["P1"]
+        deleted_ids = ["Q99"]
+        missing_ids = []
+
+    def fake_build_wikibase_cache(**kwargs):
+        _ = kwargs
+        return FakeBuildResult()
+
+    monkeypatch.setattr(cli, "get_wikibase_runtime_config", lambda: FakeRuntimeConfig())
+    monkeypatch.setattr(cli, "build_wikibase_cache", fake_build_wikibase_cache)
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "wikibase",
+            "cache-builder",
+            "--cache-dir",
+            str(tmp_path / "cache" / "entities"),
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out.strip()
+    data = json.loads(output)
+    assert data["command"] == "wikibase.cache-builder"
+    assert data["ok"] is True
+    assert data["details"]["written_count"] == 3
+    assert data["details"]["deleted_count"] == 1
+
+
 def test_wikibase_plan_write_with_shipper_plan(monkeypatch, capsys, tmp_path):
     """wikibase plan-write can run shipper.plan_batch and include diff summary."""
 

--- a/tests/test_mash.py
+++ b/tests/test_mash.py
@@ -700,6 +700,28 @@ def test_wikibase_loader_load_items_respects_batch_size(monkeypatch):
     assert calls[1] == 100
 
 
+def test_wikibase_loader_load_entities_raw_respects_batch_size(monkeypatch):
+    """load_entities_raw batches requests and returns merged raw entity JSON."""
+    fake_auth = type("FakeAuth", (), {"has_api_high_limits": lambda self: True})()
+    loader = WikibaseLoader(auth=fake_auth)
+
+    calls = []
+
+    def fake_fetch(entity_ids):
+        calls.append(len(entity_ids))
+        return {eid: {"id": eid, "type": "item"} for eid in entity_ids}
+
+    monkeypatch.setattr(loader, "_fetch_entities_batch", fake_fetch)
+
+    entity_ids = [f"Q{i}" for i in range(600)]
+    result = loader.load_entities_raw(entity_ids)
+
+    assert len(calls) == 2
+    assert calls[0] == 500
+    assert calls[1] == 100
+    assert len(result) == 600
+
+
 def test_wikipedia_template_initialization():
     """Test creating a Wikipedia template."""
     template = WikipediaTemplate(

--- a/tests/wikibase/test_cache.py
+++ b/tests/wikibase/test_cache.py
@@ -1,0 +1,203 @@
+"""Tests for SPARQL-driven Wikibase cache builder."""
+
+from __future__ import annotations
+
+import json
+
+from gkc.wikibase.cache import (
+    build_entity_profile_identifiers_sparql_query,
+    build_wikibase_cache,
+    extract_entity_profile_identifiers,
+)
+
+
+class FakeLoader:
+    """Minimal fake loader for deterministic cache build tests."""
+
+    def __init__(self, entities: dict[str, dict]):
+        self.entities = entities
+        self.calls: list[list[str]] = []
+
+    def load_entities_raw(self, entity_ids: list[str]) -> dict[str, dict]:
+        self.calls.append(list(entity_ids))
+        return {
+            entity_id: self.entities[entity_id]
+            for entity_id in entity_ids
+            if entity_id in self.entities
+        }
+
+
+def _cache_payload(entity_id: str, entity: dict) -> dict:
+    return {
+        "entity_id": entity_id,
+        "entity": entity,
+        "metadata": {
+            "source_endpoint": "https://datadistillery.wikibase.cloud/w/api.php",
+            "workflow_mode": "cache-builder",
+            "profile_entry_ids": [],
+            "graph_fetched_at": "2026-03-01T00:00:00Z",
+            "cache_exported_at": "2026-03-01T00:00:00Z",
+            "extractor": "test",
+            "extractor_version": "test",
+        },
+    }
+
+
+def test_build_entity_profile_identifiers_sparql_query():
+    """Query builder emits the expected traversal clauses and filters."""
+    query = build_entity_profile_identifiers_sparql_query(
+        wikibase_base_uri="https://datadistillery.wikibase.cloud",
+        profile_class_id="Q3",
+    )
+
+    assert "SELECT ?s ?p ?o" in query
+    assert "?root wdt:P1 wd:Q3" in query
+    assert "(wdt:P1|wdt:P2)*" in query
+    assert "FILTER(isIRI(?s) && isIRI(?p) && isIRI(?o))" in query
+    assert "entity/statement/" in query
+
+
+def test_extract_entity_profile_identifiers():
+    """Parser keeps only local Q/P IDs and de-duplicates deterministically."""
+    rows = [
+        {
+            "s": {"value": "https://datadistillery.wikibase.cloud/entity/Q10"},
+            "p": {"value": "https://datadistillery.wikibase.cloud/prop/direct/P1"},
+            "o": {"value": "https://datadistillery.wikibase.cloud/entity/Q3"},
+        },
+        {
+            "s": {"value": "https://datadistillery.wikibase.cloud/entity/Q10"},
+            "p": {"value": "https://datadistillery.wikibase.cloud/prop/P2"},
+            "o": {
+                "value": "https://datadistillery.wikibase.cloud/entity/statement/Q10-abc"
+            },
+        },
+        {
+            "s": {"value": "https://www.wikidata.org/entity/Q42"},
+            "p": {"value": "https://www.wikidata.org/prop/direct/P31"},
+            "o": {"value": "https://www.wikidata.org/entity/Q5"},
+        },
+    ]
+
+    ids = extract_entity_profile_identifiers(rows)
+
+    assert ids == ["P1", "P2", "Q10", "Q3"]
+
+
+def test_build_wikibase_cache_reconciles_and_writes_summary(tmp_path, monkeypatch):
+    """Cache builder upserts current IDs, deletes stale IDs, and reports diffs."""
+    base_uri = "https://datadistillery.wikibase.cloud"
+    cache_dir = tmp_path / "cache" / "entities"
+    refresh_summary = tmp_path / "cache" / "refresh" / "last_run_summary.json"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    unchanged_q10 = {"id": "Q10", "type": "item", "labels": {"en": {"value": "A"}}}
+    old_q11 = {"id": "Q11", "type": "item", "labels": {"en": {"value": "OLD"}}}
+    stale_q99 = {"id": "Q99", "type": "item", "labels": {"en": {"value": "STALE"}}}
+
+    (cache_dir / "Q10.json").write_text(
+        json.dumps(_cache_payload("Q10", unchanged_q10), indent=2),
+        encoding="utf-8",
+    )
+    (cache_dir / "Q11.json").write_text(
+        json.dumps(_cache_payload("Q11", old_q11), indent=2),
+        encoding="utf-8",
+    )
+    (cache_dir / "Q99.json").write_text(
+        json.dumps(_cache_payload("Q99", stale_q99), indent=2),
+        encoding="utf-8",
+    )
+
+    rows = [
+        {
+            "s": {"value": f"{base_uri}/entity/Q10"},
+            "p": {"value": f"{base_uri}/prop/direct/P1"},
+            "o": {"value": f"{base_uri}/entity/Q3"},
+        },
+        {
+            "s": {"value": f"{base_uri}/entity/Q11"},
+            "p": {"value": f"{base_uri}/prop/direct/P1"},
+            "o": {"value": f"{base_uri}/entity/Q3"},
+        },
+    ]
+
+    monkeypatch.setattr("gkc.wikibase.cache._run_sparql", lambda endpoint, query: rows)
+
+    loader = FakeLoader(
+        {
+            "Q10": unchanged_q10,
+            "Q11": {
+                "id": "Q11",
+                "type": "item",
+                "labels": {"en": {"value": "UPDATED"}},
+            },
+            "P1": {
+                "id": "P1",
+                "type": "property",
+                "labels": {"en": {"value": "instance of"}},
+            },
+            "Q3": {
+                "id": "Q3",
+                "type": "item",
+                "labels": {"en": {"value": "GKC Entity Profile"}},
+            },
+        }
+    )
+
+    result = build_wikibase_cache(
+        sparql_endpoint=f"{base_uri}/query/sparql",
+        api_url=f"{base_uri}/w/api.php",
+        cache_dir=cache_dir,
+        wikibase_base_uri=base_uri,
+        summary_output=refresh_summary,
+        loader=loader,
+    )
+
+    assert result.new_ids == ["P1", "Q3"]
+    assert result.changed_ids == ["Q11"]
+    assert result.unchanged_ids == ["Q10"]
+    assert result.deleted_ids == ["Q99"]
+    assert result.missing_ids == []
+    assert result.written_ids == ["P1", "Q10", "Q11", "Q3"]
+
+    assert (cache_dir / "Q99.json").exists() is False
+    assert (cache_dir / "P1.json").exists() is True
+
+    summary = json.loads(refresh_summary.read_text(encoding="utf-8"))
+    assert summary["summary"]["new_count"] == 2
+    assert summary["summary"]["changed_count"] == 1
+    assert summary["summary"]["unchanged_count"] == 1
+    assert summary["summary"]["deleted_count"] == 1
+
+
+def test_build_wikibase_cache_tracks_missing_ids(tmp_path, monkeypatch):
+    """IDs discovered in SPARQL but missing from API are surfaced in summary."""
+    base_uri = "https://datadistillery.wikibase.cloud"
+    cache_dir = tmp_path / "cache" / "entities"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = [
+        {
+            "s": {"value": f"{base_uri}/entity/Q10"},
+            "p": {"value": f"{base_uri}/prop/direct/P1"},
+            "o": {"value": f"{base_uri}/entity/Q3"},
+        }
+    ]
+    monkeypatch.setattr("gkc.wikibase.cache._run_sparql", lambda endpoint, query: rows)
+
+    loader = FakeLoader(
+        {
+            "Q10": {"id": "Q10", "type": "item"},
+        }
+    )
+
+    result = build_wikibase_cache(
+        sparql_endpoint=f"{base_uri}/query/sparql",
+        api_url=f"{base_uri}/w/api.php",
+        cache_dir=cache_dir,
+        wikibase_base_uri=base_uri,
+        loader=loader,
+    )
+
+    assert result.written_ids == ["Q10"]
+    assert result.missing_ids == ["P1", "Q3"]


### PR DESCRIPTION
## Summary

Implements a dedicated cache-first extraction path in a new `gkc.wikibase.cache` module and exposes it through `gkc wikibase cache-builder`.

## Included

- New module `gkc/wikibase/cache.py`
  - `build_entity_profile_identifiers_sparql_query(...)`
  - `extract_entity_profile_identifiers(...)`
  - `build_wikibase_cache(...)`
  - `WikibaseCacheBuildResult`
- Reconciliation semantics
  - overwrite existing files for currently discovered IDs
  - create files for newly discovered IDs
  - delete stale files not in current SPARQL-discovered set
- Summary JSON support for `cache/refresh/last_run_summary.json`
  - includes new/changed/unchanged/deleted/missing IDs and counts
- Loader enhancement in `gkc/mash/core.py`
  - `WikibaseLoader.load_entities_raw(...)` using high-limit-aware batching
- New CLI command `gkc wikibase cache-builder`

## Tests

- Added `tests/wikibase/test_cache.py`
- Added CLI test for `wikibase cache-builder` in `tests/test_cli.py`
- Added loader batch test for `load_entities_raw` in `tests/test_mash.py`

## Validation

- `poetry run pytest tests/wikibase/test_cache.py`
- `poetry run pytest tests/wikibase/test_cache.py tests/wikibase/test_ontology.py tests/test_cli.py tests/test_mash.py -k "cache_builder or profile_to_cache or check_for_revisions or load_entities_raw or batch_size or entity_profile_identifiers"`
- `./scripts/pre-merge-check.sh`

Closes #136