### PR TITLE
Fix value_list_graph coverage for nested reference/qualifier statements

### DIFF
--- a/.github/agents/Validation Agent.agent.md
+++ b/.github/agents/Validation Agent.agent.md
@@ -9,23 +9,23 @@ You design and engineer the code components that validate GKC Entity Profiles, C
 
 # Responsibilities
 - Design, engineer, and maintain the fermenting module of the GKC, which is responsible for validation and coercion operations.
-- Implement Pydantic model generation from YAML profiles, ensuring that the generated models accurately reflect the constraints and structures defined in the profiles.
+- Implement Pydantic model generation from Entity Profile JSON, ensuring that the generated models accurately reflect the constraints and structures defined in the profiles.
 - Implement custom validation logic that checks user input against the constraints defined in the profiles, including complex statement structures, allowed-item lists, and domain-specific rules.
-- Provide the actionable feedback recorded in GKC Entity Profiles to users when validation errors occur, helping them understand what went wrong and how to fix it.
 - Collaborate with the Wizard Engineer to ensure the generated forms support effective validation. This may involve implementing specific UI patterns or data transformation logic to ensure that user input can be validated according to the constraints defined in the profiles.
 - Collaborate with the Profile Architect to clarify profile requirements and constraints. Look for notes left by the Profile Architect in sections marked `Theoretical Design Notes` about specific anticipated features for you to develop.
 - The Entity Profile is the "arbiter of truth" for how validation operates in the GKC. If you are asked to implement a feature that is not currently supported by the profiles, look for `Theoretical Design Notes` and then raise an issue in chat sessions with your suggestions that can be tracked and addressed.
 
 # What this agent must not do
-- Must not design YAML profile schemas (those are the responsibility of the Profile Architect).
+- Must not design profile schemas (those are the responsibility of the Profile Architect).
 - Must not implement form generation logic that belongs in the Wizard Engineer's domain.
 - Must not modify SpiritSafe hydration logic.
 - Must not invent partner system data structures (e.g., Wikidata, OpenStreetMap, etc.).
 - Must not create new architectural rules (those belong in copilot‑instructions.md).
 
 # Context this agent should always assume
-- YAML profiles are the authoritative definition of an entity type.
-  - Profiles are essentially a YAML-based representation of the Wikibase/Wikidata data model. Most of the content they help data curators produce will be serialized into Wikidata JSON and written to Wikidata via the API. They map content elements that can be contributed to other parts of The Commons, which can result in data also being distributed to those other systems (e.g., Wikimedia Commons file upload, etc.).
+- Profiles first defined in the Data Distillery Wikibase and then translated through the spirit_safe module into Entity Profile JSON stored within the SpiritSafe are the authoritative definition of an entity type.
+  - Profiles are essentially a JSON-based representation of the Wikibase/Wikidata data model. Most of the content they help data curators produce will be serialized into Wikidata JSON and written to Wikidata via the API. They map content elements that can be contributed to other parts of The Commons, which can result in data also being distributed to those other systems (e.g., Wikimedia Commons file upload, etc.).
+- Curation Packets are the materialized runtime packages developed from Entity Profiles for a given curation session. They include all the necessary profiles/profile rules and associated content to support a specific curation task. They are the primary input for GKC Wizards and also support bulk data operations.
 - Effective validation is crucial for maintaining data integrity and providing a good user experience. The validation logic you implement must be robust, accurate, and provide actionable feedback to users to help them correct any issues with their input.
 - Validation via generated Pydantic models and custom logic will be applied for both GKC Wizard form input and for bulk data operations involving other sources of data input. Entity Profiles control both of these.
 - Data coercion mechanisms are an important part of the validation landscape. In many cases, user input may not be in the exact format required by the profiles, but it can be automatically transformed into a valid format. Implementing effective coercion logic can help reduce friction for users and improve the overall curator experience.
@@ -35,7 +35,7 @@ You design and engineer the code components that validate GKC Entity Profiles, C
 - “data coercion”, “input transformation”, “validation errors”, “user feedback”
 
 # Typical tasks this agent should excel at
