### PR TITLE
Model P213-derived statement-value defaults in SpiritSafe JSON

### DIFF
--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -87,6 +87,7 @@ Responsibility:
 - Validate and coerce inbound values using profile-defined directives.
 - Provide atomic datatype validators and coercion primitives.
 - Enforce fixed values, value-list constraints, and reference-level constraints.
+- Enforce derived-value constraints (for example, reference/qualifier values sourced from parent statement values).
 - Emit shared `ConformanceNotice` records with actionable feedback.
 
 Out of scope:

--- a/docs/architecture/spirit_safe_models.md
+++ b/docs/architecture/spirit_safe_models.md
@@ -93,6 +93,13 @@ Entity scaffolds carry:
 - empty `data`
 - `profile_structure` copied from JSON profile content
 
+Within `profile_structure.statements[*].value`, SpiritSafe JSON can include derived-value hints for nested references/qualifiers:
+
+- `value_source: statement_value`
+- `value_source_statement: <statement URI>`
+
+These hints are derived from statement-level Wikibase semantics and are intended for downstream wizard/validation consumers.
+
 ## Testing Strategy
 
 `tests/fixtures/spiritsafe/` now mirrors the artifact-index model with minimal fixtures:

--- a/docs/gkc/profiles.md
+++ b/docs/gkc/profiles.md
@@ -50,6 +50,13 @@ Each profile artifact contains:
 
 `metadata` includes `profile_graph` and `value_list_graph` summaries used by packet scaffolding and registry indexing. `value_list_graph` includes value-list routes used by top-level statements and nested reference/qualifier statements.
 
+Statement `value` payloads may also include derived-value semantics used by downstream consumers:
+
+- `value_source: statement_value` when the statement value should be populated from its parent statement value in context.
+- `value_source_statement` as the URI of the parent statement definition that activates this behavior.
+
+These fields are emitted for qualifier/reference statement instances when the corresponding GKC Entity Statement item declares `derives default value from` semantics in Wikibase, with `applies to profile` scoping honored when present.
+
 The SpiritSafe manifest (`cache/manifest.json`) is generated as an artifact index over these files.
 
 ## Profile Anatomy

--- a/docs/gkc/wikibase_ontology_orientation.md
+++ b/docs/gkc/wikibase_ontology_orientation.md
@@ -61,6 +61,7 @@ The following properties are in active use for profile modeling. Properties use 
 | P210 | refresh policy | wikibase-item | GKC Value List (Q7) | Required; links to a refresh policy item (e.g., Q50 manual refresh) |
 | P211 | has reference | wikibase-item | qualifier on P157 | Links to a GKC Entity Statement specifying an expected reference type; OR semantics when multiple are present |
 | P212 | same as | url | Wikidata Entity (Q52) | URL of the specific Wikidata entity (e.g., `http://www.wikidata.org/entity/Q7840353`) |
+| P213 | derives default value from | wikibase-item | GKC Entity Statement (Q5) | Declares that when this statement is used as a reference/qualifier on the target statement, its value is derived from the parent statement value |
 
 ### Cardinality And Value
 
@@ -145,6 +146,13 @@ Multiple P161 qualifiers may appear on a single P157 claim. Profile (Q3) and val
 
 A GKC Entity Statement item may carry a `default value` (P202) URL claim pointing to a Wikidata entity to pre-populate. This claim must include a `default label` (P203) string qualifier providing a human-readable label for that entity.
 
+Derived defaults are modeled separately from static defaults. A GKC Entity Statement item may carry `derives default value from` (P213) claims targeting one or more parent statement definitions. This means:
+
+- when the subject statement is used as a qualifier/reference on that parent statement,
+- the subject statement value should be populated from the parent statement value.
+
+This pattern is global by default for the targeted parent statement(s). If a derived-default rule must only apply in specific profiles, constrain the P213 claim with `applies to profile` (P205) qualifiers.
+
 ### Value Lists And Refresh Policy
 
 GKC Value List items (`P1 = Q7`) must have a `refresh policy` (P210) claim linking to a refresh policy item (e.g., Q50 for manual refresh). Value list SPARQL queries are stored in the item's Wikibase discussion page and run against the Wikidata Query Service or Qlever to hydrate the SpiritSafe value list cache.