-- Implementing Pydantic model generation from YAML profiles.
+- Implementing Pydantic model generation from Entity Profile JSON.
 - Implementing custom validation logic that checks user input against the constraints defined in the profiles.
 - Producing creative coercion logic approaches wherever possible to handle a broader range of potential inputs from both open text input form elements in GKC Wizards and "mystery data" inputs in bulk operations.
 - Collaborating effectively with the Profile Architect and Wizard Engineer to ensure the profiles and generated forms support effective validation.

--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document defines the current architectural contract between `mash`, `spirit_safe`, `still_charger`, `cooperage`, `bottler`, `shipper`, and `wikibase` for Data Distillery and broader GKC workflows.
+This document defines the current architectural contract between `mash`, `spirit_safe`, `still_charger`, `fermenter`, `cooperage`, `bottler`, `shipper`, and `wikibase` for Data Distillery and broader GKC workflows.
 
 It is written as a practical anti-reinvention guide for contributors and custom agents.
 
@@ -36,7 +36,7 @@ Responsibility:
 - Extract value-list SPARQL query files from value-list talk pages.
 - Hydrate value-list cache artifacts from extracted SPARQL queries.
 - Export profile JSON artifacts for downstream packet assembly and hydration.
-- Provide profile graph and packet scaffold utilities.
+- Provide profile graph metadata and profile-loading utilities.
 
 Out of scope:
 
@@ -50,17 +50,22 @@ Current anchor surface:
 - `discover_value_list_ids`
 - `export_value_list_sparql_queries`
 - `hydrate_value_lists_from_cache`
-- `create_curation_packet`
 - `load_manifest`
-- `load_profile_package`
+- `load_profile`
+
+Transition-only legacy surface (deferred removal):
+
+- `create_curation_packet`
+- `validate_packet_structure`
 
 ### Still Charger (`gkc.still_charger`)
 
 Responsibility:
 
+- Assemble curation packet scaffolds from Entity Profile JSON documents.
 - Fill curation packet entity scaffolds with concrete source values.
-- Support bootstrap-friendly charging behavior when specifications are still emerging.
-- Emit a structured charge report (charged/skipped entities and warnings/errors).
+- Support charging from Wikidata entities and other source adapters.
+- Emit shared conformance notices and charge summaries.
 
 Out of scope:
 
@@ -69,9 +74,32 @@ Out of scope:
 
 Current anchor surface:
 
+- `build_curation_packet_from_json_profile`
 - `charge_curation_packet`
+- `charge_packet_from_wikidata_items`
 - `ChargeReport`
 - `ChargeIssue`
+
+### Fermenter (`gkc.fermenter`)
+
+Responsibility:
+
+- Validate and coerce inbound values using profile-defined directives.
+- Provide atomic datatype validators and coercion primitives.
+- Enforce fixed values, value-list constraints, and reference-level constraints.
+- Emit shared `ConformanceNotice` records with actionable feedback.
+
+Out of scope:
+
+- Packet assembly and packet orchestration.
+- Destination-specific payload shaping and transport execution.
+
+Current anchor surface:
+
+- `ConformanceNotice`
+- `ValidationResult`
+- `validate_*` datatype validators
+- `coerce_*` datatype coercers
 
 ### Cooperage (`gkc.cooperage`)
 
@@ -175,11 +203,12 @@ Current anchor surface:
 
 ### Flow 2.5: Shared Profile-to-Write Planning Pipeline (Active)
 
-1. `spirit_safe` creates curation packet scaffolds from profile definitions.
-2. `still_charger` fills packet entities with real input values.
-3. `cooperage` transforms charged packet data into `WikibaseShipper.plan_batch` operations.
-4. `wikibase` orchestration coordinates this flow for Data Distillery-specific workflows.
-5. `shipper` computes create/update/no-op diff plans and executes writes when enabled.
+1. `spirit_safe` loads and exports JSON Entity Profiles and value-list cache artifacts.
+2. `still_charger` assembles curation packets from profile JSON and charges packet entities with source values.
+3. `fermenter` validates and coerces charged values, emitting shared conformance notices.
+4. `cooperage` transforms charged packet data into `WikibaseShipper.plan_batch` operations.
+5. `wikibase` orchestration coordinates this flow for Data Distillery-specific workflows.
+6. `shipper` computes create/update/no-op diff plans and executes writes when enabled.
 
 ### Flow 2.6: SpiritSafe JSON Profile Materialization (Active)
 