@@ -160,6 +168,8 @@ Qualifier specifications do not currently appear at the GKC Entity Statement ite
 Expected references for a statement are specified using `has reference` (P211) qualifiers on the P157 claim in the profile item. Each P211 qualifier targets a GKC Entity Statement item. When multiple P211 qualifiers are present on a single P157 claim, the rule is OR — at least one reference conforming to any of the listed types is expected.
 
 Reference specifications do not currently appear at the GKC Entity Statement item level.
+
+Reference value-derivation rules can appear at the GKC Entity Statement item level via P213. Consumers should apply those rules when reference/qualifier statements are instantiated in profile context, honoring any P205 profile constraints attached to the P213 claim.
 
 ### Guidance Precedence
 

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -1361,6 +1361,8 @@ class EntityProfileJsonBuilder:
     ERROR_MESSAGE = "P168"
     MAX_COUNT = "P182"
     HAS_REFERENCE = "P211"
+    APPLIES_TO_PROFILE = "P205"
+    DERIVES_DEFAULT_VALUE_FROM = "P213"
 
     LABEL_PROMPT = "P188"
     LABEL_GUIDANCE = "P185"
@@ -1608,6 +1610,7 @@ class EntityProfileJsonBuilder:
                 role="statement",
                 overlay_qualifiers=claim.get("qualifiers", {}),
                 visited={root_id} if root_id else set(),
+                current_profile_id=root_id,
             )
             if built:
                 statements.append(built)
@@ -1620,6 +1623,8 @@ class EntityProfileJsonBuilder:
         role: str,
         overlay_qualifiers: Optional[dict[str, list[dict[str, Any]]]] = None,
         visited: Optional[set[str]] = None,
+        current_profile_id: Optional[str] = None,
+        parent_statement_id: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
         if visited is None:
             visited = set()
@@ -1644,6 +1649,18 @@ class EntityProfileJsonBuilder:
             statement_json["value"]["type"], combined_value_ids
         )
 
+        source_statement_id = self._derived_value_source_statement_id(
+            statement_item=statement_item,
+            role=role,
+            parent_statement_id=parent_statement_id,
+            current_profile_id=current_profile_id,
+        )
+        if source_statement_id:
+            statement_json["value"]["value_source"] = "statement_value"
+            statement_json["value"][
+                "value_source_statement"
+            ] = f"{self.entity_prefix}{source_statement_id}"
+
         if qualifiers:
             statement_json["messages"] = self._merge_messages(
                 statement_json.get("messages", {}),
@@ -1664,11 +1681,15 @@ class EntityProfileJsonBuilder:
                     qualifier_ids,
                     role="qualifier",
                     visited=next_visited,
+                    current_profile_id=current_profile_id,
+                    parent_statement_id=entity_id,
                 )
                 statement_json["references"] = self._resolve_linked_statements(
                     reference_ids,
                     role="reference",
                     visited=next_visited,
+                    current_profile_id=current_profile_id,
+                    parent_statement_id=entity_id,
                 )
 
         if role in {"qualifier", "reference"}:
@@ -1683,11 +1704,17 @@ class EntityProfileJsonBuilder:
         *,
         role: str,
         visited: set[str],
+        current_profile_id: Optional[str],
+        parent_statement_id: str,
     ) -> list[dict[str, Any]]:
         resolved: list[dict[str, Any]] = []
         for entity_id in entity_ids:
             nested = self._build_statement_from_cache_id(
-                entity_id, role=role, visited=visited
+                entity_id,
+                role=role,
+                visited=visited,
+                current_profile_id=current_profile_id,
+                parent_statement_id=parent_statement_id,
             )
             if nested:
                 resolved.append(nested)