@@ -216,7 +245,7 @@ Current anchor surface:
 
 - Do not add a new generic Wikibase client under `gkc.wikibase`.
 - Do not bypass `shipper` for Wikibase write execution paths.
-- Keep profile YAML/SpiritSafe runtime contracts stable and testable.
+- Keep SpiritSafe runtime contracts stable and testable.
 - Preserve offline-first behavior: network-backed enhancement must not break cache-only operation.
 - Preserve JSON profile export determinism (stable ordering and artifact path shape).
 
@@ -226,7 +255,8 @@ When adding new functionality, assign ownership using this matrix:
 
 - Need to fetch/query source entity data? -> `mash`
 - Need to build/export profile JSON artifacts from SpiritSafe cache entities? -> `spirit_safe`
-- Need to populate curation packet scaffolds with concrete values? -> `still_charger`
+- Need to assemble curation packets from profile JSON and populate them with source values? -> `still_charger`
+- Need atomic validation/coercion and conformance notices? -> `fermenter`
 - Need to build/shape values into claim/snak/payload structures? -> `bottler`
 - Need schema/specification retrieval or reusable projection logic? -> `cooperage`
 - Need to execute write operations to external APIs? -> `shipper`
@@ -234,7 +264,8 @@ When adding new functionality, assign ownership using this matrix:
 
 ## Current Gaps to Revisit During Critical Analysis
 
-- Still Charger currently supports specificationless charging for bootstrap workflows; strict charging contracts need additional profile-spec alignment.
+- Still Charger URI-keyed packet assembly and source resolution are still in active migration from profile-name keyed behavior.
+- Fermenter module implementation is pending; current validation/coercion logic remains distributed and not yet unified.
 - Cooperage currently provides packet-to-Wikibase operation planning; additional target transformers still need explicit acceptance criteria per phase.
 - Boundaries between cooperage and bottler for transformation stages still need explicit acceptance criteria per phase.
 - Wikibase orchestration should continue preferring composition over new transport abstractions.

--- a/docs/architecture/spirit_safe_models.md
+++ b/docs/architecture/spirit_safe_models.md
@@ -59,7 +59,7 @@ Top-level fields:
 - `labels`, `descriptions`
 - `statement_count`
 - `profile_graph`
-- `value_list_graph`
+- `value_list_graph` (includes value-list routes referenced by statements and nested qualifier/reference statements)
 
 ## Profile Graph Model
 

--- a/docs/gkc/profiles.md
+++ b/docs/gkc/profiles.md
@@ -48,7 +48,7 @@ Each profile artifact contains:
 - `statements`
 - `metadata`
 
-`metadata` includes `profile_graph` and `value_list_graph` summaries used by packet scaffolding and registry indexing.
+`metadata` includes `profile_graph` and `value_list_graph` summaries used by packet scaffolding and registry indexing. `value_list_graph` includes value-list routes used by top-level statements and nested reference/qualifier statements.
 
 The SpiritSafe manifest (`cache/manifest.json`) is generated as an artifact index over these files.
 

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -1455,7 +1455,7 @@ class EntityProfileJsonBuilder:
             "languages": [],
             "statement_count": len(statements),
             "profile_graph": self._build_profile_graph(wikibase_item),
-            "value_list_graph": self._build_value_list_graph(wikibase_item),
+            "value_list_graph": self._build_value_list_graph(statements),
             "exported_from": entity_uri,
         }
 
@@ -1499,30 +1499,73 @@ class EntityProfileJsonBuilder:
         return graph
 
     def _build_value_list_graph(
-        self, wikibase_item: dict[str, Any]
+        self, statements: list[dict[str, Any]]
     ) -> list[dict[str, Optional[str]]]:
         graph: list[dict[str, Optional[str]]] = []
         seen: set[tuple[str, str]] = set()