@@ -1993,6 +2020,48 @@ class EntityProfileJsonBuilder:
             if entity_id:
                 values.append(entity_id)
         return values
+
+    def _derived_value_source_statement_id(
+        self,
+        *,
+        statement_item: dict[str, Any],
+        role: str,
+        parent_statement_id: Optional[str],
+        current_profile_id: Optional[str],
+    ) -> Optional[str]:
+        if role not in {"qualifier", "reference"}:
+            return None
+        if not parent_statement_id:
+            return None
+
+        claims = statement_item.get("entity", {}).get("claims", {})
+        derives_claims = claims.get(self.DERIVES_DEFAULT_VALUE_FROM, [])
+        for claim in derives_claims:
+            source_statement_id = self._claim_entity_id(claim)
+            if not source_statement_id or source_statement_id != parent_statement_id:
+                continue
+            if self._claim_applies_to_profile(claim, current_profile_id):
+                return source_statement_id
+        return None
+
+    def _claim_applies_to_profile(
+        self,
+        claim: dict[str, Any],
+        current_profile_id: Optional[str],
+    ) -> bool:
+        if not current_profile_id:
+            return True
+
+        qualifiers = claim.get("qualifiers", {})
+        if not isinstance(qualifiers, dict):
+            return True
+
+        applies_to_profiles = self._qualifier_entity_ids(
+            qualifiers, self.APPLIES_TO_PROFILE
+        )
+        if not applies_to_profiles:
+            return True
+        return current_profile_id in applies_to_profiles
 
     def _claim_string_values(self, claims: list[dict[str, Any]]) -> list[str]:
         values: list[str] = []

--- a/tests/test_spirit_safe_entity_profile_json.py
+++ b/tests/test_spirit_safe_entity_profile_json.py
@@ -215,3 +215,190 @@ def test_value_list_graph_includes_reference_and_qualifier_routes(tmp_path):
             "cache_path": "cache/queries/Q28.json",
         },
     ]