-        for statement_id, linked_value_ids in self._iter_statement_value_linkages(
-            wikibase_item
-        ):
-            for target_id in linked_value_ids:
-                type_ids = self._entity_type_ids(self._cache_index.get(target_id))
-                if self.GKC_VALUE_LIST_CLASS not in type_ids:
-                    continue
-                key = (statement_id, target_id)
-                if key in seen:
-                    continue
-                seen.add(key)
-                graph.append(
-                    {
-                        "entity": f"{self.entity_prefix}{target_id}",
-                        "label": self._entity_label(target_id),
-                        "via_statement": f"{self.entity_prefix}{statement_id}",
-                        "cache_path": f"cache/queries/{target_id}.json",
-                    }
-                )
+
+        for statement in self._iter_statement_nodes(statements):
+            if not isinstance(statement, dict):
+                continue
+
+            statement_entity = statement.get("entity")
+            if not isinstance(statement_entity, str) or not statement_entity:
+                continue
+
+            value_payload = statement.get("value")
+            if not isinstance(value_payload, dict):
+                continue
+
+            cache_path = value_payload.get("value_list_reference")
+            if not isinstance(cache_path, str) or not cache_path:
+                continue
+
+            target_id = self._qid_from_cache_path(cache_path)
+            if not target_id:
+                continue
+
+            type_ids = self._entity_type_ids(self._cache_index.get(target_id))
+            if type_ids and self.GKC_VALUE_LIST_CLASS not in type_ids:
+                continue
+
+            key = (statement_entity, cache_path)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            graph.append(
+                {
+                    "entity": f"{self.entity_prefix}{target_id}",
+                    "label": self._entity_label(target_id),
+                    "via_statement": statement_entity,
+                    "cache_path": cache_path,
+                }
+            )
         return graph
+
+    def _iter_statement_nodes(
+        self, statements: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+
+        def _walk(statement_list: list[dict[str, Any]]) -> None:
+            for statement in statement_list:
+                if not isinstance(statement, dict):
+                    continue
+                nodes.append(statement)
+                for key in ("qualifiers", "references"):
+                    nested = statement.get(key)
+                    if isinstance(nested, list):
+                        _walk(nested)
+
+        _walk(statements)
+        return nodes
+
+    def _qid_from_cache_path(self, cache_path: str) -> Optional[str]:
+        candidate = Path(cache_path).stem.upper()
+        if candidate.startswith("Q") and candidate[1:].isdigit():
+            return candidate
+        return None
 
     def _iter_statement_value_linkages(
         self, wikibase_item: dict[str, Any]

--- a/tests/test_spirit_safe_entity_profile_json.py
+++ b/tests/test_spirit_safe_entity_profile_json.py
@@ -20,6 +20,26 @@ def _build_entity_claim_entity_id(entity_id: str) -> dict:
     }
 
 
+def _build_qualifier_entity_id(entity_id: str) -> dict:
+    return {
+        "datavalue": {
+            "value": {
+                "id": entity_id,
+            }
+        }
+    }
+
+
+def _build_entity_claim_string(value: str) -> dict:
+    return {
+        "mainsnak": {
+            "datavalue": {
+                "value": value,
+            }
+        }
+    }
+
+
 def test_build_entity_profile_json_documents_from_cache_entities(tmp_path):
     """Build returns JSON entity profile docs for cache entities typed as Q3."""
     cache_entities_dir = tmp_path / "cache" / "entities"
@@ -73,3 +93,125 @@ def test_export_entity_profile_json_documents_writes_qid_files(tmp_path):
     assert profile_path.exists()
     profile_payload = json.loads(profile_path.read_text(encoding="utf-8"))
     assert profile_payload["entity"].endswith("/Q4")
+
+
+def test_value_list_graph_includes_reference_and_qualifier_routes(tmp_path):
+    """Metadata graph should include value-list routes from nested statements."""
+
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+
+    profile_payload = {
+        "entity_id": "Q4",
+        "entity": {
+            "labels": {"mul": {"value": "Tribal Government in the United States"}},
+            "descriptions": {"mul": {"value": "Example profile"}},
+            "aliases": {},
+            "claims": {
+                "P1": [_build_entity_claim_entity_id("Q3")],
+                "P157": [
+                    {
+                        "mainsnak": {
+                            "datavalue": {
+                                "value": {"id": "Q16"},
+                            }
+                        },
+                        "qualifiers": {
+                            "P211": [_build_qualifier_entity_id("Q30")],
+                            "P158": [_build_qualifier_entity_id("Q41")],
+                        },
+                    }
+                ],
+            },
+        },
+    }
+    (cache_entities_dir / "Q4.json").write_text(
+        json.dumps(profile_payload), encoding="utf-8"
+    )
+
+    statement_payloads = {
+        "Q16": {
+            "entity_id": "Q16",
+            "entity": {
+                "labels": {"mul": {"value": "instance of"}},
+                "claims": {
+                    "P5": [
+                        _build_entity_claim_string("http://www.wikidata.org/entity/P31")
+                    ],
+                    "P194": [_build_entity_claim_entity_id("Q52")],
+                },
+            },
+        },
+        "Q30": {
+            "entity_id": "Q30",
+            "entity": {
+                "labels": {"mul": {"value": "stated in"}},
+                "claims": {
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P248"
+                        )
+                    ],
+                    "P194": [_build_entity_claim_entity_id("Q52")],
+                    "P161": [_build_entity_claim_entity_id("Q28")],
+                },
+            },
+        },
+        "Q41": {
+            "entity_id": "Q41",
+            "entity": {
+                "labels": {"mul": {"value": "applies to jurisdiction"}},
+                "claims": {
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P1001"
+                        )
+                    ],
+                    "P194": [_build_entity_claim_entity_id("Q52")],
+                    "P161": [_build_entity_claim_entity_id("Q43")],
+                },
+            },
+        },
+        "Q28": {
+            "entity_id": "Q28",
+            "entity": {
+                "labels": {"mul": {"value": "List of Federal Register Sources"}},
+                "claims": {
+                    "P1": [_build_entity_claim_entity_id("Q7")],
+                },
+            },
+        },
+        "Q43": {
+            "entity_id": "Q43",
+            "entity": {
+                "labels": {"mul": {"value": "List of Tribal Jurisdictions"}},
+                "claims": {
+                    "P1": [_build_entity_claim_entity_id("Q7")],
+                },
+            },
+        },
+    }
+
+    for entity_id, payload in statement_payloads.items():
+        (cache_entities_dir / f"{entity_id}.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    docs = build_entity_profile_json_documents(cache_entities_dir)
+
+    assert len(docs) == 1
+    value_list_graph = docs[0]["metadata"]["value_list_graph"]
+    assert value_list_graph == [
+        {
+            "entity": "https://datadistillery.wikibase.cloud/entity/Q43",
+            "label": "List of Tribal Jurisdictions",
+            "via_statement": "https://datadistillery.wikibase.cloud/entity/Q41",
+            "cache_path": "cache/queries/Q43.json",
+        },
+        {
+            "entity": "https://datadistillery.wikibase.cloud/entity/Q28",
+            "label": "List of Federal Register Sources",
+            "via_statement": "https://datadistillery.wikibase.cloud/entity/Q30",
+            "cache_path": "cache/queries/Q28.json",
+        },
+    ]

--- a/tests/test_spirit_safe_phase3.py
+++ b/tests/test_spirit_safe_phase3.py
@@ -51,6 +51,18 @@ def test_build_spiritsafe_manifest_document(fixture_root: Path):
         }
     ]
 
+    q4_profile = next(
+        profile for profile in manifest["profiles"] if profile["qid"] == "Q4"
+    )
+    assert q4_profile["value_list_graph"] == [
+        {
+            "entity": "https://datadistillery.wikibase.cloud/entity/Q28",
+            "label": "List of Federal Register Sources",
+            "via_statement": "https://datadistillery.wikibase.cloud/entity/Q16",
+            "cache_path": "cache/queries/Q28.json",
+        }
+    ]
+
 
 def test_export_spiritsafe_manifest(fixture_root: Path, tmp_path: Path):
     """Manifest export should write JSON to the requested path."""


### PR DESCRIPTION
## Summary
- build profile metadata value_list_graph from the fully-built statement tree
- include value list routes referenced by nested reference/qualifier statements
- add regression tests for nested value list routes and manifest profile metadata passthrough
- update architecture docs for value_list_graph behavior and module boundaries

## Validation
- ./scripts/pre-merge-check.sh