+
+
+def test_reference_statement_derives_value_from_parent_statement(tmp_path):
+    """Nested reference should expose statement_value source when P213 matches parent."""
+
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+
+    profile_payload = {
+        "entity_id": "Q4",
+        "entity": {
+            "labels": {"mul": {"value": "Tribal Government in the United States"}},
+            "descriptions": {"mul": {"value": "Example profile"}},
+            "aliases": {},
+            "claims": {
+                "P1": [_build_entity_claim_entity_id("Q3")],
+                "P157": [
+                    {
+                        "mainsnak": {
+                            "datavalue": {
+                                "value": {"id": "Q19"},
+                            }
+                        },
+                        "qualifiers": {
+                            "P211": [_build_qualifier_entity_id("Q29")],
+                        },
+                    }
+                ],
+            },
+        },
+    }
+    (cache_entities_dir / "Q4.json").write_text(
+        json.dumps(profile_payload), encoding="utf-8"
+    )
+
+    statement_payloads = {
+        "Q19": {
+            "entity_id": "Q19",
+            "entity": {
+                "labels": {"mul": {"value": "official website"}},
+                "claims": {
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P856"
+                        )
+                    ],
+                    "P194": [_build_entity_claim_entity_id("Q54")],
+                },
+            },
+        },
+        "Q29": {
+            "entity_id": "Q29",
+            "entity": {
+                "labels": {"mul": {"value": "reference URL"}},
+                "claims": {
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P854"
+                        )
+                    ],
+                    "P194": [_build_entity_claim_entity_id("Q54")],
+                    "P213": [_build_entity_claim_entity_id("Q19")],
+                },
+            },
+        },
+        "Q54": {
+            "entity_id": "Q54",
+            "entity": {
+                "labels": {"mul": {"value": "url"}},
+                "claims": {
+                    "P1": [_build_entity_claim_entity_id("Q44")],
+                },
+            },
+        },
+    }
+
+    for entity_id, payload in statement_payloads.items():
+        (cache_entities_dir / f"{entity_id}.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    docs = build_entity_profile_json_documents(cache_entities_dir)
+
+    references = docs[0]["statements"][0]["references"]
+    assert len(references) == 1
+    assert references[0]["value"]["value_source"] == "statement_value"
+    assert references[0]["value"]["value_source_statement"] == (
+        "https://datadistillery.wikibase.cloud/entity/Q19"
+    )
+
+
+def test_reference_statement_derived_value_respects_profile_scope(tmp_path):
+    """P205 profile scoping should prevent derived value source outside scope."""
+
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+
+    profile_payload = {
+        "entity_id": "Q4",
+        "entity": {
+            "labels": {"mul": {"value": "Tribal Government in the United States"}},
+            "descriptions": {"mul": {"value": "Example profile"}},
+            "aliases": {},
+            "claims": {
+                "P1": [_build_entity_claim_entity_id("Q3")],
+                "P157": [
+                    {
+                        "mainsnak": {
+                            "datavalue": {
+                                "value": {"id": "Q19"},
+                            }
+                        },
+                        "qualifiers": {
+                            "P211": [_build_qualifier_entity_id("Q29")],
+                        },
+                    }
+                ],
+            },
+        },
+    }
+    (cache_entities_dir / "Q4.json").write_text(
+        json.dumps(profile_payload), encoding="utf-8"
+    )
+
+    statement_payloads = {
+        "Q19": {
+            "entity_id": "Q19",
+            "entity": {
+                "labels": {"mul": {"value": "official website"}},
+                "claims": {
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P856"
+                        )
+                    ],
+                    "P194": [_build_entity_claim_entity_id("Q54")],
+                },
+            },
+        },
+        "Q29": {
+            "entity_id": "Q29",
+            "entity": {
+                "labels": {"mul": {"value": "reference URL"}},
+                "claims": {
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P854"
+                        )
+                    ],
+                    "P194": [_build_entity_claim_entity_id("Q54")],
+                    "P213": [
+                        {
+                            "mainsnak": {
+                                "datavalue": {
+                                    "value": {"id": "Q19"},
+                                }
+                            },
+                            "qualifiers": {
+                                "P205": [_build_qualifier_entity_id("Q39")],
+                            },
+                        }
+                    ],
+                },
+            },
+        },
+        "Q54": {
+            "entity_id": "Q54",
+            "entity": {
+                "labels": {"mul": {"value": "url"}},
+                "claims": {
+                    "P1": [_build_entity_claim_entity_id("Q44")],
+                },
+            },
+        },
+    }
+
+    for entity_id, payload in statement_payloads.items():
+        (cache_entities_dir / f"{entity_id}.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    docs = build_entity_profile_json_documents(cache_entities_dir)
+
+    references = docs[0]["statements"][0]["references"]
+    assert len(references) == 1
+    assert "value_source" not in references[0]["value"]
+    assert "value_source_statement" not in references[0]["value"]


### PR DESCRIPTION
## Summary
- add P213 (derives default value from) handling in EntityProfileJsonBuilder
- emit value.value_source=statement_value and value.value_source_statement for nested reference/qualifier statements when parent-statement linkage matches
- honor optional P205 applies-to-profile qualifier on P213 claims; treat missing P205 as global behavior
- add regression tests for global and profile-scoped P213 behavior
- update ontology/profile/architecture docs for static (P202/P203) vs derived (P213) defaults and Validation Agent implications

## Validation
- poetry run pytest tests/test_spirit_safe_entity_profile_json.py tests/test_spirit_safe_phase3.py -q
- ./scripts/pre-merge-check.sh
