### PR TITLE
Wizard V2 Phase A/B baseline: packet-native launch + validation bridge

### DIFF
--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -384,7 +384,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # Profile commands
-    profile_parser = subparsers.add_parser("profile", help="YAML profile utilities")
+    profile_parser = subparsers.add_parser("profile", help="Profile utilities")
     profile_subparsers = profile_parser.add_subparsers(dest="profile_command")
 
     profile_validate = profile_subparsers.add_parser(
@@ -467,12 +467,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     profile_run_form = profile_subparsers.add_parser(
-        "form", help="Launch an interactive Textual wizard for a YAML profile"
+        "form", help="Launch an interactive Streamlit wizard for a JSON profile"
     )
     profile_run_form.add_argument(
         "--profile",
         required=True,
-        help="Path to YAML profile definition",
+        help="Profile reference (QID or full profile entity URI)",
     )
     profile_run_form.add_argument(
         "--qid",
@@ -2002,7 +2002,7 @@ def _handle_profile_form_schema(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _handle_profile_form(args: argparse.Namespace) -> dict[str, Any]:
-    """Launch an interactive Streamlit wizard from a YAML profile.
+    """Launch an interactive Streamlit wizard from a JSON profile or packet.
 
     Note: Starts a local Streamlit server at http://localhost:8501
     """
@@ -2014,9 +2014,14 @@ def _handle_profile_form(args: argparse.Namespace) -> dict[str, Any]:
     previous_source, source_overridden = _apply_source_override(args)
 
     try:
-        # Verify profile exists before launching Streamlit
-        loader = ProfileLoader()
-        profile, resolved_profile = _load_profile_from_reference(loader, args.profile)
+        # Verify profile is loadable before launching Streamlit.
+        profile_doc = load_profile(args.profile)
+        profile_entity = profile_doc.get("entity", args.profile)
+        profile_name = (
+            profile_doc.get("metadata", {}).get("labels", {}).get("mul")
+            or profile_doc.get("metadata", {}).get("labels", {}).get("en")
+            or profile_entity
+        )
 
         try:
             from gkc.profiles.forms import streamlit_app
@@ -2031,12 +2036,14 @@ def _handle_profile_form(args: argparse.Namespace) -> dict[str, Any]:
 
         # Set environment variables for Streamlit app to read
         env = os.environ.copy()
-        env["GKC_WIZARD_PROFILE"] = args.profile
+        env["GKC_WIZARD_PROFILE"] = profile_entity
         if args.qid:
             env["GKC_WIZARD_QID"] = args.qid
+        if args.packet:
+            env["GKC_WIZARD_PACKET"] = args.packet
 
         # Launch Streamlit in subprocess
-        print(f"🚀 Launching Streamlit wizard for profile: {profile.name}")
+        print(f"🚀 Launching Streamlit wizard for profile: {profile_name}")
         print("📍 URL: http://localhost:8501")
         print("⌨️  Press Ctrl+C to stop the server")
         print()
@@ -2051,9 +2058,10 @@ def _handle_profile_form(args: argparse.Namespace) -> dict[str, Any]:
             "ok": result.returncode == 0,
             "message": "Streamlit wizard closed",
             "details": {
-                "profile": profile.name,
-                "profile_ref": resolved_profile,
+                "profile": profile_name,
+                "profile_ref": profile_entity,
                 "qid": args.qid,
+                "packet": args.packet,
             },
         }
     finally:

--- a/gkc/profiles/forms/streamlit_app.py
+++ b/gkc/profiles/forms/streamlit_app.py
@@ -1,196 +1,21 @@
-"""Streamlit-based wizard for entity profile data curation.
-
-Plain meaning: Interactive web form for creating/editing Wikidata entities from profiles.
-"""
+"""Streamlit-based packet-native wizard for JSON entity profile curation."""
 
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime, timezone
-from typing import Any
+from pathlib import Path
+from typing import Any, Optional
 
-import requests
 import streamlit as st
 
 import gkc
-from gkc.profiles import ProfileLoader
 from gkc.profiles.forms.draft_manager import DraftManager
+from gkc.profiles.forms.validation_bridge import validate_entity_packet_data
 from gkc.profiles.forms.wizard import IdentificationStep, SitelinksStep, StatementsStep
-from gkc.profiles.validators import EntityJSONValidator
-
-# ============================================================================
-# SESSION STATE INITIALIZATION
-# ============================================================================
-
-
-def _create_primary_entity(profile_name: str) -> dict[str, Any]:
-    """Create a new primary entity following GKC Entity JSON schema.
-
-    Args:
-        profile_name: The profile name for this entity (e.g., "TribalGovernmentUS").
-
-    Returns:
-        GKC Entity JSON object for the primary entity.
-
-    Plain meaning: Build the template for a new entity being curated.
-    """
-    username = os.environ.get("WIKIVERSE_USERNAME", "unknown")
-    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    return {
-        "packet_id": "ent-001-primary",
-        "profile_name": profile_name,
-        "username": username,
-        "status": "in_progress",
-        "created_at": timestamp,
-        "creation_path": "primary",
-        "labels": {},
-        "descriptions": {},
-        "aliases": {},
-        "statements": {},
-        "sitelinks": {},
-    }
-
-
-def init_session_state() -> None:
-    """Initialize Streamlit session state with default values.
-
-    Plain meaning: Set up the persistent data store for the wizard session.
-    """
-    if "draft_data" not in st.session_state:
-        # Initialize empty curation packet (entity will be added once profile loads)
-        st.session_state.draft_data = {
-            "metadata": {
-                "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "last_modified": datetime.now(timezone.utc).strftime(
-                    "%Y-%m-%dT%H:%M:%SZ"
-                ),
-                "curator": os.environ.get("WIKIVERSE_USERNAME", "unknown"),
-            },
-            "entities": [],
-        }
-
-    if "current_step" not in st.session_state:
-        st.session_state.current_step = "plan"
-
-    if "profile" not in st.session_state:
-        st.session_state.profile = None
-
-    if "profile_name" not in st.session_state:
-        st.session_state.profile_name = None
-
-    if "profile_metadata" not in st.session_state:
-        st.session_state.profile_metadata = None
-
-    if "validation_errors" not in st.session_state:
-        st.session_state.validation_errors = {}
-
-    if "draft_manager" not in st.session_state:
-        st.session_state.draft_manager = DraftManager()
-
-    if "current_draft_path" not in st.session_state:
-        st.session_state.current_draft_path = None
-
-    if "save_success_message" not in st.session_state:
-        st.session_state.save_success_message = None
-
-
-def get_primary_entity() -> dict[str, Any]:
-    """Get the primary entity from the curation packet.
-
-    Returns:
-        The primary entity (packet_id "ent-001-primary").
-
-    Plain meaning: Access the main entity being edited (for MVP, always the first/only one).
-    """
-    entities = st.session_state.draft_data.get("entities", [])
-
-    # Find primary entity
-    for entity in entities:
-        if entity["packet_id"] == "ent-001-primary":
-            return entity
-
-    # If no primary entity exists, create one
-    if st.session_state.profile_name:
-        primary = _create_primary_entity(st.session_state.profile_name)
-        st.session_state.draft_data["entities"].append(primary)
-        return primary
-
-    # Fallback (should not reach here in normal flow)
-    return {}
-
-
-# ============================================================================
-# PROFILE LOADING
-# ============================================================================
-
-
-@st.cache_resource
-def get_profile_loader() -> ProfileLoader:
-    """Get cached ProfileLoader instance.
-
-    Plain meaning: Reuse the same profile loader across reruns.
-    """
-    return ProfileLoader()
-
-
-@st.cache_data(ttl=3600)  # Cache for 1 hour
-def load_profile(profile_name: str) -> Any:
-    """Load a profile by name from SpiritSafe (cached to avoid rate limits).
-
-    Args:
-        profile_name: Name of the profile to load (e.g., "TribalGovernmentUS").
-
-    Returns:
-        ProfileDefinition object.
-
-    Plain meaning: Fetch the profile YAML and parse it, caching to avoid repeated API calls.
-    """
-    loader = get_profile_loader()
-    resolved_profile = gkc.resolve_profile_path(profile_name)
-
-    resolved_profile_str = str(resolved_profile)
-    try:
-        # First try direct path load (works for absolute/relative paths)
-        return loader.load_from_file(resolved_profile_str)
-    except FileNotFoundError:
-        # If relative path doesn't exist, resolve via SpiritSafe source
-        source = gkc.get_spirit_safe_source()
-        resolved = source.resolve_relative(resolved_profile_str)
-
-        if isinstance(resolved, str):
-            # It's a GitHub URL
-            response = requests.get(resolved, timeout=30)
-            response.raise_for_status()
-            return loader.load_from_text(response.text)
-        else:
-            # It's a Path
-            return loader.load_from_file(resolved)
-
-
-@st.cache_data(ttl=3600)  # Cache for 1 hour
-def load_profile_metadata(profile_name: str) -> Any:
-    """Load profile metadata from metadata.yaml (cached to avoid rate limits).
-
-    Args:
-        profile_name: Name of the profile (e.g., "TribalGovernmentUS").
-
-    Returns:
-        ProfileMetadata object or None if not found.
-
-    Plain meaning: Fetch the profile's metadata.yaml and parse it, caching to avoid repeated API calls.
-    """
-    try:
-        return gkc.get_profile_metadata(profile_name)
-    except (FileNotFoundError, ValueError) as e:
-        st.warning(f"Could not load metadata for {profile_name}: {e}")
-        return None
-
-
-# ============================================================================
-# STEP NAVIGATION
-# ============================================================================
-
+from gkc.spirit_safe import load_profile
+from gkc.still_charger import build_curation_packet_from_json_profile
 
 STEPS = [
     {"id": "plan", "title": "Plan", "icon": "📋"},
@@ -201,70 +26,426 @@ STEPS = [
 ]
 
 
-def render_status_widget() -> None:
-    """Render entity status widget in sidebar (Phase 7.2).
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    Shows:
-    - Entity label with fallback
-    - Progress (X of Y completed)
-    - Progress bar visualization
 
-    Plain meaning: Display curation progress summary for quick reference.
-    """
-    if not st.session_state.profile:
+def _entity_id_from_uri(entity_uri: str) -> str:
+    if "/" in entity_uri:
+        return entity_uri.split("/")[-1]
+    return entity_uri
+
+
+def _profile_display_name(profile_doc: dict[str, Any]) -> str:
+    metadata = profile_doc.get("metadata", {})
+    labels = metadata.get("labels", {})
+    return (
+        labels.get("mul")
+        or labels.get("en")
+        or _entity_id_from_uri(profile_doc.get("entity", "unknown"))
+    )
+
+
+def _profile_description(profile_doc: dict[str, Any]) -> str:
+    metadata = profile_doc.get("metadata", {})
+    descriptions = metadata.get("descriptions", {})
+    return descriptions.get("mul") or descriptions.get("en") or ""
+
+
+def _metadata_text(messages: dict[str, Any], key: str) -> str:
+    if not isinstance(messages, dict):
+        return ""
+    for lang in ("mul", "en", "es"):
+        lang_map = messages.get(lang)
+        if isinstance(lang_map, dict) and isinstance(lang_map.get(key), str):
+            return lang_map[key]
+    return ""
+
+
+def _statement_label(statement_def: dict[str, Any]) -> str:
+    label = statement_def.get("label")
+    if isinstance(label, str) and label.strip():
+        return label
+    entity_ref = statement_def.get("entity", "statement")
+    return _entity_id_from_uri(str(entity_ref))
+
+
+def _statement_label_map(entity_slot: dict[str, Any]) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    for statement_def in entity_slot.get("statements", []):
+        if not isinstance(statement_def, dict):
+            continue
+        statement_ref = statement_def.get("entity")
+        if not isinstance(statement_ref, str) or not statement_ref:
+            continue
+        labels[statement_ref] = _statement_label(statement_def)
+    return labels
+
+
+def _collect_review_consequences(entity_slot: dict[str, Any]) -> dict[str, str]:
+    statements = entity_slot.get("statements", [])
+    data = entity_slot.get("data", {})
+    data_statements = data.get("statements", {}) if isinstance(data, dict) else {}
+
+    consequences: dict[str, str] = {}
+    for statement_def in statements:
+        if not isinstance(statement_def, dict):
+            continue
+
+        statement_ref = statement_def.get("entity")
+        if not isinstance(statement_ref, str) or not statement_ref:
+            continue
+
+        configured_values = data_statements.get(statement_ref, [])
+        has_value = isinstance(configured_values, list) and len(configured_values) > 0
+        if has_value:
+            continue
+
+        consequence = _metadata_text(
+            statement_def.get("messages", {}),
+            "consequences_message",
+        )
+        if consequence:
+            consequences[statement_ref] = consequence
+
+    return consequences
+
+
+def _group_review_items(
+    *,
+    entity_slot: dict[str, Any],
+    notices: list[Any],
+) -> tuple[list[dict[str, Any]], list[Any]]:
+    statement_labels = _statement_label_map(entity_slot)
+    consequences = _collect_review_consequences(entity_slot)
+    entity_ref = entity_slot.get("id") or entity_slot.get("profile_entity")
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for statement_ref, label in statement_labels.items():
+        grouped[statement_ref] = {
+            "statement_ref": statement_ref,
+            "label": label,
+            "consequence": consequences.get(statement_ref),
+            "notices": [],
+        }
+
+    ungrouped: list[Any] = []
+    for notice in notices:
+        if entity_ref and notice.entity_ref != entity_ref:
+            ungrouped.append(notice)
+            continue
+
+        statement_ref = notice.statement_ref
+        if isinstance(statement_ref, str) and statement_ref in grouped:
+            grouped[statement_ref]["notices"].append(notice)
+        else:
+            ungrouped.append(notice)
+
+    ordered_sections = [
+        grouped[statement_ref]
+        for statement_ref in statement_labels
+        if grouped[statement_ref]["consequence"] or grouped[statement_ref]["notices"]
+    ]
+    return ordered_sections, ungrouped
+
+
+def _normalize_profile_ref(profile_ref: str) -> str:
+    if profile_ref.startswith("http://") or profile_ref.startswith("https://"):
+        return profile_ref
+    if profile_ref.startswith("Q"):
+        return f"https://datadistillery.wikibase.cloud/entity/{profile_ref}"
+    raise ValueError(
+        f"Invalid profile reference '{profile_ref}'. Use QID or full entity URI."
+    )
+
+
+def _build_initial_packet(
+    profile_ref: str,
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    profile_entity = _normalize_profile_ref(profile_ref)
+    primary_doc = load_profile(profile_entity)
+
+    source = gkc.get_spirit_safe_source()
+    source_root: Optional[Path] = (
+        source.local_root if source.mode == "local" and source.local_root else None
+    )
+
+    packet = build_curation_packet_from_json_profile(
+        profile_entity=profile_entity,
+        json_profile_doc=primary_doc,
+        source_root=source_root,
+    )
+
+    profile_docs: dict[str, dict[str, Any]] = {}
+    for entity_slot in packet.get("entities", []):
+        slot_uri = entity_slot.get("profile_entity")
+        if not isinstance(slot_uri, str) or not slot_uri:
+            continue
+        try:
+            profile_docs[slot_uri] = load_profile(slot_uri)
+        except Exception:
+            pass
+
+    # Ensure primary profile doc is always present.
+    profile_docs.setdefault(profile_entity, primary_doc)
+
+    # Ensure packet metadata exists for draft persistence.
+    packet.setdefault(
+        "metadata",
+        {
+            "created_at": _utc_now_iso(),
+            "last_modified": _utc_now_iso(),
+            "curator": os.environ.get("WIKIVERSE_USERNAME", "unknown"),
+            "profile_entity": profile_entity,
+        },
+    )
+
+    return packet, profile_docs
+
+
+def _entity_sort_key(entity_slot: dict[str, Any]) -> tuple[int, str]:
+    entity_id = str(entity_slot.get("id", ""))
+    # Primary packet slot tends to be ent-001; keep deterministic order.
+    is_primary = 0 if entity_id == "ent-001" else 1
+    return (is_primary, entity_id)
+
+
+def _entity_label(entity_slot: dict[str, Any], profile_doc: dict[str, Any]) -> str:
+    entity_uri = entity_slot.get("profile_entity", "")
+    entity_id = entity_slot.get("id", "unknown")
+    profile_name = _profile_display_name(profile_doc)
+    data = entity_slot.get("data", {})
+    labels = data.get("labels", {}) if isinstance(data, dict) else {}
+    chosen = labels.get("mul") or labels.get("en")
+    if chosen:
+        return f"{entity_id} - {chosen} ({profile_name})"
+    return f"{entity_id} - New {profile_name} ({_entity_id_from_uri(entity_uri)})"
+
+
+def init_session_state() -> None:
+    if "packet" not in st.session_state:
+        st.session_state.packet = None
+    if "profile_docs" not in st.session_state:
+        st.session_state.profile_docs = {}
+    if "root_profile_entity" not in st.session_state:
+        st.session_state.root_profile_entity = None
+    if "current_step" not in st.session_state:
+        st.session_state.current_step = "plan"
+    if "active_entity_id" not in st.session_state:
+        st.session_state.active_entity_id = None
+    if "draft_manager" not in st.session_state:
+        st.session_state.draft_manager = DraftManager()
+    if "current_draft_path" not in st.session_state:
+        st.session_state.current_draft_path = None
+    if "save_success_message" not in st.session_state:
+        st.session_state.save_success_message = None
+    if "source_root" not in st.session_state:
+        st.session_state.source_root = None
+    if "conformance_notices" not in st.session_state:
+        st.session_state.conformance_notices = []
+
+
+def _find_active_entity_slot() -> Optional[dict[str, Any]]:
+    packet = st.session_state.packet or {}
+    entities = packet.get("entities", [])
+    if not entities:
+        return None
+
+    active_id = st.session_state.active_entity_id
+    if active_id:
+        for entity_slot in entities:
+            if entity_slot.get("id") == active_id:
+                return entity_slot
+
+    entities_sorted = sorted(entities, key=_entity_sort_key)
+    chosen = entities_sorted[0]
+    st.session_state.active_entity_id = chosen.get("id")
+    return chosen
+
+
+def _active_profile_doc() -> Optional[dict[str, Any]]:
+    entity_slot = _find_active_entity_slot()
+    if not entity_slot:
+        return None
+    entity_uri = entity_slot.get("profile_entity")
+    return st.session_state.profile_docs.get(entity_uri)
+
+
+def _active_entity_data() -> dict[str, Any]:
+    entity_slot = _find_active_entity_slot()
+    if entity_slot is None:
+        return {}
+    if "data" not in entity_slot or not isinstance(entity_slot["data"], dict):
+        entity_slot["data"] = {}
+    data = entity_slot["data"]
+    data.setdefault("labels", {})
+    data.setdefault("descriptions", {})
+    data.setdefault("aliases", {})
+    data.setdefault("statements", {})
+    data.setdefault("sitelinks", {})
+    return data
+
+
+def _auto_save_draft() -> None:
+    packet = st.session_state.packet
+    if not isinstance(packet, dict):
         return
 
-    entity = get_primary_entity()
-    profile = st.session_state.profile
-    profile_name = st.session_state.profile_name
+    metadata = packet.setdefault("metadata", {})
+    metadata["last_modified"] = _utc_now_iso()
 
-    # Calculate completeness
-    completeness = EntityJSONValidator.calculate_completeness(
-        entity, profile, required_languages=None
+    root_entity = st.session_state.root_profile_entity or "packet"
+    draft_name = _entity_id_from_uri(root_entity)
+
+    if st.session_state.current_draft_path is None:
+        st.session_state.current_draft_path = (
+            st.session_state.draft_manager.create_draft_path(draft_name)
+        )
+
+    st.session_state.draft_manager.save(st.session_state.current_draft_path, packet)
+
+
+def _save_draft_manual() -> None:
+    _auto_save_draft()
+    draft_path = st.session_state.current_draft_path
+    if draft_path:
+        st.session_state.save_success_message = f"Draft saved to: {draft_path.name}"
+
+
+def _run_packet_validation() -> list[Any]:
+    packet = st.session_state.packet or {}
+    source_root = st.session_state.source_root
+    if isinstance(source_root, str) and source_root:
+        source_root = Path(source_root)
+    if not isinstance(source_root, Path):
+        source_root = None
+
+    notices = []
+    for entity_slot in packet.get("entities", []):
+        notices.extend(
+            validate_entity_packet_data(
+                entity_slot=entity_slot,
+                packet=packet,
+                source_root=source_root,
+            )
+        )
+
+    st.session_state.conformance_notices = notices
+    return notices
+
+
+def _render_conformance_notices(notices: list[Any]) -> None:
+    if not notices:
+        st.success("No conformance notices detected.")
+        return
+
+    error_count = sum(1 for n in notices if n.severity == "error")
+    warning_count = sum(1 for n in notices if n.severity == "warning")
+    info_count = sum(1 for n in notices if n.severity == "info")
+
+    st.write(
+        f"Errors: **{error_count}** | Warnings: **{warning_count}** | Info: **{info_count}**"
     )
 
-    # Determine display label (priority: curator label → fallback)
-    entity_labels = entity.get("labels", {})
-    if entity_labels:
-        # Use first available label
-        display_label = next(iter(entity_labels.values()))
-        # Truncate if too long for sidebar
-        if len(display_label) > 30:
-            display_label = display_label[:27] + "..."
-    else:
-        display_label = f"New {profile_name}"
+    for notice in notices:
+        message = (
+            f"[{notice.code}] {notice.message} "
+            f"(entity={notice.entity_ref}, statement={notice.statement_ref or 'n/a'})"
+        )
+        if notice.severity == "error":
+            st.error(message)
+        elif notice.severity == "warning":
+            st.warning(message)
+        else:
+            st.info(message)
 
-    # Render status widget
-    st.sidebar.subheader("📊 Status")
-    st.sidebar.write(f"**{display_label}**")
-    st.sidebar.caption(f"Profile: {profile_name}")
 
-    # Progress metrics
-    st.sidebar.progress(completeness.progress_percentage / 100)
-    st.sidebar.write(
-        f"**{completeness.completed_fields} of {completeness.required_fields_total}** completed"
+def _render_grouped_review_sections(
+    sections: list[dict[str, Any]],
+    ungrouped_notices: list[Any],
+) -> None:
+    if not sections and not ungrouped_notices:
+        st.success(
+            "No statement-level consequences or conformance notices for the active entity."
+        )
+        return
+
+    for section in sections:
+        label = section["label"]
+        statement_ref = section["statement_ref"]
+        consequence = section["consequence"]
+        section_notices = section["notices"]
+
+        with st.expander(
+            f"{label} ({_entity_id_from_uri(statement_ref)})", expanded=True
+        ):
+            if consequence:
+                st.warning(f"Consequence: {consequence}")
+
+            if not section_notices:
+                st.info("No conformance notices for this statement.")
+                continue
+
+            for notice in section_notices:
+                message = f"[{notice.code}] {notice.message}"
+                if notice.severity == "error":
+                    st.error(message)
+                elif notice.severity == "warning":
+                    st.warning(message)
+                else:
+                    st.info(message)
+
+    if ungrouped_notices:
+        with st.expander("Other Notices", expanded=False):
+            _render_conformance_notices(ungrouped_notices)
+
+
+def render_entity_sidebar() -> None:
+    packet = st.session_state.packet or {}
+    entities = packet.get("entities", [])
+    if not entities:
+        return
+
+    st.sidebar.subheader("Entities")
+
+    entities_sorted = sorted(entities, key=_entity_sort_key)
+    options = []
+    labels = []
+    for entity_slot in entities_sorted:
+        entity_id = entity_slot.get("id")
+        profile_uri = entity_slot.get("profile_entity")
+        profile_doc = st.session_state.profile_docs.get(profile_uri, {})
+        options.append(entity_id)
+        labels.append(_entity_label(entity_slot, profile_doc))
+
+    label_by_id = dict(zip(options, labels))
+    active = st.session_state.active_entity_id or options[0]
+
+    selected = st.sidebar.selectbox(
+        "Active entity",
+        options,
+        format_func=lambda x: label_by_id.get(x, x),
+        index=options.index(active) if active in options else 0,
     )
-    st.sidebar.caption(f"{completeness.progress_percentage:.0f}% complete")
+
+    if selected != st.session_state.active_entity_id:
+        st.session_state.active_entity_id = selected
+        st.rerun()
 
     st.sidebar.divider()
 
 
 def render_step_sidebar() -> None:
-    """Render step navigation in sidebar.
-
-    Plain meaning: Show clickable step buttons with visual highlighting.
-    """
     st.sidebar.title("Wizard Steps")
 
     for step in STEPS:
-        # Visual indicator for current step
-        if st.session_state.current_step == step["id"]:
-            button_label = f"**→ {step['icon']} {step['title']}**"
-            button_type = "primary"
-        else:
-            button_label = f"{step['icon']} {step['title']}"
-            button_type = "secondary"
-
+        is_current = st.session_state.current_step == step["id"]
+        button_label = (
+            f"**-> {step['icon']} {step['title']}**"
+            if is_current
+            else f"{step['icon']} {step['title']}"
+        )
+        button_type = "primary" if is_current else "secondary"
         if st.sidebar.button(
             button_label,
             key=f"nav_{step['id']}",
@@ -275,13 +456,170 @@ def render_step_sidebar() -> None:
             st.rerun()
 
 
+def render_plan_step() -> None:
+    st.header("📋 Plan")
+
+    profile_doc = _active_profile_doc()
+    entity_slot = _find_active_entity_slot()
+    if not profile_doc or not entity_slot:
+        st.warning("No active profile/entity loaded")
+        return
+
+    st.subheader(_profile_display_name(profile_doc))
+    description = _profile_description(profile_doc)
+    if description:
+        st.write(description)
+
+    statements = entity_slot.get("statements", [])
+    st.subheader("Profile Statements")
+    for statement_def in statements:
+        label = statement_def.get("label") or _entity_id_from_uri(
+            statement_def.get("entity", "statement")
+        )
+        if st.button(
+            label,
+            key=f"goto_stmt_{statement_def.get('entity')}",
+            use_container_width=True,
+        ):
+            st.session_state.current_step = "statements"
+            st.session_state.expand_statement = statement_def.get("entity")
+            st.rerun()
+
+    col1, col2, col3 = st.columns([1, 1, 1])
+    with col3:
+        if st.button("Next: Identification ->", type="primary", key="next_plan"):
+            st.session_state.current_step = "identification"
+            st.rerun()
+
+
+def render_identification_step() -> None:
+    entity_data = _active_entity_data()
+    step = IdentificationStep(id="identification", title="", description="")
+    step.render(entity_data)
+    _auto_save_draft()
+
+    warnings = step.validate(entity_data)
+    if warnings:
+        with st.expander("⚠️ Validation Warnings"):
+            for messages in warnings.values():
+                for message in messages:
+                    st.warning(message)
+
+    col1, _, col3 = st.columns([1, 1, 1])
+    with col1:
+        if st.button("<- Back: Plan", type="secondary", key="back_identification"):
+            st.session_state.current_step = "plan"
+            st.rerun()
+    with col3:
+        if st.button("Next: Statements ->", type="primary", key="next_identification"):
+            st.session_state.current_step = "statements"
+            st.rerun()
+
+
+def render_statements_step() -> None:
+    entity_data = _active_entity_data()
+    step = StatementsStep(id="statements", title="", description="")
+    step.render(entity_data)
+    _auto_save_draft()
+
+    warnings = step.validate(entity_data)
+    if warnings:
+        with st.expander("⚠️ Validation Warnings", expanded=False):
+            for section, messages in warnings.items():
+                st.warning(f"{section}: {'; '.join(messages)}")
+
+    col1, _, col3 = st.columns([1, 1, 1])
+    with col1:
+        if st.button(
+            "<- Back: Identification", type="secondary", key="back_statements"
+        ):
+            st.session_state.current_step = "identification"
+            st.rerun()
+    with col3:
+        if st.button("Next: Sitelinks ->", type="primary", key="next_statements"):
+            st.session_state.current_step = "sitelinks"
+            st.rerun()
+
+
+def render_sitelinks_step() -> None:
+    entity_data = _active_entity_data()
+    step = SitelinksStep(id="sitelinks", title="", description="")
+    step.render(entity_data)
+    _auto_save_draft()
+
+    col1, _, col3 = st.columns([1, 1, 1])
+    with col1:
+        if st.button("<- Back: Statements", type="secondary", key="back_sitelinks"):
+            st.session_state.current_step = "statements"
+            st.rerun()
+    with col3:
+        if st.button("Next: Review ->", type="primary", key="next_sitelinks"):
+            st.session_state.current_step = "review"
+            st.rerun()
+
+
+def render_review_step() -> None:
+    st.header("✅ Review")
+
+    packet = st.session_state.packet or {}
+    entity_slot = _find_active_entity_slot()
+    entity_data = _active_entity_data()
+
+    if entity_slot:
+        st.subheader(
+            f"Active Entity: {entity_slot.get('id')} ({_entity_id_from_uri(entity_slot.get('profile_entity', ''))})"
+        )
+
+    if st.session_state.save_success_message:
+        st.success(st.session_state.save_success_message)
+        st.session_state.save_success_message = None
+
+    col1, col2, _ = st.columns([1, 1, 1])
+    with col1:
+        if st.button("💾 Save Draft", type="primary", key="save_review"):
+            _save_draft_manual()
+            st.rerun()
+
+    with col2:
+        if st.button("Re-run Session Validation", key="rerun_validation"):
+            _run_packet_validation()
+            st.rerun()
+
+    notices = st.session_state.conformance_notices
+    if not notices:
+        notices = _run_packet_validation()
+
+    st.write("### Statement Review")
+    sections: list[dict[str, Any]] = []
+    ungrouped_notices: list[Any] = notices
+    if entity_slot:
+        sections, ungrouped_notices = _group_review_items(
+            entity_slot=entity_slot,
+            notices=notices,
+        )
+    _render_grouped_review_sections(sections, ungrouped_notices)
+
+    blocking_errors = [n for n in notices if n.severity == "error"]
+    if blocking_errors:
+        st.error("Submission is currently blocked because error-level notices exist.")
+    else:
+        st.success("No error-level notices. Submission would be allowed.")
+
+    st.write("### Active Entity Data")
+    st.code(json.dumps(entity_data, indent=2, ensure_ascii=False), language="json")
+
+    st.write("### Full Curation Packet")
+    st.code(json.dumps(packet, indent=2, ensure_ascii=False), language="json")
+
+    col1, _, _ = st.columns([1, 1, 1])
+    with col1:
+        if st.button("<- Back: Sitelinks", type="secondary", key="back_review"):
+            st.session_state.current_step = "sitelinks"
+            st.rerun()
+
+
 def render_step_content() -> None:
-    """Render the content for the current step.
-
-    Plain meaning: Show the form fields appropriate for the current wizard step.
-    """
     current_step = st.session_state.current_step
-
     if current_step == "plan":
         render_plan_step()
     elif current_step == "identification":
@@ -296,576 +634,109 @@ def render_step_content() -> None:
         st.error(f"Unknown step: {current_step}")
 
 
-# ============================================================================
-# STEP IMPLEMENTATIONS (PHASE 2-6)
-# ============================================================================
+def _load_packet_from_env_or_profile() -> None:
+    env_packet = os.environ.get("GKC_WIZARD_PACKET")
+    env_profile = os.environ.get("GKC_WIZARD_PROFILE")
 
+    if env_packet:
+        packet_path = Path(env_packet)
+        if not packet_path.exists():
+            st.sidebar.error(f"Packet file not found: {packet_path}")
+            st.stop()
 
-def _auto_save_draft() -> None:
-    """Auto-save the current draft after step changes.
+        try:
+            packet = json.loads(packet_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            st.sidebar.error(f"Failed to load packet JSON: {exc}")
+            st.stop()
 
-    Plain meaning: Persist data to disk so work isn't lost.
-    """
-    if st.session_state.profile_name and st.session_state.draft_manager:
-        # Update last_modified timestamp
-        st.session_state.draft_data["metadata"]["last_modified"] = datetime.now(
-            timezone.utc
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        profile_docs: dict[str, dict[str, Any]] = {}
+        for entity_slot in packet.get("entities", []):
+            profile_uri = entity_slot.get("profile_entity")
+            if not profile_uri:
+                continue
+            try:
+                profile_docs[profile_uri] = load_profile(profile_uri)
+            except Exception:
+                pass
 
-        # Use existing draft path or create new one
-        if st.session_state.current_draft_path is None:
-            draft_path = st.session_state.draft_manager.create_draft_path(
-                st.session_state.profile_name
-            )
-            st.session_state.current_draft_path = draft_path
-        else:
-            draft_path = st.session_state.current_draft_path
-
-        st.session_state.draft_manager.save(draft_path, st.session_state.draft_data)
-
-
-def _save_draft_manual() -> None:
-    """Manually save draft and provide user feedback.
-
-    Plain meaning: Save the draft and show confirmation to the user.
-    """
-    _auto_save_draft()
-    draft_path = st.session_state.current_draft_path
-    if draft_path:
-        st.session_state.save_success_message = f"Draft saved to: {draft_path.name}"
-    else:
-        st.session_state.save_success_message = "Draft saved successfully!"
-
-
-def render_plan_step() -> None:
-    """Render the Plan step (Phase 2).
-
-    Plain meaning: Show planning/overview of the editing session.
-    """
-    if st.session_state.profile:
-        profile = st.session_state.profile
-        metadata = st.session_state.profile_metadata
-
-        # Show profile name
-        st.subheader(profile.name)
-
-        # Show extended description from metadata if available, otherwise profile description
-        if metadata and metadata.description:
-            st.write(metadata.description)
-        else:
-            st.write(profile.description)
-
-        # Show full metadata in an expander
-        if metadata:
-            with st.expander("📄 View Full Profile Metadata"):
-                import yaml
-
-                # Convert metadata to dict for YAML rendering
-                metadata_dict = {
-                    "name": metadata.name,
-                    "description": metadata.description,
-                    "version": metadata.version,
-                    "status": metadata.status,
-                    "published_date": metadata.published_date,
-                }
-                if metadata.authors:
-                    metadata_dict["authors"] = metadata.authors
-                if metadata.maintainers:
-                    metadata_dict["maintainers"] = metadata.maintainers
-                if metadata.source_references:
-                    metadata_dict["source_references"] = metadata.source_references
-                if metadata.related_profiles:
-                    metadata_dict["related_profiles"] = metadata.related_profiles
-                if metadata.community_feedback:
-                    metadata_dict["community_feedback"] = metadata.community_feedback
-                if metadata.datatypes_used:
-                    metadata_dict["datatypes_used"] = metadata.datatypes_used
-                if metadata.statements_count is not None:
-                    metadata_dict["statements_count"] = metadata.statements_count
-                if metadata.references_required is not None:
-                    metadata_dict["references_required"] = metadata.references_required
-                if metadata.qualifiers_used:
-                    metadata_dict["qualifiers_used"] = metadata.qualifiers_used
-                if metadata.sparql_sources:
-                    metadata_dict["sparql_sources"] = metadata.sparql_sources
-
-                st.code(
-                    yaml.dump(metadata_dict, sort_keys=False, allow_unicode=True),
-                    language="yaml",
-                )
-
-        # Show profile statements
-        if hasattr(profile, "statements") and profile.statements:
-            st.subheader("Profile Statements")
-            for stmt in profile.statements:
-                # Display statement label as clickable link to jump to Statements step
-                if st.button(
-                    stmt.label, key=f"goto_{stmt.id}", use_container_width=True
-                ):
-                    st.session_state.expand_statement = stmt.id
-                    st.session_state.current_step = "statements"
-                    st.rerun()
-    else:
-        st.warning("No profile loaded. Please select a profile from the configuration.")
-
-    # Navigation
-    col1, col2, col3 = st.columns([1, 1, 1])
-    with col3:
-        if st.button("Next: Identification →", type="primary", key="next_plan"):
-            st.session_state.current_step = "identification"
-            st.rerun()
-
-
-def render_identification_step() -> None:
-    """Render the Identification step.
-
-    Plain meaning: Collect labels, descriptions, and aliases.
-    """
-    # Get primary entity from curation packet
-    entity = get_primary_entity()
-
-    step = IdentificationStep(
-        id="identification",
-        title="",
-        description="",
-    )
-
-    # Pass entity data to step renderer (step modifies in-place)
-    step.render(entity)
-
-    # Auto-save after rendering
-    _auto_save_draft()
-
-    # Show validation warnings
-    validation_errors = step.validate(entity)
-    if validation_errors:
-        with st.expander("⚠️ Validation Warnings"):
-            for field, messages in validation_errors.items():
-                for msg in messages:
-                    st.warning(msg)
-
-    # Navigation
-    col1, col2, col3 = st.columns([1, 1, 1])
-    with col1:
-        if st.button("← Back: Plan", type="secondary", key="back_identification"):
-            st.session_state.current_step = "plan"
-            st.rerun()
-    with col3:
-        if st.button("Next: Statements →", type="primary", key="next_identification"):
-            st.session_state.current_step = "statements"
-            st.rerun()
-
-
-def render_statements_step() -> None:
-    """Render the Statements step.
-
-    Plain meaning: Collect statement values with qualifiers and references.
-    """
-    # Get primary entity from curation packet
-    entity = get_primary_entity()
-
-    # Create step instance
-    step = StatementsStep(
-        id="statements",
-        title="",  # Title shown in step header
-        description="",  # Description not needed, profile provides context
-    )
-
-    # Render step content and collect data (step modifies entity in-place)
-    step.render(entity)
-
-    # Run validation (non-blocking)
-    warnings = step.validate(entity)
-    if warnings:
-        with st.expander("⚠️ Validation Warnings", expanded=False):
-            for section, messages in warnings.items():
-                st.warning(f"**{section.title()}**: " + "; ".join(messages))
-
-    # Navigation
-    st.write("---")
-    col1, col2, col3 = st.columns([1, 1, 1])
-    with col1:
-        if st.button("← Back: Identification", type="secondary"):
-            _auto_save_draft()
-            st.session_state.current_step = "identification"
-            st.rerun()
-    with col3:
-        if st.button("Next: Sitelinks →", type="primary"):
-            _auto_save_draft()
-            st.session_state.current_step = "sitelinks"
-            st.rerun()
-
-
-def render_sitelinks_step() -> None:
-    """Render the Sitelinks step.
-
-    Plain meaning: Collect Wikipedia/sister project links.
-    """
-    # Get primary entity from curation packet
-    entity = get_primary_entity()
-
-    step = SitelinksStep(
-        id="sitelinks",
-        title="",
-        description="",
-    )
-
-    step.render(entity)
-
-    # Auto-save after rendering
-    _auto_save_draft()
-
-    # Show validation warnings
-    validation_errors = step.validate(entity)
-    if validation_errors:
-        with st.expander("⚠️ Validation Warnings"):
-            for field, messages in validation_errors.items():
-                for msg in messages:
-                    st.warning(msg)
-
-    # Navigation
-    col1, col2, col3 = st.columns([1, 1, 1])
-    with col1:
-        if st.button("← Back: Statements", type="secondary", key="back_sitelinks"):
-            st.session_state.current_step = "statements"
-            st.rerun()
-    with col3:
-        if st.button("Next: Review →", type="primary", key="next_sitelinks"):
-            st.session_state.current_step = "review"
-            st.rerun()
-
-
-def render_review_step() -> None:
-    """Render the Review step (Phase 6 + 7.3).
-
-    Plain meaning: Show collected data, calculate completeness, and export options.
-    """
-    st.header("✅ Review & Export")
-
-    entity = get_primary_entity()
-    profile = st.session_state.profile
-
-    # Calculate completeness
-    if profile:
-        completeness = EntityJSONValidator.calculate_completeness(
-            entity, profile, required_languages=None
+        st.session_state.packet = packet
+        st.session_state.profile_docs = profile_docs
+        st.session_state.root_profile_entity = packet.get("profile_entity")
+        source = gkc.get_spirit_safe_source()
+        st.session_state.source_root = (
+            str(source.local_root)
+            if source.mode == "local" and source.local_root is not None
+            else None
         )
+        if packet.get("entities"):
+            st.session_state.active_entity_id = packet["entities"][0].get("id")
 
-        # Show progress (Phase 7.3: larger format in review)
-        st.subheader("Curation Progress")
-        st.progress(completeness.progress_percentage / 100)
-        st.write(
-            f"**{completeness.progress_text}** ({completeness.progress_percentage:.0f}% complete)"
+        st.sidebar.success(f"Loaded packet: {packet_path.name}")
+        return
+
+    if not env_profile:
+        st.sidebar.warning(
+            "No profile specified. Set GKC_WIZARD_PROFILE or GKC_WIZARD_PACKET."
         )
+        st.stop()
 
-        # Phase 7.3: Statement-level completeness breakdown
-        st.subheader("📋 Statement Completeness")
-        entity_statements = entity.get("statements", {})
+    profile_ref = str(env_profile)
 
-        # Display all statements from profile in order
-        for stmt_def in profile.statements:
-            statement_id = stmt_def.id
-            statement_label = stmt_def.label
-            is_filled = (
-                statement_id in entity_statements and entity_statements[statement_id]
-            )
-            is_required = stmt_def.required
-
-            # Visual indicator
-            if is_filled:
-                icon = "✅"
-                status = "Completed"
-                status_color = "green"
-            elif is_required:
-                icon = "❌"
-                status = "Required - Missing"
-                status_color = "red"
-            else:
-                icon = "⚪"
-                status = "Optional - Not filled"
-                status_color = "gray"
-
-            # Display row
-            col1, col2, col3 = st.columns([1, 3, 2])
-            with col1:
-                st.write(icon)
-            with col2:
-                st.write(f"**{statement_label}**")
-                if stmt_def.input_prompt:
-                    st.caption(stmt_def.input_prompt)
-            with col3:
-                if status_color == "green":
-                    st.success(status)
-                elif status_color == "red":
-                    st.error(status)
-                else:
-                    st.write(status)
-
-        st.write("---")
-
-        # Show language coverage
-        with st.expander("🌐 Language Coverage"):
-            st.write(f"**Required:** {', '.join(completeness.required_languages)}")
-            st.write(
-                f"**Completed:** {', '.join(completeness.completed_languages) or 'None'}"
-            )
-            if completeness.missing_languages:
-                st.write(f"**Missing:** {', '.join(completeness.missing_languages)}")
-
-    # Validate schema compliance (Phase 7.4: validation display)
-    st.subheader("Schema Validation")
-    validation_result = EntityJSONValidator.validate_schema(entity)
-
-    if validation_result.is_valid:
-        st.success("✅ Entity JSON schema is valid")
-    else:
-        st.error("❌ Schema validation failed")
-
-    if validation_result.issues:
-        with st.expander(
-            f"⚠️ Validation Issues ({len(validation_result.issues)})", expanded=True
-        ):
-            for issue in validation_result.issues:
-                if issue.severity == "error":
-                    st.error(f"**{issue.field}**: {issue.message}")
-                elif issue.severity == "warning":
-                    st.warning(f"**{issue.field}**: {issue.message}")
-                else:
-                    st.info(f"**{issue.field}**: {issue.message}")
-
-                if issue.suggestion:
-                    st.caption(f"💡 {issue.suggestion}")
-
-    # Save draft button
-    st.subheader("Actions")
-
-    # Show save success message if present
-    if st.session_state.save_success_message:
-        st.success(st.session_state.save_success_message)
-        st.session_state.save_success_message = None  # Clear after displaying
-
-    col1, col2, col3 = st.columns([1, 1, 1])
-    with col1:
-        if st.button("💾 Save Draft", type="primary"):
-            _save_draft_manual()
-            st.rerun()
-
-    # Show current draft path info
-    if st.session_state.current_draft_path:
-        with st.expander("💾 Draft File Info", expanded=False):
-            st.write(f"**Location:** `{st.session_state.current_draft_path}`")
-            st.write(
-                f"**Last modified:** {st.session_state.draft_data.get('metadata', {}).get('last_modified', 'N/A')}"
-            )
-            st.caption(
-                "💡 Your work is automatically saved as you navigate between steps. "
-                "Drafts are stored in `~/.gkc/drafts/` (Streamlit standard approach). "
-                "Use the 'Save Draft' button above to force a save at any time."
-            )
-
-    # Navigation
-    st.write("---")
-    col1, col2, col3 = st.columns([1, 1, 1])
-    with col1:
-        if st.button("← Back: Sitelinks", type="secondary"):
-            st.session_state.current_step = "sitelinks"
-            st.rerun()
-
-
-# ============================================================================
-# DRAFT LOADING
-# ============================================================================
-
-
-def load_most_recent_draft(
-    profile_name: str, draft_manager: DraftManager
-) -> tuple[dict[str, Any] | None, list[str]]:
-    """Load the most recent draft for a profile if one exists.
-
-    Args:
-        profile_name: Profile name to load draft for
-        draft_manager: DraftManager instance
-
-    Returns:
-        Tuple of (draft_data, validation_errors). If no draft exists, returns (None, []).
-
-    Plain meaning: Find and load the latest saved draft with validation.
-    """
-    # Find all drafts for this profile
-    safe_name = "_".join(profile_name.split())
-    draft_files = sorted(
-        draft_manager.drafts_dir.glob(f"{safe_name}_*.json"), reverse=True
-    )
-
-    if not draft_files:
-        return None, []
-
-    # Load the most recent draft
     try:
-        draft_path = draft_files[0]
-        draft_data = draft_manager.load(draft_path)
-        validation_errors = []
+        packet, profile_docs = _build_initial_packet(profile_ref)
+    except Exception as exc:
+        st.sidebar.error(f"Failed to build packet: {exc}")
+        st.stop()
 
-        # Validate structure (basic checks)
-        if not isinstance(draft_data, dict):
-            return None, ["Draft file is not a valid JSON object"]
+    st.session_state.packet = packet
+    st.session_state.profile_docs = profile_docs
+    st.session_state.root_profile_entity = packet.get("profile_entity")
+    source = gkc.get_spirit_safe_source()
+    st.session_state.source_root = (
+        str(source.local_root)
+        if source.mode == "local" and source.local_root is not None
+        else None
+    )
+    if packet.get("entities"):
+        st.session_state.active_entity_id = packet["entities"][0].get("id")
 
-        # Check for curation packet structure
-        if "entities" not in draft_data:
-            # Legacy format - convert to new format
-            validation_errors.append(
-                "Legacy draft format detected - creating new packet structure"
-            )
-            return None, validation_errors
-
-        # Validate each entity's schema
-        for i, entity in enumerate(draft_data.get("entities", [])):
-            result = EntityJSONValidator.validate_schema(entity)
-            if not result.is_valid:
-                error_count = len(
-                    [issue for issue in result.issues if issue.severity == "error"]
-                )
-                validation_errors.append(
-                    f"Entity {i + 1} has {error_count} schema errors"
-                )
-
-        return draft_data, validation_errors
-
-    except Exception as e:
-        return None, [f"Failed to load draft: {str(e)}"]
-
-
-# ============================================================================
-# MAIN APPLICATION
-# ============================================================================
+    root_qid = _entity_id_from_uri(packet.get("profile_entity", env_profile))
+    st.sidebar.success(f"Built uncharged packet from {root_qid}")
 
 
 def main() -> None:
-    """Main Streamlit app entry point.
-
-    Plain meaning: Run the wizard application.
-    """
-    # Page configuration
     st.set_page_config(
-        page_title="GKC Entity Wizard",
+        page_title="GKC Packet Wizard",
         page_icon="🏛️",
         layout="wide",
         initial_sidebar_state="expanded",
     )
 
-    # Initialize session state
     init_session_state()
 
-    # Configuration sidebar
     st.sidebar.title("Configuration")
 
-    # Check for environment variable from CLI
-    env_profile = os.environ.get("GKC_WIZARD_PROFILE")
-    env_qid = os.environ.get("GKC_WIZARD_QID")
+    if st.session_state.packet is None:
+        _load_packet_from_env_or_profile()
 
-    # Determine which profile to load
-    # Profile is set via CLI (GKC_WIZARD_PROFILE env var) or defaults to first available
-    if st.session_state.profile_name is None:
-        # First run: load profile from environment or default
-        if env_profile:
-            profile_to_load = env_profile
-        else:
-            st.sidebar.warning(
-                "No profile specified. Set GKC_WIZARD_PROFILE environment variable."
-            )
-            st.stop()
-
-        try:
-            profile = load_profile(profile_to_load)
-            metadata = load_profile_metadata(profile_to_load)
-            st.session_state.profile = profile
-            st.session_state.profile_name = profile_to_load
-            st.session_state.profile_metadata = metadata
-
-            # Try to load existing draft for this profile
-            draft_data, load_errors = load_most_recent_draft(
-                profile_to_load, st.session_state.draft_manager
-            )
-
-            if draft_data:
-                st.session_state.draft_data = draft_data
-                # Track the loaded draft path
-                draft_files = sorted(
-                    st.session_state.draft_manager.drafts_dir.glob(
-                        f"{('_'.join(profile_to_load.split()))}_*.json"
-                    ),
-                    reverse=True,
-                )
-                if draft_files:
-                    st.session_state.current_draft_path = draft_files[0]
-
-                if load_errors:
-                    st.sidebar.warning(f"Draft loaded with {len(load_errors)} issues")
-                else:
-                    st.sidebar.info(
-                        f"📂 Loaded draft: {draft_files[0].name if draft_files else 'N/A'}"
-                    )
-            else:
-                # No valid draft - ensure primary entity exists
-                if load_errors:
-                    for error in load_errors:
-                        st.sidebar.info(f"ℹ️ {error}")
-
-                # Create primary entity if it doesn't exist
-                get_primary_entity()
-
-        except Exception as e:
-            st.sidebar.error(f"Failed to load profile '{profile_to_load}': {e}")
-            st.stop()
-
-    # Show loaded profile
-    st.sidebar.success(f"✓ Loaded {st.session_state.profile_name}")
-
-    # Show QID input if editing existing item
-    if env_qid:
-        st.sidebar.text_input(
-            "Editing QID",
-            value=env_qid,
-            disabled=True,
-            help="Wikidata QID passed from CLI (edit mode not yet implemented)",
-        )
-
+    packet = st.session_state.packet or {}
+    st.sidebar.caption(f"Packet: {packet.get('packet_id', 'unknown')}")
+    st.sidebar.caption(
+        f"Root: {_entity_id_from_uri(packet.get('profile_entity', 'unknown'))}"
+    )
     st.sidebar.divider()
 
-    # Entity status widget (Phase 7.2)
-    render_status_widget()
-
-    # Step navigation sidebar
+    render_entity_sidebar()
     render_step_sidebar()
 
-    # Main content area
-    if st.session_state.profile is None:
-        st.warning("⚠️ No profile loaded")
-    else:
-        render_step_content()
+    render_step_content()
 
-    # Footer with draft info
     st.divider()
-    with st.expander("🔧 Debug Info", expanded=False):
-        st.write("**Current Step:**", st.session_state.current_step)
-        st.write("**Profile:**", st.session_state.profile_name)
-        st.write("**Working Directory:**", os.getcwd())
-        st.write(
-            "**Draft Path:**",
-            (
-                str(st.session_state.current_draft_path)
-                if st.session_state.current_draft_path
-                else "N/A"
-            ),
-        )
-        st.write("**GKC Entity JSON (Curation Packet):**")
-
-        import json
-
-        st.code(
-            json.dumps(st.session_state.draft_data, indent=2, ensure_ascii=False),
-            language="json",
-        )
+    with st.expander("Debug", expanded=False):
+        st.write("Current step:", st.session_state.current_step)
+        st.write("Active entity:", st.session_state.active_entity_id)
+        st.write("Draft path:", str(st.session_state.current_draft_path or "N/A"))
 
 
 if __name__ == "__main__":

--- a/gkc/profiles/forms/validation_bridge.py
+++ b/gkc/profiles/forms/validation_bridge.py
@@ -1,0 +1,374 @@
+"""Wizard validation bridge built on fermenter primitives.
+
+This module keeps UI code free from datatype-specific validation logic while still
+providing real-time and review-time ConformanceNotice rendering.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from gkc.fermenter import (
+    ConformanceNotice,
+    ValidationResult,
+    enforce_fixed_value,
+    validate_by_datatype,
+    validate_value_from_list,
+)
+
+
+def _validation_result_notices(
+    result: ValidationResult,
+    *,
+    entity_ref: str,
+    statement_ref: str,
+    code_prefix: str,
+) -> list[ConformanceNotice]:
+    notices: list[ConformanceNotice] = []
+
+    for error in result.errors:
+        notices.append(
+            ConformanceNotice(
+                severity="error",
+                entity_ref=entity_ref,
+                statement_ref=statement_ref,
+                code=f"{code_prefix}_invalid",
+                message=error,
+            )
+        )
+
+    for warning in result.warnings:
+        notices.append(
+            ConformanceNotice(
+                severity="warning",
+                entity_ref=entity_ref,
+                statement_ref=statement_ref,
+                code=f"{code_prefix}_coerced",
+                message=warning,
+                normalized_value=result.value,
+            )
+        )
+
+    return notices
+
+
+def validate_inline_value(
+    *,
+    datatype: str,
+    value: Any,
+    entity_ref: str,
+    statement_ref: str,
+) -> tuple[Any, list[ConformanceNotice]]:
+    """Run lightweight datatype validation for immediate inline feedback."""
+    if value in (None, "", {}, []):
+        return value, []
+
+    result = validate_by_datatype(datatype, value)
+    notices = _validation_result_notices(
+        result,
+        entity_ref=entity_ref,
+        statement_ref=statement_ref,
+        code_prefix="datatype",
+    )
+
+    if result.valid:
+        return result.value, notices
+    return value, notices
+
+
+def _resolve_value_list_path(
+    *,
+    statement_def: dict[str, Any],
+    packet: dict[str, Any],
+    source_root: Optional[Path],
+) -> Optional[Path]:
+    if source_root is None:
+        return None
+
+    statement_ref = statement_def.get("entity")
+    route = packet.get("value_list_routes", {}).get(statement_ref, {})
+    route_cache = route.get("cache_path") if isinstance(route, dict) else None
+
+    value_block = statement_def.get("value", {})
+    statement_cache = value_block.get("value_list_reference")
+
+    cache_path = statement_cache or route_cache
+    if not isinstance(cache_path, str) or not cache_path:
+        return None
+
+    return source_root / cache_path
+
+
+def validate_entity_packet_data(
+    *,
+    entity_slot: dict[str, Any],
+    packet: dict[str, Any],
+    source_root: Optional[Path],
+) -> list[ConformanceNotice]:
+    """Run full validation pass for one packet entity slot.
+
+    Validation policy for Wizard phase B:
+    - malformed datatype/value-list/fixed-value => error
+    - missing expected data => warning
+    """
+    notices: list[ConformanceNotice] = []
+
+    entity_ref = entity_slot.get("id") or entity_slot.get("profile_entity") or "unknown"
+    statement_defs = entity_slot.get("statements", [])
+    data = entity_slot.get("data", {})
+    data_statements = data.get("statements", {}) if isinstance(data, dict) else {}
+
+    for statement_def in statement_defs:
+        if not isinstance(statement_def, dict):
+            continue
+
+        statement_ref = statement_def.get("entity")
+        if not isinstance(statement_ref, str) or not statement_ref:
+            continue
+
+        value_block = statement_def.get("value", {})
+        datatype = value_block.get("type", "string")
+        if datatype == "globe-coordinate":
+            datatype = "globe-coordinate"
+
+        configured_values = data_statements.get(statement_ref, [])
+        if not isinstance(configured_values, list):
+            notices.append(
+                ConformanceNotice(
+                    severity="error",
+                    entity_ref=entity_ref,
+                    statement_ref=statement_ref,
+                    code="statement_shape_invalid",
+                    message="Statement values must be a list in packet entity data.",
+                )
+            )
+            continue
+
+        if len(configured_values) == 0:
+            notices.append(
+                ConformanceNotice(
+                    severity="warning",
+                    entity_ref=entity_ref,
+                    statement_ref=statement_ref,
+                    code="statement_missing",
+                    message="No values entered for this expected statement.",
+                )
+            )
+            continue
+
+        max_count = statement_def.get("max_count")
+        if isinstance(max_count, int) and len(configured_values) > max_count:
+            notices.append(
+                ConformanceNotice(
+                    severity="error",
+                    entity_ref=entity_ref,
+                    statement_ref=statement_ref,
+                    code="max_count_exceeded",
+                    message=(
+                        f"Statement has {len(configured_values)} values, "
+                        f"but max_count is {max_count}."
+                    ),
+                )
+            )
+
+        fixed_flag = bool(statement_def.get("fixed"))
+        fixed_value = None
+        value_list = value_block.get("value_list")
+        if fixed_flag and isinstance(value_list, list) and value_list:
+            first = value_list[0]
+            if isinstance(first, dict):
+                fixed_value = first.get("item") or first.get("id")
+            else:
+                fixed_value = first
+
+        value_list_path = _resolve_value_list_path(
+            statement_def=statement_def,
+            packet=packet,
+            source_root=source_root,
+        )
+
+        qualifier_defs = {
+            q.get("entity"): q
+            for q in statement_def.get("qualifiers", [])
+            if isinstance(q, dict) and isinstance(q.get("entity"), str)
+        }
+
+        reference_defs = {
+            r.get("entity"): r
+            for r in statement_def.get("references", [])
+            if isinstance(r, dict) and isinstance(r.get("entity"), str)
+        }
+
+        for idx, statement_value in enumerate(configured_values):
+            if not isinstance(statement_value, dict):
+                notices.append(
+                    ConformanceNotice(
+                        severity="error",
+                        entity_ref=entity_ref,
+                        statement_ref=statement_ref,
+                        code="statement_entry_invalid",
+                        message=f"Value entry {idx + 1} must be an object.",
+                    )
+                )
+                continue
+
+            candidate = statement_value.get("value")
+
+            if fixed_flag and fixed_value is not None:
+                fixed_result, fixed_notice = enforce_fixed_value(
+                    candidate,
+                    fixed_value,
+                    statement_ref,
+                )
+                if fixed_notice is not None:
+                    fixed_notice.entity_ref = entity_ref
+                    notices.append(fixed_notice)
+                if fixed_result.valid:
+                    candidate = fixed_result.value
+                    statement_value["value"] = fixed_result.value
+
+            datatype_result = validate_by_datatype(datatype, candidate)
+            notices.extend(
+                _validation_result_notices(
+                    datatype_result,
+                    entity_ref=entity_ref,
+                    statement_ref=statement_ref,
+                    code_prefix="datatype",
+                )
+            )
+
+            if datatype_result.valid:
+                statement_value["value"] = datatype_result.value
+
+            if value_list_path is not None and datatype_result.valid:
+                list_result = validate_value_from_list(candidate, value_list_path)
+                notices.extend(
+                    _validation_result_notices(
+                        list_result,
+                        entity_ref=entity_ref,
+                        statement_ref=statement_ref,
+                        code_prefix="value_list",
+                    )
+                )
+
+            qualifiers = statement_value.get("qualifiers", {})
+            if not isinstance(qualifiers, dict):
+                notices.append(
+                    ConformanceNotice(
+                        severity="error",
+                        entity_ref=entity_ref,
+                        statement_ref=statement_ref,
+                        code="qualifiers_shape_invalid",
+                        message="Qualifiers must be stored as a mapping.",
+                    )
+                )
+                qualifiers = {}
+
+            for qualifier_ref, qualifier_def in qualifier_defs.items():
+                q_datatype = qualifier_def.get("value", {}).get("type", "string")
+                q_value = qualifiers.get(qualifier_ref)
+                if q_value in (None, "", {}, []):
+                    notices.append(
+                        ConformanceNotice(
+                            severity="warning",
+                            entity_ref=entity_ref,
+                            statement_ref=statement_ref,
+                            code="qualifier_missing",
+                            message=(
+                                "Expected qualifier is missing from this statement value "
+                                f"({qualifier_def.get('label', qualifier_ref)})."
+                            ),
+                        )
+                    )
+                    continue
+
+                q_result = validate_by_datatype(q_datatype, q_value)
+                notices.extend(
+                    _validation_result_notices(
+                        q_result,
+                        entity_ref=entity_ref,
+                        statement_ref=str(qualifier_ref),
+                        code_prefix="qualifier",
+                    )
+                )
+                if q_result.valid:
+                    qualifiers[qualifier_ref] = q_result.value
+
+            references = statement_value.get("references", [])
+            if not isinstance(references, list):
+                notices.append(
+                    ConformanceNotice(
+                        severity="error",
+                        entity_ref=entity_ref,
+                        statement_ref=statement_ref,
+                        code="references_shape_invalid",
+                        message="References must be stored as a list.",
+                    )
+                )
+                references = []
+
+            present_reference_props = set()
+            for ref_entry in references:
+                if not isinstance(ref_entry, dict):
+                    continue
+                ref_prop = ref_entry.get("property")
+                ref_value = ref_entry.get("value")
+                if not isinstance(ref_prop, str):
+                    continue
+                present_reference_props.add(ref_prop)
+
+                ref_def = reference_defs.get(ref_prop)
+                if not ref_def:
+                    notices.append(
+                        ConformanceNotice(
+                            severity="warning",
+                            entity_ref=entity_ref,
+                            statement_ref=statement_ref,
+                            code="reference_unexpected",
+                            message=f"Reference {ref_prop} is not defined in profile statement.",
+                        )
+                    )
+                    continue
+
+                r_datatype = ref_def.get("value", {}).get("type", "string")
+                if ref_value in (None, "", {}, []):
+                    notices.append(
+                        ConformanceNotice(
+                            severity="warning",
+                            entity_ref=entity_ref,
+                            statement_ref=ref_prop,
+                            code="reference_missing_value",
+                            message="Reference entry exists but has no value.",
+                        )
+                    )
+                    continue
+
+                r_result = validate_by_datatype(r_datatype, ref_value)
+                notices.extend(
+                    _validation_result_notices(
+                        r_result,
+                        entity_ref=entity_ref,
+                        statement_ref=str(ref_prop),
+                        code_prefix="reference",
+                    )
+                )
+                if r_result.valid:
+                    ref_entry["value"] = r_result.value
+
+            for ref_prop, ref_def in reference_defs.items():
+                if ref_prop not in present_reference_props:
+                    notices.append(
+                        ConformanceNotice(
+                            severity="warning",
+                            entity_ref=entity_ref,
+                            statement_ref=statement_ref,
+                            code="reference_missing",
+                            message=(
+                                "Expected reference not provided "
+                                f"({ref_def.get('label', ref_prop)})."
+                            ),
+                        )
+                    )
+
+    return notices

--- a/gkc/profiles/forms/wizard/steps.py
+++ b/gkc/profiles/forms/wizard/steps.py
@@ -1,7 +1,4 @@
-"""Concrete step implementations for the wizard.
-
-Plain meaning: The actual form content for each step.
-"""
+"""Packet-native step implementations for the Streamlit wizard."""
 
 from __future__ import annotations
 
@@ -9,816 +6,483 @@ from typing import Any
 
 import streamlit as st
 
+from gkc.profiles.forms.validation_bridge import validate_inline_value
 from gkc.profiles.forms.widgets import WidgetFactory
 from gkc.profiles.forms.wizard.step_base import Step
 
-# ============================================================================
-# HELPER FUNCTIONS
-# ============================================================================
+
+def _active_profile_doc() -> dict[str, Any] | None:
+    packet = st.session_state.get("packet", {})
+    profile_docs = st.session_state.get("profile_docs", {})
+    active_entity_id = st.session_state.get("active_entity_id")
+
+    for entity_slot in packet.get("entities", []):
+        if entity_slot.get("id") == active_entity_id:
+            return profile_docs.get(entity_slot.get("profile_entity"))
+    return None
 
 
-def get_profile_languages(profile) -> list[str]:
-    """Extract all languages defined in the profile's identification sections.
-
-    Args:
-        profile: The loaded EntityProfile.
-
-    Returns:
-        Sorted list of unique language codes found across labels, descriptions, aliases.
-
-    Plain meaning: Figure out which languages this profile supports.
-    """
-    languages = set()
-
-    # Scan labels section
-    if hasattr(profile, "labels") and isinstance(profile.labels, dict):
-        languages.update(profile.labels.keys())
-
-    # Scan descriptions section
-    if hasattr(profile, "descriptions") and isinstance(profile.descriptions, dict):
-        languages.update(profile.descriptions.keys())
-
-    # Scan aliases section
-    if hasattr(profile, "aliases") and isinstance(profile.aliases, dict):
-        languages.update(profile.aliases.keys())
-
-    return sorted(languages)
+def _active_entity_slot() -> dict[str, Any] | None:
+    packet = st.session_state.get("packet", {})
+    active_entity_id = st.session_state.get("active_entity_id")
+    for entity_slot in packet.get("entities", []):
+        if entity_slot.get("id") == active_entity_id:
+            return entity_slot
+    return None
 
 
-def _as_language_map(section: Any) -> dict[str, Any]:
-    """Normalize a metadata section into a language->definition mapping."""
-    if isinstance(section, dict):
-        return section
-    languages = getattr(section, "languages", None)
-    if isinstance(languages, dict):
-        return languages
-    return {}
+def _metadata_text(messages: dict[str, Any], key: str) -> str:
+    if not isinstance(messages, dict):
+        return ""
+    for lang in ("mul", "en", "es"):
+        lang_map = messages.get(lang)
+        if isinstance(lang_map, dict) and isinstance(lang_map.get(key), str):
+            return lang_map[key]
+    return ""
 
 
-def _clean_empty_aliases(id_data: dict[str, Any]) -> dict[str, Any]:
-    """Remove empty strings from alias lists in identification data.
-
-    Used when exporting or serializing data for external systems.
-    Aliases are kept as-is during editing to allow user input to persist.
-
-    Args:
-        id_data: Identification data dict with 'aliases' key
-
-    Returns:
-        Copy of id_data with empty aliases filtered out
-    """
-    cleaned = dict(id_data)
-    if "aliases" in cleaned:
-        cleaned["aliases"] = {
-            lang: [a.strip() for a in aliases if a.strip()]
-            for lang, aliases in cleaned["aliases"].items()
-        }
-    return cleaned
+def _identification_map(profile_doc: dict[str, Any], section: str) -> dict[str, Any]:
+    identification = profile_doc.get("identification", {})
+    section_map = identification.get(section, {})
+    return section_map if isinstance(section_map, dict) else {}
 
 
-# ============================================================================
-# STEP IMPLEMENTATIONS
-# ============================================================================
+def _profile_name(profile_doc: dict[str, Any]) -> str:
+    metadata = profile_doc.get("metadata", {})
+    labels = metadata.get("labels", {}) if isinstance(metadata, dict) else {}
+    return labels.get("mul") or labels.get("en") or "Profile"
+
+
+def _statement_key(statement_def: dict[str, Any]) -> str:
+    return statement_def.get("entity", "")
+
+
+def _statement_prompt(statement_def: dict[str, Any]) -> str:
+    return _metadata_text(statement_def.get("messages", {}), "prompt")
+
+
+def _statement_guidance(statement_def: dict[str, Any]) -> str:
+    return _metadata_text(statement_def.get("messages", {}), "guidance")
+
+
+def _statement_consequence(statement_def: dict[str, Any]) -> str:
+    return _metadata_text(statement_def.get("messages", {}), "consequences_message")
+
+
+def _statement_label(statement_def: dict[str, Any]) -> str:
+    return statement_def.get("label") or _statement_key(statement_def).split("/")[-1]
+
+
+def _is_fixed(statement_def: dict[str, Any]) -> bool:
+    if statement_def.get("fixed") is True:
+        return True
+    value_block = statement_def.get("value", {})
+    return (
+        isinstance(value_block.get("value_list"), list)
+        and len(value_block["value_list"]) > 0
+    )
+
+
+def _initial_fixed_value(statement_def: dict[str, Any]) -> Any:
+    value_block = statement_def.get("value", {})
+    value_list = value_block.get("value_list")
+    if isinstance(value_list, list) and value_list:
+        first = value_list[0]
+        if isinstance(first, dict):
+            return first.get("item") or first.get("id") or first.get("itemLabel")
+        return first
+    return None
+
+
+def _value_datatype(value_block: dict[str, Any]) -> str:
+    dtype = value_block.get("type", "string")
+    if dtype == "globe-coordinate":
+        return "globecoordinate"
+    return dtype
 
 
 class IdentificationStep(Step):
-    """Collect labels, descriptions, and aliases for the entity.
-
-    Plain meaning: The "who/what is this?" step.
-    """
+    """Collect labels, descriptions, and aliases from profile identification metadata."""
 
     def render(self, draft_data: dict[str, Any]) -> dict[str, Any]:
-        """Render labels, descriptions, and aliases by language.
-
-        Args:
-            draft_data: GKC Entity JSON object (not flat structure).
-
-        Returns:
-            The same entity object (modified in-place).
-        """
         st.header("🏷️ Identification")
 
-        # Get the profile from session state (set in streamlit_app.py)
-        if "profile" not in st.session_state or st.session_state.profile is None:
-            st.error("No profile loaded")
+        profile_doc = _active_profile_doc()
+        if not profile_doc:
+            st.error("No profile document loaded for active entity")
             return draft_data
 
-        profile = st.session_state.profile
+        st.write(f"**{_profile_name(profile_doc)}**")
 
-        # Show profile name and description
-        st.write(f"**{profile.name}** — {profile.description}")
+        draft_data.setdefault("labels", {})
+        draft_data.setdefault("descriptions", {})
+        draft_data.setdefault("aliases", {})
 
-        # Initialize multilingual fields if not present (entity schema uses top-level keys)
-        if "labels" not in draft_data:
-            draft_data["labels"] = {}
-        if "descriptions" not in draft_data:
-            draft_data["descriptions"] = {}
-        if "aliases" not in draft_data:
-            draft_data["aliases"] = {}
+        labels_map = _identification_map(profile_doc, "labels")
+        descriptions_map = _identification_map(profile_doc, "descriptions")
+        aliases_map = _identification_map(profile_doc, "aliases")
 
-        # Determine which languages are defined in the profile
-        supported_languages = get_profile_languages(profile)
-
-        if not supported_languages:
-            st.warning("Profile has no language configuration")
+        languages = sorted(set(labels_map) | set(descriptions_map) | set(aliases_map))
+        if not languages:
+            st.info("No identification metadata configured in profile.")
             return draft_data
 
-        # Get language maps for each section
-        labels_map = _as_language_map(getattr(profile, "labels", {}))
-        descriptions_map = _as_language_map(getattr(profile, "descriptions", {}))
-        aliases_map = _as_language_map(getattr(profile, "aliases", {}))
-
-        # If multiple languages, use tabs; otherwise render directly
-        if len(supported_languages) > 1:
-            tabs = st.tabs([lang.upper() for lang in supported_languages])
-            for i, lang in enumerate(supported_languages):
-                with tabs[i]:
-                    self._render_language_section(
+        if len(languages) > 1:
+            tabs = st.tabs([lang.upper() for lang in languages])
+            for idx, lang in enumerate(languages):
+                with tabs[idx]:
+                    self._render_language(
                         lang, labels_map, descriptions_map, aliases_map, draft_data
                     )
         else:
-            # Single language - no tabs needed
-            lang = supported_languages[0]
-            self._render_language_section(
-                lang, labels_map, descriptions_map, aliases_map, draft_data
+            self._render_language(
+                languages[0], labels_map, descriptions_map, aliases_map, draft_data
             )
 
         return draft_data
 
-    def _render_language_section(
+    def _render_language(
         self,
         lang: str,
         labels_map: dict[str, Any],
         descriptions_map: dict[str, Any],
         aliases_map: dict[str, Any],
-        entity_data: dict[str, Any],
+        draft_data: dict[str, Any],
     ) -> None:
-        """Render label, description, and alias fields for a single language.
-
-        Args:
-            lang: Language code (e.g., "en", "chr")
-            labels_map: Profile labels metadata
-            descriptions_map: Profile descriptions metadata
-            aliases_map: Profile aliases metadata
-            entity_data: GKC Entity JSON object (modified in-place)
-
-        Plain meaning: Show the input fields for one language's worth of metadata.
-        """
-        # ---- LABEL ----
-        label_meta = labels_map.get(lang)
-        if label_meta:
-            field_label = getattr(label_meta, "label", "Label")
-            input_prompt = getattr(label_meta, "input_prompt", "")
-            guidance = getattr(label_meta, "guidance", "")
-
-            st.write(f"**{field_label}**")
-            if input_prompt:
-                st.caption(input_prompt)
-
-            current_value = entity_data["labels"].get(lang, "")
-            label_value = st.text_input(
-                "Label",
-                value=current_value,
+        label_meta = labels_map.get(lang, {})
+        if isinstance(label_meta, dict):
+            st.write("**Label**")
+            if label_meta.get("prompt"):
+                st.caption(label_meta["prompt"])
+            draft_data["labels"][lang] = st.text_input(
+                f"label-{lang}",
+                value=draft_data["labels"].get(lang, ""),
                 key=f"label_{lang}",
-                help=guidance if guidance else None,
+                help=label_meta.get("guidance"),
                 label_visibility="collapsed",
             )
-            entity_data["labels"][lang] = label_value
 
-        # ---- DESCRIPTION ----
-        desc_meta = descriptions_map.get(lang)
-        if desc_meta:
-            field_label = getattr(desc_meta, "label", "Description")
-            input_prompt = getattr(desc_meta, "input_prompt", "")
-            guidance = getattr(desc_meta, "guidance", "")
-
-            st.write(f"**{field_label}**")
-            if input_prompt:
-                st.caption(input_prompt)
-
-            current_value = entity_data["descriptions"].get(lang, "")
-            desc_value = st.text_area(
-                "Description",
-                value=current_value,
-                height=80,
+        desc_meta = descriptions_map.get(lang, {})
+        if isinstance(desc_meta, dict):
+            st.write("**Description**")
+            if desc_meta.get("prompt"):
+                st.caption(desc_meta["prompt"])
+            draft_data["descriptions"][lang] = st.text_area(
+                f"description-{lang}",
+                value=draft_data["descriptions"].get(lang, ""),
                 key=f"description_{lang}",
-                help=guidance if guidance else None,
+                help=desc_meta.get("guidance"),
+                height=80,
                 label_visibility="collapsed",
             )
-            entity_data["descriptions"][lang] = desc_value
 
-        # ---- ALIASES ----
-        alias_meta = aliases_map.get(lang)
-        if alias_meta:
-            field_label = getattr(alias_meta, "label", "Aliases")
-            input_prompt = getattr(alias_meta, "input_prompt", "")
-            guidance = getattr(alias_meta, "guidance", "")
-
+        alias_meta = aliases_map.get(lang, {})
+        if isinstance(alias_meta, dict):
             st.divider()
-            st.write(f"**{field_label}**")
-            if input_prompt:
-                st.caption(input_prompt)
+            st.write("**Aliases**")
+            if alias_meta.get("prompt"):
+                st.caption(alias_meta["prompt"])
 
-            # Initialize aliases list if needed
-            if lang not in entity_data["aliases"]:
-                entity_data["aliases"][lang] = []
-
-            current_aliases = entity_data["aliases"][lang]
-
-            # Render alias input fields with delete buttons
-            # Collect updates and save them (including empty ones for in-progress editing)
-            updated_aliases = []
-            for idx, alias in enumerate(current_aliases):
-                col1, col2 = st.columns([5, 1])
-                with col1:
+            draft_data["aliases"].setdefault(lang, [])
+            aliases = draft_data["aliases"][lang]
+            updated = []
+            for idx, alias in enumerate(aliases):
+                c1, c2 = st.columns([5, 1])
+                with c1:
                     updated_alias = st.text_input(
-                        "Alias",
+                        f"alias-{lang}-{idx}",
                         value=alias,
                         key=f"alias_{lang}_{idx}",
-                        help=guidance if guidance and idx == 0 else None,
+                        help=alias_meta.get("guidance") if idx == 0 else None,
                         label_visibility="collapsed",
                     )
-                    updated_aliases.append(updated_alias)
-                with col2:
+                    updated.append(updated_alias)
+                with c2:
                     if st.button("🗑️", key=f"delete_alias_{lang}_{idx}"):
-                        entity_data["aliases"][lang].pop(idx)
+                        aliases.pop(idx)
                         st.rerun()
 
-            # Save ALL values to state (keep empty ones during editing, will be filtered at validation/save)
-            entity_data["aliases"][lang] = updated_aliases
+            draft_data["aliases"][lang] = updated
 
-            # "Add" button
             if st.button("➕ Add", key=f"add_alias_{lang}"):
-                entity_data["aliases"][lang].append("")
+                draft_data["aliases"][lang].append("")
                 st.rerun()
 
     def validate(self, draft_data: dict[str, Any]) -> dict[str, list[str]]:
-        """Validate identification data.
-
-        Args:
-            draft_data: GKC Entity JSON object.
-
-        Returns warnings if:
-        - Required labels are missing
-        - Required descriptions are missing
-        """
-        warnings = {}
-
+        warnings: dict[str, list[str]] = {}
         labels = draft_data.get("labels", {})
-        descriptions = draft_data.get("descriptions", {})
-
-        # Get profile and language configuration
-        if "profile" not in st.session_state or st.session_state.profile is None:
-            return warnings
-
-        profile = st.session_state.profile
-        supported_languages = get_profile_languages(profile)
-
-        if not supported_languages:
-            return warnings
-
-        # Get metadata maps
-        labels_map = _as_language_map(getattr(profile, "labels", {}))
-        descriptions_map = _as_language_map(getattr(profile, "descriptions", {}))
-
-        # Check for required labels
-        missing_required_labels = []
-        for lang in supported_languages:
-            meta = labels_map.get(lang)
-            if meta and getattr(meta, "required", False):
-                if not labels.get(lang, "").strip():
-                    missing_required_labels.append(lang)
-
-        if missing_required_labels:
-            warnings["labels"] = [
-                f"Missing **required** labels for: {', '.join(missing_required_labels)}"
-            ]
-
-        # Check for required descriptions
-        missing_required_descriptions = []
-        for lang in supported_languages:
-            meta = descriptions_map.get(lang)
-            if meta and getattr(meta, "required", False):
-                if not descriptions.get(lang, "").strip():
-                    missing_required_descriptions.append(lang)
-
-        if missing_required_descriptions:
-            warnings["descriptions"] = [
-                f"Missing **required** descriptions for: {', '.join(missing_required_descriptions)}"
-            ]
-
+        if not any(v.strip() for v in labels.values() if isinstance(v, str)):
+            warnings["labels"] = ["No labels entered yet."]
         return warnings
 
 
 class SitelinksStep(Step):
-    """Collect Wikipedia/Wikimedia sitelinks.
-
-    Plain meaning: The "where is this on Wikipedia?" step.
-    """
+    """Collect sitelinks as optional freeform site-code/title pairs."""
 
     def render(self, draft_data: dict[str, Any]) -> dict[str, Any]:
-        """Render sitelinks selector and title entry.
-
-        Args:
-            draft_data: GKC Entity JSON object.
-
-        Returns:
-            The same entity object (modified in-place).
-        """
         st.header("🔗 Sitelinks")
+        st.caption("Sitelinks are optional in the baseline packet wizard.")
 
-        if "profile" not in st.session_state or st.session_state.profile is None:
-            st.error("No profile loaded")
-            return draft_data
+        draft_data.setdefault("sitelinks", {})
 
-        profile = st.session_state.profile
+        if "sitelink_rows" not in st.session_state:
+            st.session_state.sitelink_rows = max(1, len(draft_data["sitelinks"]))
 
-        # Show profile name and description
-        st.write(f"**{profile.name}** — {profile.description}")
+        for idx in range(st.session_state.sitelink_rows):
+            c1, c2 = st.columns([2, 3])
+            default_site = ""
+            default_title = ""
+            if idx < len(draft_data["sitelinks"]):
+                site_code = list(draft_data["sitelinks"].keys())[idx]
+                default_site = site_code
+                default_title = draft_data["sitelinks"][site_code]
 
-        # Initialize sitelinks field if not present
-        if "sitelinks" not in draft_data:
-            draft_data["sitelinks"] = {}
+            with c1:
+                site = st.text_input(
+                    f"Site code {idx + 1}",
+                    value=default_site,
+                    key=f"sitelink_site_{idx}",
+                    placeholder="enwiki",
+                )
+            with c2:
+                title = st.text_input(
+                    f"Page title {idx + 1}",
+                    value=default_title,
+                    key=f"sitelink_title_{idx}",
+                )
 
-        # Get sitelinks configuration from profile
-        if not hasattr(profile, "sitelinks") or not profile.sitelinks:
-            st.warning("Profile has no sitelinks configuration")
-            return draft_data
+        draft_data["sitelinks"] = {}
+        for idx in range(st.session_state.sitelink_rows):
+            site = st.session_state.get(f"sitelink_site_{idx}", "").strip()
+            title = st.session_state.get(f"sitelink_title_{idx}", "").strip()
+            if site and title:
+                draft_data["sitelinks"][site] = title
 
-        # Get top-level guidance if present
-        sitelinks_guidance = getattr(profile.sitelinks, "guidance", "")
-        if sitelinks_guidance:
-            st.info(sitelinks_guidance)
-
-        # Get available languages from profile.sitelinks.languages
-        available_langs = _as_language_map(profile.sitelinks)
-
-        if not available_langs:
-            st.warning("No sitelinks languages configured in profile")
-            return draft_data
-
-        # Determine which languages are currently configured
-        current_site_codes = list(draft_data["sitelinks"].keys())
-        current_langs = [
-            code.replace("wiki", "")
-            for code in current_site_codes
-            if code.endswith("wiki")
-        ]
-
-        # Language selector
-        st.subheader("Select Languages")
-        selected_langs = st.multiselect(
-            "Which language editions should have articles/links?",
-            options=list(available_langs.keys()),
-            default=current_langs,
-            help="Select languages where this entity has Wikipedia articles or other wiki links",
-        )
-
-        # Title entry for selected languages
-        if selected_langs:
-            st.subheader("Article Titles")
-
-            for lang in selected_langs:
-                lang_meta = available_langs.get(lang)
-                site_code = f"{lang}wiki"  # e.g., "enwiki", "chrwiki"
-
-                if lang_meta:
-                    field_label = getattr(
-                        lang_meta, "description", f"{lang.upper()} article title"
-                    )
-                    input_prompt = getattr(lang_meta, "input_prompt", "")
-                    guidance = getattr(lang_meta, "guidance", "")
-
-                    if input_prompt:
-                        st.write(input_prompt)
-
-                    current_title = draft_data["sitelinks"].get(site_code, "")
-                    title = st.text_input(
-                        field_label,
-                        value=current_title,
-                        key=f"sitelink_{lang}",
-                        help=guidance if guidance else None,
-                    )
-
-                    # Store in entity sitelinks using standard Wikidata format
-                    if title.strip():
-                        draft_data["sitelinks"][site_code] = title
-                    elif site_code in draft_data["sitelinks"]:
-                        # Remove if emptied
-                        del draft_data["sitelinks"][site_code]
-
-        # Remove sitelinks for languages that were deselected
-        for site_code in list(draft_data["sitelinks"].keys()):
-            lang_code = site_code.replace("wiki", "")
-            if lang_code not in selected_langs:
-                del draft_data["sitelinks"][site_code]
+        if st.button("➕ Add sitelink", key="add_sitelink_row"):
+            st.session_state.sitelink_rows += 1
+            st.rerun()
 
         return draft_data
 
     def validate(self, draft_data: dict[str, Any]) -> dict[str, list[str]]:
-        """Validate sitelinks data.
-
-        Args:
-            draft_data: GKC Entity JSON object.
-
-        Returns:
-            Dictionary of validation warnings.
-        """
-        warnings = {}
-
-        sitelinks_data = draft_data.get("sitelinks", {})
-
-        # Warn if no sitelinks provided (may be acceptable for some entities)
-        if not sitelinks_data:
-            warnings["sitelinks"] = ["No sitelinks provided"]
-
-        return warnings
+        return {}
 
 
 class StatementsStep(Step):
-    """Collect structured statements about the entity.
-
-    Plain meaning: The "what do we know about this thing?" step.
-
-    Handles complex statement rendering with qualifiers and references.
-    """
+    """Collect statement values from packet statement scaffolds."""
 
     def render(self, draft_data: dict[str, Any]) -> dict[str, Any]:
-        """Render statements collection interface."""
         st.header("📊 Statements")
 
-        if "profile" not in st.session_state or st.session_state.profile is None:
-            st.error("No profile loaded")
+        entity_slot = _active_entity_slot()
+        if not entity_slot:
+            st.error("No active entity slot loaded")
             return draft_data
 
-        profile = st.session_state.profile
+        profile_doc = _active_profile_doc()
+        if profile_doc:
+            st.write(f"**{_profile_name(profile_doc)}**")
 
-        # Show profile name and description
-        st.write(f"**{profile.name}** — {profile.description}")
-
-        # Initialize statements section
-        if "statements" not in draft_data:
-            draft_data["statements"] = {}
-
-        # Check if profile has statements
-        if not hasattr(profile, "statements") or not profile.statements:
-            st.warning("Profile has no statements configuration")
+        draft_data.setdefault("statements", {})
+        statement_defs = entity_slot.get("statements", [])
+        if not statement_defs:
+            st.info("No statement scaffolds found on active entity slot.")
             return draft_data
 
-        # Group statements (for MVP, just show as tabs)
-        statement_ids = [stmt.id for stmt in profile.statements]
-
-        if not statement_ids:
-            st.info("No statements configured in this profile")
-            return draft_data
-
-        # For MVP: Show all statements in one screen with expanders for each
-        st.write("Add structured data about this entity:")
-
-        for statement_def in profile.statements:
+        for statement_def in statement_defs:
+            if not isinstance(statement_def, dict):
+                continue
             self._render_statement(statement_def, draft_data)
 
         return draft_data
 
-    def _render_statement(self, statement_def: Any, draft_data: dict[str, Any]) -> None:
-        """Render a single statement property.
-
-        Args:
-            statement_def: Statement definition from profile
-            draft_data: Current draft data being edited
-        """
-        stmt_id = statement_def.id
-
-        # Initialize statement data if needed
-        if stmt_id not in draft_data["statements"]:
-            draft_data["statements"][stmt_id] = []
-
-        # Get current values for this statement
-        current_values = draft_data["statements"][stmt_id]
-
-        # Check if this statement should be auto-expanded
-        # Expand if: (1) coming from Plan screen, (2) after Add/Delete, or (3) has values entered
-        auto_expand = (
-            (
-                hasattr(st.session_state, "expand_statement")
-                and st.session_state.expand_statement == stmt_id
-            )
-            or (
-                hasattr(st.session_state, "keep_expanded")
-                and st.session_state.keep_expanded == stmt_id
-            )
-            or (len(current_values) > 0)  # Keep open if user is working on it
-        )
-
-        # Clear the flags after using them
-        if hasattr(st.session_state, "expand_statement"):
-            st.session_state.expand_statement = None
-        if hasattr(st.session_state, "keep_expanded"):
-            st.session_state.keep_expanded = None
-
-        # Create expander for this statement (removed PID from title)
-        with st.expander(f"**{statement_def.label}**", expanded=auto_expand):
-            # Show input prompt/guidance if present
-            if hasattr(statement_def, "input_prompt") and statement_def.input_prompt:
-                st.caption(statement_def.input_prompt)
-
-            if hasattr(statement_def, "guidance") and statement_def.guidance:
-                with st.popover("ℹ️ Help"):
-                    st.write(statement_def.guidance)
-
-            # Check for form_policy
-            form_policy = getattr(statement_def, "form_policy", None)
-            entity_profile = getattr(statement_def, "entity_profile", None)
-
-            if form_policy == "target_only" and entity_profile:
-                st.info(
-                    f"🔗 This property references items from the **{entity_profile}** profile. "
-                    f"For MVP, enter the QID directly. Sub-wizard creation coming soon."
-                )
-
-            # Check behavior (fixed value vs editable)
-            behavior = getattr(statement_def, "behavior", None)
-            value_behavior = (
-                getattr(behavior, "value", "editable") if behavior else "editable"
-            )
-
-            if value_behavior == "fixed":
-                # Show fixed value read-only
-                self._render_fixed_value(statement_def)
-            else:
-                # Show editable values
-                self._render_editable_values(statement_def, current_values, draft_data)
-
-            # Show add button if not at max count
-            max_count = getattr(statement_def, "max_count", None)
-            can_add_more = max_count is None or len(current_values) < max_count
-
-            if can_add_more and value_behavior != "fixed":
-                if st.button(f"➕ Add {statement_def.label}", key=f"add_{stmt_id}"):
-                    # Add empty statement to trigger form display
-                    current_values.append(self._create_empty_statement(statement_def))
-                    # Keep this expander open after rerun
-                    st.session_state.keep_expanded = stmt_id
-                    st.rerun()
-
-    def _render_fixed_value(self, statement_def: Any) -> None:
-        """Render a fixed value statement (read-only).
-
-        Args:
-            statement_def: Statement definition from profile
-        """
-        # Get fixed value from definition
-        value_config = getattr(statement_def, "value", None)
-        fixed_value = getattr(value_config, "fixed", None) if value_config else None
-        if fixed_value is not None:
-            fixed_label = getattr(value_config, "label", fixed_value)
-
-            st.markdown(f"**Value (fixed):** {fixed_label} `({fixed_value})`")
-            st.caption("This value is fixed by the profile and cannot be changed.")
-
-            # Still show references section (editable for fixed values)
-            st.write("---")
-            st.write("**References**")
-            st.caption("Add source references for this statement:")
-            st.info("References rendering coming in next update")
-        else:
-            st.warning("Fixed value configured but no value specified in profile")
-
-    def _render_editable_values(
-        self, statement_def: Any, current_values: list, draft_data: dict[str, Any]
+    def _render_statement(
+        self, statement_def: dict[str, Any], draft_data: dict[str, Any]
     ) -> None:
-        """Render editable value inputs for a statement.
+        stmt_key = _statement_key(statement_def)
+        stmt_label = _statement_label(statement_def)
 
-        Args:
-            statement_def: Statement definition from profile
-            current_values: List of current statement values
-            draft_data: Current draft data
-        """
-        stmt_id = statement_def.id
+        draft_data["statements"].setdefault(stmt_key, [])
+        current_values = draft_data["statements"][stmt_key]
 
-        if not current_values:
-            st.caption("_No values added yet. Click 'Add' below to create one._")
-            return
+        if _is_fixed(statement_def) and not current_values:
+            current_values.append(
+                {
+                    "value": _initial_fixed_value(statement_def),
+                    "qualifiers": {},
+                    "references": [],
+                }
+            )
 
-        # Render each value
-        for idx, value_data in enumerate(current_values):
-            with st.container(border=True):
-                col1, col2 = st.columns([5, 1])
+        auto_expand = (
+            st.session_state.get("expand_statement") == stmt_key
+            or len(current_values) > 0
+        )
+        if st.session_state.get("expand_statement") == stmt_key:
+            st.session_state.expand_statement = None
 
-                with col1:
-                    st.markdown(f"**Value {idx + 1}**")
+        with st.expander(f"**{stmt_label}**", expanded=auto_expand):
+            prompt = _statement_prompt(statement_def)
+            if prompt:
+                st.caption(prompt)
 
-                with col2:
-                    if st.button(
-                        "🗑️", key=f"delete_{stmt_id}_{idx}", help="Delete this value"
-                    ):
-                        current_values.pop(idx)
-                        # Keep this expander open after rerun
-                        st.session_state.keep_expanded = stmt_id
-                        st.rerun()
+            guidance = _statement_guidance(statement_def)
+            if guidance:
+                with st.popover("ℹ️ Guidance"):
+                    st.write(guidance)
 
-                # Render main value
-                self._render_value_input(statement_def, value_data, idx)
+            is_fixed = _is_fixed(statement_def)
+            if is_fixed:
+                st.caption("This value is fixed for this profile.")
 
-                # Render qualifiers if defined
-                if hasattr(statement_def, "qualifiers") and statement_def.qualifiers:
-                    st.write("**Qualifiers**")
+            for idx, value_data in enumerate(current_values):
+                with st.container(border=True):
+                    c1, c2 = st.columns([5, 1])
+                    with c1:
+                        st.markdown(f"**Value {idx + 1}**")
+                    with c2:
+                        if not is_fixed and st.button(
+                            "🗑️", key=f"delete_{stmt_key}_{idx}"
+                        ):
+                            current_values.pop(idx)
+                            st.rerun()
+
+                    self._render_value_input(statement_def, value_data, idx, is_fixed)
                     self._render_qualifiers(statement_def, value_data, idx)
-
-                # Render references if defined
-                if hasattr(statement_def, "references") and statement_def.references:
-                    st.write("**References**")
                     self._render_references(statement_def, value_data, idx)
 
-    def _render_value_input(
-        self, statement_def: Any, value_data: dict, idx: int
-    ) -> None:
-        """Render the main value input widget.
+            max_count = statement_def.get("max_count")
+            can_add_more = (max_count is None) or (len(current_values) < max_count)
+            if not is_fixed and can_add_more:
+                if st.button(f"➕ Add {stmt_label}", key=f"add_stmt_{stmt_key}"):
+                    current_values.append(
+                        {"value": None, "qualifiers": {}, "references": []}
+                    )
+                    st.rerun()
 
-        Args:
-            statement_def: Statement definition from profile
-            value_data: Current value data
-            idx: Index of this value in the list
-        """
-        value_config = getattr(statement_def, "value", None)
-        if not value_config:
-            st.warning("No value configuration in statement definition")
+    def _render_value_input(
+        self,
+        statement_def: dict[str, Any],
+        value_data: dict[str, Any],
+        idx: int,
+        is_fixed: bool,
+    ) -> None:
+        value_block = statement_def.get("value", {})
+        dtype = _value_datatype(value_block)
+        current_value = value_data.get("value")
+
+        if is_fixed:
+            fixed_value = _initial_fixed_value(statement_def)
+            st.text_input(
+                "Value",
+                value=str(fixed_value or ""),
+                key=f"fixed_{_statement_key(statement_def)}_{idx}",
+                disabled=True,
+            )
+            value_data["value"] = fixed_value
             return
 
-        datatype = getattr(value_config, "type", "string")
-
-        # Get current value
-        current_value = value_data.get("value", None)
-
-        # Render widget based on datatype
-        widget_key = f"{statement_def.id}_value_{idx}"
-        new_value = WidgetFactory.render_widget(
-            datatype=datatype,
+        value_data["value"] = WidgetFactory.render_widget(
+            datatype=dtype,
             label="Value",
             value=current_value,
-            key=widget_key,
-            help_text=getattr(statement_def, "input_prompt", None),
+            key=f"value_{_statement_key(statement_def)}_{idx}",
+            help_text=_statement_prompt(statement_def),
         )
 
-        # Store value
-        value_data["value"] = new_value
+        normalized, notices = validate_inline_value(
+            datatype=dtype,
+            value=value_data["value"],
+            entity_ref=st.session_state.get("active_entity_id", "unknown"),
+            statement_ref=_statement_key(statement_def),
+        )
+        value_data["value"] = normalized
+        # Inline entry applies coercion but defers conformance messaging to review phase.
+        del notices
 
     def _render_qualifiers(
-        self, statement_def: Any, value_data: dict, idx: int
+        self, statement_def: dict[str, Any], value_data: dict[str, Any], idx: int
     ) -> None:
-        """Render qualifiers for a statement value.
+        qualifiers = statement_def.get("qualifiers", [])
+        if not qualifiers:
+            return
 
-        Args:
-            statement_def: Statement definition from profile
-            value_data: Current value data
-            idx: Index of this value in the list
-        """
-        if "qualifiers" not in value_data:
-            value_data["qualifiers"] = {}
+        st.write("**Qualifiers**")
+        value_data.setdefault("qualifiers", {})
 
-        qualifiers_def = statement_def.qualifiers
+        for qualifier_def in qualifiers:
+            if not isinstance(qualifier_def, dict):
+                continue
+            qual_key = _statement_key(qualifier_def)
+            qual_label = _statement_label(qualifier_def)
+            qual_dtype = _value_datatype(qualifier_def.get("value", {}))
+            current = value_data["qualifiers"].get(qual_key)
 
-        for qualifier_def in qualifiers_def:
-            qual_id = qualifier_def.id
-
-            # Get current qualifier value
-            current_qual_value = value_data["qualifiers"].get(qual_id, None)
-
-            # Check if this qualifier has a fixed value (must be non-None)
-            qual_value_config = getattr(qualifier_def, "value", None)
-            fixed_value = (
-                getattr(qual_value_config, "fixed", None) if qual_value_config else None
+            value_data["qualifiers"][qual_key] = WidgetFactory.render_widget(
+                datatype=qual_dtype,
+                label=qual_label,
+                value=current,
+                key=f"qual_{_statement_key(statement_def)}_{qual_key}_{idx}",
+                help_text=_statement_prompt(qualifier_def),
             )
 
-            if fixed_value is not None:
-                # Fixed qualifier value - show read-only
-                fixed_label = getattr(qual_value_config, "label", fixed_value)
-                st.markdown(
-                    f"**{qualifier_def.label}** (fixed): {fixed_label} `({fixed_value})`"
-                )
-            else:
-                # Editable qualifier
-                datatype = (
-                    getattr(qual_value_config, "type", "string")
-                    if qual_value_config
-                    else "string"
-                )
-
-                widget_key = f"{statement_def.id}_qual_{qual_id}_{idx}"
-                new_qual_value = WidgetFactory.render_widget(
-                    datatype=datatype,
-                    label=qualifier_def.label,
-                    value=current_qual_value,
-                    key=widget_key,
-                    help_text=getattr(qualifier_def, "input_prompt", None),
-                )
-
-                value_data["qualifiers"][qual_id] = new_qual_value
+            normalized, notices = validate_inline_value(
+                datatype=qual_dtype,
+                value=value_data["qualifiers"][qual_key],
+                entity_ref=st.session_state.get("active_entity_id", "unknown"),
+                statement_ref=qual_key,
+            )
+            value_data["qualifiers"][qual_key] = normalized
+            del notices
 
     def _render_references(
-        self, statement_def: Any, value_data: dict, idx: int
+        self, statement_def: dict[str, Any], value_data: dict[str, Any], idx: int
     ) -> None:
-        """Render references for a statement value.
-
-        Args:
-            statement_def: Statement definition from profile
-            value_data: Current value data
-            idx: Index of this value in the list
-        """
-        refs_config = getattr(statement_def, "references", None)
-        if not refs_config:
+        references = statement_def.get("references", [])
+        if not references:
             return
 
-        # Initialize references list if needed
-        if "references" not in value_data:
-            value_data["references"] = []
+        st.write("**References**")
+        value_data.setdefault("references", [])
 
-        stmt_id = statement_def.id
+        by_ref_key = {
+            r.get("property"): r
+            for r in value_data["references"]
+            if isinstance(r, dict)
+        }
 
-        # Show input prompt if present
-        if hasattr(refs_config, "input_prompt") and refs_config.input_prompt:
-            st.caption(refs_config.input_prompt)
+        updated: list[dict[str, Any]] = []
+        for ref_def in references:
+            if not isinstance(ref_def, dict):
+                continue
 
-        # Check for min_count requirement
-        min_count = getattr(refs_config, "min_count", None)
-        if min_count and min_count > 0:
-            st.caption(f"_Minimum {min_count} reference(s) required_")
+            ref_key = _statement_key(ref_def)
+            ref_label = _statement_label(ref_def)
+            ref_dtype = _value_datatype(ref_def.get("value", {}))
+            existing = by_ref_key.get(ref_key, {"property": ref_key, "value": None})
 
-        # Get allowed reference types (can be from 'allowed' or 'target')
-        allowed_refs = []
-        if hasattr(refs_config, "allowed") and refs_config.allowed:
-            allowed_refs = refs_config.allowed
-        elif hasattr(refs_config, "target") and refs_config.target:
-            allowed_refs = [refs_config.target]
-
-        if not allowed_refs:
-            st.caption("_No reference types configured_")
-            return
-
-        # For MVP, render all allowed reference types as separate inputs
-        # (Not implementing full Wikidata reference "groups" yet - one snak per reference)
-        for ref_idx, ref_target in enumerate(allowed_refs):
-            ref_id = ref_target.id
-            ref_label = ref_target.label
-            ref_type = ref_target.type
-
-            # Find existing reference value for this type
-            existing_ref = next(
-                (r for r in value_data["references"] if r.get("property") == ref_id),
-                None,
-            )
-
-            # Initialize if needed
-            if existing_ref is None:
-                existing_ref = {"property": ref_id, "value": None}
-                value_data["references"].append(existing_ref)
-
-            # Render input widget
-            key = f"ref_{stmt_id}_{idx}_{ref_id}"
-
-            # Render widget based on datatype
-            existing_ref["value"] = WidgetFactory.render_widget(
-                datatype=ref_type,
+            ref_value = WidgetFactory.render_widget(
+                datatype=ref_dtype,
                 label=ref_label,
-                value=existing_ref.get("value"),
-                key=key,
-                help_text=getattr(ref_target, "input_prompt", None),
+                value=existing.get("value"),
+                key=f"ref_{_statement_key(statement_def)}_{ref_key}_{idx}",
+                help_text=_statement_prompt(ref_def),
             )
+            normalized, notices = validate_inline_value(
+                datatype=ref_dtype,
+                value=ref_value,
+                entity_ref=st.session_state.get("active_entity_id", "unknown"),
+                statement_ref=ref_key,
+            )
+            updated.append({"property": ref_key, "value": ref_value})
+            updated[-1]["value"] = normalized
+            del notices
 
-    def _create_empty_statement(self, statement_def: Any) -> dict:
-        """Create an empty statement value structure.
-
-        Args:
-            statement_def: Statement definition from profile
-
-        Returns:
-            Empty statement value dict
-        """
-        return {"value": None, "qualifiers": {}, "references": []}
+        value_data["references"] = updated
 
     def validate(self, draft_data: dict[str, Any]) -> dict[str, list[str]]:
-        """Validate statements data.
-
-        Args:
-            draft_data: Current draft data
-
-        Returns:
-            Dict of warnings by section
-        """
-        warnings = {}
-
-        statements_data = draft_data.get("statements", {})
-
-        # Check if any statements were added
-        if not any(values for values in statements_data.values()):
-            warnings["statements"] = [
-                "No statements added yet - consider adding at least one"
-            ]
-
-        # TODO: Add more sophisticated validation:
-        # - Required statements from profile
-        # - Format validation for each value type
-        # - Qualifier requirements
-        # - Reference requirements
-
+        warnings: dict[str, list[str]] = {}
+        statements = draft_data.get("statements", {})
+        if not any(values for values in statements.values()):
+            warnings["statements"] = ["No statement values added yet."]
         return warnings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1302,22 +1302,18 @@ def test_profile_form_schema_resolves_profile_name_local_source(capsys):
 
 
 def test_profile_form_launches_streamlit_app(monkeypatch):
-    """Profile form command loads profile and runs Streamlit app."""
-    profile_path = (
-        Path(__file__).parent
-        / "fixtures"
-        / "profiles"
-        / "TribalGovernmentUS"
-        / "profile.yaml"
-    )
+    """Profile form command loads JSON profile and runs Streamlit app."""
+    local_root = Path(__file__).parent / "fixtures" / "spiritsafe"
 
     args = argparse.Namespace(
-        profile=str(profile_path),
+        profile="Q4",
         qid="Q123",
-        source=None,
-        local_root=None,
+        packet=None,
+        source="local",
+        local_root=str(local_root),
         repo=None,
         github_ref=None,
+        depth=1,
         command_path="profile.form",
     )
 
@@ -1335,11 +1331,11 @@ def test_profile_form_launches_streamlit_app(monkeypatch):
 
 
 def test_profile_form_from_profile_name_with_local_source(monkeypatch):
-    """Profile form command resolves profile names via local SpiritSafe source override.
+    """Profile form command resolves QID references via local SpiritSafe source override.
 
     This test verifies profile resolution with local source while mocking Streamlit launch.
     """
-    fixtures_root = Path(__file__).parent / "fixtures"
+    fixtures_root = Path(__file__).parent / "fixtures" / "spiritsafe"
 
     class FakeResult:
         returncode = 0
@@ -1355,7 +1351,7 @@ def test_profile_form_from_profile_name_with_local_source(monkeypatch):
             "profile",
             "form",
             "--profile",
-            "TribalGovernmentUS",
+            "Q4",
             "--source",
             "local",
             "--local-root",

--- a/tests/test_wizard_review_messages.py
+++ b/tests/test_wizard_review_messages.py
@@ -1,0 +1,110 @@
+"""Tests for review-stage wizard messaging semantics."""
+
+from gkc.fermenter import ConformanceNotice
+from gkc.profiles.forms.streamlit_app import (
+    _collect_review_consequences,
+    _group_review_items,
+)
+
+
+def test_collect_review_consequences_only_for_empty_statements() -> None:
+    statement_missing = "https://datadistillery.wikibase.cloud/entity/Q80"
+    statement_present = "https://datadistillery.wikibase.cloud/entity/Q81"
+
+    entity_slot = {
+        "id": "ent-001",
+        "statements": [
+            {
+                "entity": statement_missing,
+                "label": "native label",
+                "messages": {
+                    "mul": {
+                        "consequences_message": "Missing this can reduce discoverability."
+                    }
+                },
+            },
+            {
+                "entity": statement_present,
+                "label": "headquarters location",
+                "messages": {
+                    "mul": {
+                        "consequences_message": "Missing this can limit map linkage."
+                    }
+                },
+            },
+        ],
+        "data": {
+            "statements": {
+                statement_missing: [],
+                statement_present: [
+                    {"value": "Q60", "qualifiers": {}, "references": []}
+                ],
+            }
+        },
+    }
+
+    consequences = _collect_review_consequences(entity_slot)
+
+    assert len(consequences) == 1
+    assert statement_missing in consequences
+    assert "discoverability" in consequences[statement_missing]
+
+
+def test_group_review_items_groups_consequences_and_notices() -> None:
+    statement_ref = "https://datadistillery.wikibase.cloud/entity/Q19"
+    other_ref = "https://datadistillery.wikibase.cloud/entity/Q16"
+    entity_slot = {
+        "id": "ent-001",
+        "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "statements": [
+            {
+                "entity": statement_ref,
+                "label": "official website",
+                "messages": {
+                    "mul": {
+                        "consequences_message": "Missing this weakens external linkage."
+                    }
+                },
+            },
+            {
+                "entity": other_ref,
+                "label": "instance of",
+                "messages": {"mul": {"consequences_message": ""}},
+            },
+        ],
+        "data": {
+            "statements": {
+                statement_ref: [],
+                other_ref: [{"value": "Q42", "qualifiers": {}, "references": []}],
+            }
+        },
+    }
+
+    notices = [
+        ConformanceNotice(
+            severity="error",
+            entity_ref="ent-001",
+            statement_ref=statement_ref,
+            code="datatype_invalid",
+            message="Invalid URL datatype",
+        ),
+        ConformanceNotice(
+            severity="warning",
+            entity_ref="ent-999",
+            statement_ref=statement_ref,
+            code="statement_missing",
+            message="Different entity warning",
+        ),
+    ]
+
+    sections, ungrouped = _group_review_items(entity_slot=entity_slot, notices=notices)
+
+    assert len(sections) == 1
+    section = sections[0]
+    assert section["statement_ref"] == statement_ref
+    assert section["label"] == "official website"
+    assert "external linkage" in section["consequence"]
+    assert len(section["notices"]) == 1
+    assert section["notices"][0].code == "datatype_invalid"
+    assert len(ungrouped) == 1
+    assert ungrouped[0].entity_ref == "ent-999"

--- a/tests/test_wizard_validation_bridge.py
+++ b/tests/test_wizard_validation_bridge.py
@@ -1,0 +1,115 @@
+"""Tests for packet wizard validation bridge (Phase B)."""
+
+from pathlib import Path
+
+from gkc.profiles.forms.validation_bridge import (
+    validate_entity_packet_data,
+    validate_inline_value,
+)
+
+
+def test_validate_inline_value_coerces_wikibase_item_qid() -> None:
+    normalized, notices = validate_inline_value(
+        datatype="wikibase-item",
+        value="Q42",
+        entity_ref="ent-001",
+        statement_ref="https://datadistillery.wikibase.cloud/entity/Q16",
+    )
+
+    assert isinstance(normalized, dict)
+    assert normalized["id"] == "Q42"
+    assert all(n.severity != "error" for n in notices)
+
+
+def test_validate_entity_packet_data_reports_datatype_errors() -> None:
+    statement_ref = "https://datadistillery.wikibase.cloud/entity/Q16"
+    packet = {
+        "value_list_routes": {},
+        "entities": [
+            {
+                "id": "ent-001",
+                "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+                "statements": [
+                    {
+                        "entity": statement_ref,
+                        "label": "instance of",
+                        "value": {"type": "wikibase-item"},
+                        "max_count": 1,
+                        "qualifiers": [],
+                        "references": [],
+                    }
+                ],
+                "data": {
+                    "statements": {
+                        statement_ref: [
+                            {
+                                "value": "not-a-qid",
+                                "qualifiers": {},
+                                "references": [],
+                            }
+                        ]
+                    }
+                },
+            }
+        ],
+    }
+
+    notices = validate_entity_packet_data(
+        entity_slot=packet["entities"][0],
+        packet=packet,
+        source_root=None,
+    )
+
+    assert any(n.severity == "error" for n in notices)
+    assert any(n.code == "datatype_invalid" for n in notices)
+
+
+def test_validate_entity_packet_data_warns_missing_expected_reference() -> None:
+    statement_ref = "https://datadistillery.wikibase.cloud/entity/Q21"
+    ref_ref = "https://datadistillery.wikibase.cloud/entity/Q29"
+    packet = {
+        "value_list_routes": {},
+        "entities": [
+            {
+                "id": "ent-001",
+                "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+                "statements": [
+                    {
+                        "entity": statement_ref,
+                        "label": "member count",
+                        "value": {"type": "quantity"},
+                        "max_count": 1,
+                        "qualifiers": [],
+                        "references": [
+                            {
+                                "entity": ref_ref,
+                                "label": "reference URL",
+                                "value": {"type": "url"},
+                            }
+                        ],
+                    }
+                ],
+                "data": {
+                    "statements": {
+                        statement_ref: [
+                            {
+                                "value": {"amount": "+100", "unit": "1"},
+                                "qualifiers": {},
+                                "references": [],
+                            }
+                        ]
+                    }
+                },
+            }
+        ],
+    }
+
+    notices = validate_entity_packet_data(
+        entity_slot=packet["entities"][0],
+        packet=packet,
+        source_root=Path("/tmp"),
+    )
+
+    assert any(
+        n.code == "reference_missing" and n.severity == "warning" for n in notices
+    )


### PR DESCRIPTION
## Summary\n- migrate  wizard path to SpiritSafe JSON profile references (QID/URI) and optional packet loading\n- replace legacy YAML-centered Streamlit state with packet-native entity editing flow\n- add wizard validation bridge using fermenter primitives ()\n- defer malformed/error messaging to review stage and add statement-grouped review sections with consequences + notices\n- add/adjust tests for CLI, validation bridge, and grouped review messaging\n\n## Validation\n- ==================================
Running Pre-Merge Checks
==================================

✓ Poetry found

📦 Ensuring dependencies are installed...
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: gkc (0.1.0)

🔍 Running ruff linter...
All checks passed!
✓ Ruff checks passed

🎨 Checking code formatting with black...
✓ Black formatting verified

🔎 Running type checking with mypy...
gkc/fermenter.py:497: error: Incompatible return value type (got "tuple[ValidationResult, None]", expected "tuple[ValidationResult, ConformanceNotice]")  [return-value]
gkc/fermenter.py:521: error: Returning Any from function declared to return "bool"  [no-any-return]
gkc/bottler.py:160: error: Incompatible default for argument "transform_config" (default has type "None", argument has type "dict[Any, Any]")  [assignment]
gkc/bottler.py:160: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
gkc/bottler.py:160: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
gkc/bottler.py:206: error: Incompatible default for argument "transform_config" (default has type "None", argument has type "dict[Any, Any]")  [assignment]
gkc/bottler.py:206: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
gkc/bottler.py:206: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
gkc/bottler.py:207: error: Incompatible default for argument "qualifiers" (default has type "None", argument has type "list[dict[Any, Any]]")  [assignment]
gkc/bottler.py:207: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
gkc/bottler.py:207: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
gkc/bottler.py:208: error: Incompatible default for argument "references" (default has type "None", argument has type "list[dict[Any, Any]]")  [assignment]
gkc/bottler.py:208: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
gkc/bottler.py:208: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
gkc/bottler.py:230: error: Argument 4 to "create_snak" of "SnakBuilder" has incompatible type "Any | None"; expected "dict[Any, Any]"  [arg-type]
gkc/bottler.py:232: error: Unsupported target for indexed assignment ("Collection[Any]")  [index]
gkc/bottler.py:233: error: "Collection[Any]" has no attribute "append"  [attr-defined]
gkc/bottler.py:250: error: "Collection[Any]" has no attribute "append"  [attr-defined]
gkc/bottler.py:355: error: Library stubs not installed for "pandas"  [import-untyped]
gkc/bottler.py:355: note: Hint: "python3 -m pip install pandas-stubs"
gkc/bottler.py:355: note: (or run "mypy --install-types" to install all missing stub packages)
gkc/bottler.py:355: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
gkc/profiles/forms/draft_manager.py:41: error: Returning Any from function declared to return "dict[str, Any]"  [no-any-return]
gkc/profiles/models.py:782: error: Item "None" of "StatementLinkage | None" has no attribute "target_profile"  [union-attr]
gkc/profiles/models.py:805: error: Item "None" of "StatementLinkage | None" has no attribute "target_profile"  [union-attr]
gkc/profiles/validators/entity_json_validator.py:35: error: Argument "severity" to "ValidationIssue" has incompatible type "str"; expected "Literal['error', 'warning', 'info']"  [arg-type]
gkc/sparql.py:18: error: Library stubs not installed for "pandas"  [import-untyped]
gkc/sparql.py:18: note: Hint: "python3 -m pip install pandas-stubs"
gkc/sparql.py:18: note: (or run "mypy --install-types" to install all missing stub packages)
gkc/sparql.py:18: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
gkc/profiles/loaders/yaml_loader.py:136: error: Returning Any from function declared to return "dict[str, Any]"  [no-any-return]
gkc/profiles/validation/validator.py:175: error: Argument 1 to "get" of "dict" has incompatible type "int | str"; expected "str"  [arg-type]
gkc/still_charger.py:117: error: Invalid index type "Any | str | None" for "dict[str, dict[str, Any]]"; expected type "str"  [index]
gkc/still_charger.py:118: error: Argument 1 to "_visit" has incompatible type "Any | str | None"; expected "str"  [arg-type]
gkc/still_charger.py:513: error: Incompatible return value type (got "set[Any | None]", expected "set[str]")  [return-value]
gkc/mash/core.py:67: error: Item "None" of "MutableMapping[str, str | bytes] | Any | None" has no attribute "update"  [union-attr]
gkc/mash/core.py:87: error: Returning Any from function declared to return "list[dict[str, Any]]"  [no-any-return]
gkc/mash/core.py:135: error: Returning Any from function declared to return "dict[str, Any]"  [no-any-return]
gkc/mash/core.py:2036: error: Return type "dict[str, WikipediaTemplate]" of "load_many" incompatible with return type "dict[str, DataTemplate]" in supertype "gkc.mash.protocols.MashSourceAdapter"  [override]
gkc/spirit_safe.py:439: error: Returning Any from function declared to return "dict[str, Any] | None"  [no-any-return]
gkc/spirit_safe.py:645: error: Returning Any from function declared to return "list[dict[str, str]]"  [no-any-return]
gkc/spirit_safe.py:1888: error: Incompatible types in assignment (expression has type "list[Any | None]", target has type "list[str]")  [assignment]
gkc/spirit_safe.py:1974: error: Returning Any from function declared to return "str | None"  [no-any-return]
gkc/spirit_safe.py:1977: error: Returning Any from function declared to return "str | None"  [no-any-return]
gkc/spirit_safe.py:2270: error: Returning Any from function declared to return "dict[str, Any]"  [no-any-return]
gkc/wikibase/ontology.py:189: error: Returning Any from function declared to return "list[dict[Any, Any]]"  [no-any-return]
gkc/wikibase/ontology.py:561: error: Returning Any from function declared to return "str | None"  [no-any-return]
gkc/wikibase/ontology.py:563: error: Returning Any from function declared to return "str | None"  [no-any-return]
gkc/wikibase/ontology.py:565: error: Returning Any from function declared to return "str | None"  [no-any-return]
gkc/wikibase/cache.py:200: error: Argument "queried_ids" to "WikibaseCacheBuildResult" has incompatible type "object"; expected "list[str]"  [arg-type]
gkc/wikibase/cache.py:201: error: Argument "fetched_ids" to "WikibaseCacheBuildResult" has incompatible type "object"; expected "list[str]"  [arg-type]
gkc/wikibase/cache.py:202: error: Argument "written_ids" to "WikibaseCacheBuildResult" has incompatible type "object"; expected "list[str]"  [arg-type]
gkc/wikibase/cache.py:203: error: Argument "new_ids" to "WikibaseCacheBuildResult" has incompatible type "object"; expected "list[str]"  [arg-type]
gkc/wikibase/cache.py:204: error: Argument "changed_ids" to "WikibaseCacheBuildResult" has incompatible type "object"; expected "list[str]"  [arg-type]
gkc/wikibase/cache.py:205: error: Argument "unchanged_ids" to "WikibaseCacheBuildResult" has incompatible type "object"; expected "list[str]"  [arg-type]
gkc/wikibase/cache.py:206: error: Argument "deleted_ids" to "WikibaseCacheBuildResult" has incompatible type "object"; expected "list[str]"  [arg-type]
gkc/wikibase/cache.py:207: error: Argument "missing_ids" to "WikibaseCacheBuildResult" has incompatible type "object"; expected "list[str]"  [arg-type]
gkc/profiles/forms/widgets.py:55: error: Argument 3 has incompatible type "str | None"; expected "str"  [arg-type]
gkc/profiles/forms/widgets.py:55: error: Argument 4 has incompatible type "str | None"; expected "str"  [arg-type]
gkc/profiles/forms/wizard/steps.py:21: error: Returning Any from function declared to return "dict[str, Any] | None"  [no-any-return]
gkc/profiles/forms/wizard/steps.py:30: error: Returning Any from function declared to return "dict[str, Any] | None"  [no-any-return]
gkc/profiles/forms/wizard/steps.py:40: error: Returning Any from function declared to return "str"  [no-any-return]
gkc/profiles/forms/wizard/steps.py:57: error: Returning Any from function declared to return "str"  [no-any-return]
gkc/profiles/forms/wizard/steps.py:101: error: Returning Any from function declared to return "str"  [no-any-return]
gkc/profiles/forms/streamlit_app.py:61: error: Returning Any from function declared to return "str"  [no-any-return]
gkc/profiles/forms/streamlit_app.py:258: error: Returning Any from function declared to return "dict[str, Any] | None"  [no-any-return]
gkc/profiles/forms/streamlit_app.py:263: error: Returning Any from function declared to return "dict[str, Any] | None"  [no-any-return]
gkc/profiles/forms/streamlit_app.py:271: error: Returning Any from function declared to return "dict[str, Any] | None"  [no-any-return]
gkc/profiles/forms/streamlit_app.py:286: error: Returning Any from function declared to return "dict[str, Any]"  [no-any-return]
gkc/profiles/forms/streamlit_app.py:452: error: Argument "type" to "button" of "ButtonMixin" has incompatible type "str"; expected "Literal['primary', 'secondary', 'tertiary']"  [arg-type]
Found 56 errors in 16 files (checked 51 source files)
⚠️  Type checking had issues (non-blocking)

🧪 Running test suite...
============================= test session starts ==============================
platform darwin -- Python 3.12.2, pytest-8.4.2, pluggy-1.6.0 -- /Users/sky/code/gkc/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/sky/code/gkc
configfile: pyproject.toml
testpaths: tests
plugins: cov-6.3.0
collecting ... collected 359 items

tests/test_auth.py::TestWikiverseAuth::test_init_with_credentials PASSED [  0%]
tests/test_auth.py::TestWikiverseAuth::test_init_from_environment PASSED [  0%]
tests/test_auth.py::TestWikiverseAuth::test_init_with_custom_api_url PASSED [  0%]
tests/test_auth.py::TestWikiverseAuth::test_init_with_api_url_shortcut_wikidata PASSED [  1%]
tests/test_auth.py::TestWikiverseAuth::test_init_with_api_url_shortcut_wikipedia PASSED [  1%]
tests/test_auth.py::TestWikiverseAuth::test_init_with_api_url_shortcut_commons PASSED [  1%]
tests/test_auth.py::TestWikiverseAuth::test_default_api_url_is_wikidata PASSED [  1%]
tests/test_auth.py::TestWikiverseAuth::test_api_url_from_environment PASSED [  2%]
tests/test_auth.py::TestWikiverseAuth::test_init_partial_credentials PASSED [  2%]
tests/test_auth.py::TestWikiverseAuth::test_init_no_credentials PASSED   [  2%]
tests/test_auth.py::TestWikiverseAuth::test_repr PASSED                  [  3%]
tests/test_auth.py::TestWikiverseAuth::test_get_bot_name PASSED          [  3%]
tests/test_auth.py::TestWikiverseAuth::test_get_bot_name_no_bot PASSED   [  3%]
tests/test_auth.py::TestWikiverseAuth::test_get_bot_name_no_username PASSED [  3%]
tests/test_auth.py::TestWikiverseAuth::test_get_account_name PASSED      [  4%]
tests/test_auth.py::TestWikiverseAuth::test_get_account_name_no_bot PASSED [  4%]
tests/test_auth.py::TestWikiverseAuth::test_get_account_name_no_username PASSED [  4%]
tests/test_auth.py::TestWikiverseAuth::test_should_mark_bot_edits_true_for_bot_username PASSED [  5%]
tests/test_auth.py::TestWikiverseAuth::test_should_mark_bot_edits_false_for_plain_username PASSED [  5%]
tests/test_auth.py::TestWikiverseAuth::test_login_success PASSED         [  5%]
tests/test_auth.py::TestWikiverseAuth::test_login_failure PASSED         [  5%]
tests/test_auth.py::TestWikiverseAuth::test_login_without_credentials PASSED [  6%]
tests/test_auth.py::TestWikiverseAuth::test_get_csrf_token PASSED        [  6%]
tests/test_auth.py::TestWikiverseAuth::test_get_csrf_token_not_logged_in PASSED [  6%]
tests/test_auth.py::TestWikiverseAuth::test_logout PASSED                [  6%]
tests/test_auth.py::TestWikiverseAuth::test_get_user_rights_returns_list PASSED [  7%]
tests/test_auth.py::TestWikiverseAuth::test_get_user_rights_empty_when_no_rights_key PASSED [  7%]
tests/test_auth.py::TestWikiverseAuth::test_get_user_rights_raises_when_not_logged_in PASSED [  7%]
tests/test_auth.py::TestWikiverseAuth::test_get_user_rights_raises_on_network_error PASSED [  8%]
tests/test_auth.py::TestWikiverseAuth::test_has_api_high_limits_true PASSED [  8%]
tests/test_auth.py::TestWikiverseAuth::test_has_api_high_limits_false_when_right_absent PASSED [  8%]
tests/test_auth.py::TestWikiverseAuth::test_has_api_high_limits_false_when_not_logged_in PASSED [  8%]
tests/test_auth.py::TestOpenStreetMapAuth::test_init_with_credentials PASSED [  9%]
tests/test_auth.py::TestOpenStreetMapAuth::test_init_from_environment PASSED [  9%]
tests/test_auth.py::TestOpenStreetMapAuth::test_init_partial_credentials PASSED [  9%]
tests/test_auth.py::TestOpenStreetMapAuth::test_init_no_credentials PASSED [ 10%]
tests/test_auth.py::TestOpenStreetMapAuth::test_repr PASSED              [ 10%]
tests/test_cli.py::test_wikiverse_status_json PASSED                     [ 10%]
tests/test_cli.py::test_wikiverse_token_redacted PASSED                  [ 10%]
tests/test_cli.py::test_osm_status_json PASSED                           [ 11%]
tests/test_cli.py::test_wikibase_plan_write_json PASSED                  [ 11%]
tests/test_cli.py::test_wikibase_plan_write_missing_source_values_file PASSED [ 11%]
tests/test_cli.py::test_packet_build_supports_github_source PASSED       [ 11%]
tests/test_cli.py::test_wikibase_profile_to_cache_json PASSED            [ 12%]
tests/test_cli.py::test_wikibase_check_for_revisions_json PASSED         [ 12%]
tests/test_cli.py::test_wikibase_cache_builder_json PASSED               [ 12%]
tests/test_cli.py::test_wikibase_plan_write_with_shipper_plan PASSED     [ 13%]
tests/test_cli.py::test_wikibase_execute_write_dry_run PASSED            [ 13%]
tests/test_cli.py::test_wikibase_execute_write_requires_auth PASSED      [ 13%]
tests/test_cli.py::test_mash_qid_filter_properties PASSED                [ 13%]
tests/test_cli.py::test_mash_qid_shell_transform PASSED                  [ 14%]
tests/test_cli.py::test_mash_pid_basic PASSED                            [ 14%]
tests/test_cli.py::test_mash_eid_basic PASSED                            [ 14%]
tests/test_cli.py::test_mash_qid_summary PASSED                          [ 15%]
tests/test_cli.py::test_mash_pid_summary PASSED                          [ 15%]
tests/test_cli.py::test_mash_eid_summary PASSED                          [ 15%]
tests/test_cli.py::test_mash_wp_template_summary PASSED                  [ 15%]
tests/test_cli.py::test_mash_wp_template_raw PASSED                      [ 16%]
tests/test_cli.py::test_shex_validate_missing_args PASSED                [ 16%]
tests/test_cli.py::test_shex_validate_success PASSED                     [ 16%]
tests/test_cli.py::test_shex_validate_failure PASSED                     [ 16%]
tests/test_cli.py::test_profile_validate_with_item_json PASSED           [ 17%]
tests/test_cli.py::test_profile_form_schema PASSED                       [ 17%]
tests/test_cli.py::test_profile_form_schema_resolves_profile_name_local_source PASSED [ 17%]
tests/test_cli.py::test_profile_form_launches_streamlit_app PASSED       [ 18%]
tests/test_cli.py::test_profile_form_from_profile_name_with_local_source PASSED [ 18%]
tests/test_cli.py::test_shex_validate_local_files PASSED                 [ 18%]
tests/test_cli.py::test_profile_lookups_hydrate_dry_run PASSED           [ 18%]
tests/test_cli.py::test_profile_lookups_hydrate_uses_dd_wb_sparql_env_default PASSED [ 19%]
tests/test_cli.py::test_profile_lookups_hydrate_local_source_override PASSED [ 19%]
tests/test_cli.py::test_profile_lookups_hydrate_profile_name_resolution PASSED [ 19%]
tests/test_cli.py::test_profile_export_json_writes_output_directory PASSED [ 20%]
tests/test_cli.py::test_profile_value_lists_hydrate_local_source_defaults PASSED [ 20%]
tests/test_cli.py::test_profile_value_lists_hydrate_reports_failures PASSED [ 20%]
tests/test_cooperage_barreling.py::test_barrel_packet_to_operation_plan PASSED [ 20%]
tests/test_cooperage_barreling.py::test_barrel_uses_global_property_map_when_statement_map_missing PASSED [ 21%]
tests/test_cooperage_barreling.py::test_barrel_reports_unknown_statement_mapping PASSED [ 21%]
tests/test_datatypes.py::TestMonolingualtext::test_monolingualtext_normalization PASSED [ 21%]
tests/test_datatypes.py::TestMonolingualtext::test_monolingualtext_missing_language PASSED [ 22%]
tests/test_datatypes.py::TestMonolingualtext::test_monolingualtext_missing_text PASSED [ 22%]
tests/test_datatypes.py::TestGlobecoordinate::test_globecoordinate_normalization PASSED [ 22%]
tests/test_datatypes.py::TestGlobecoordinate::test_globecoordinate_minimal PASSED [ 22%]
tests/test_datatypes.py::TestGlobecoordinate::test_globecoordinate_missing_latitude PASSED [ 23%]
tests/test_datatypes.py::TestGlobecoordinate::test_globecoordinate_invalid_latitude_range PASSED [ 23%]
tests/test_datatypes.py::TestGlobecoordinate::test_globecoordinate_invalid_longitude_range PASSED [ 23%]
tests/test_datatypes.py::TestGlobecoordinate::test_globecoordinate_valid_ranges PASSED [ 23%]
tests/test_datatypes.py::TestCommonsMedia::test_commonsmedia_normalization PASSED [ 24%]
tests/test_datatypes.py::TestExternalId::test_externalid_normalization PASSED [ 24%]
tests/test_datatypes.py::TestQuantityWithUnits::test_quantity_with_unit PASSED [ 24%]
tests/test_datatypes.py::TestQuantityWithUnits::test_quantity_without_unit PASSED [ 25%]
tests/test_datatypes.py::TestTimeEnhanced::test_time_with_precision_and_calendar PASSED [ 25%]
tests/test_datatypes.py::TestTimeEnhanced::test_time_minimal PASSED      [ 25%]
tests/test_datatypes.py::TestIntegerOnlyWithComplexTypes::test_integer_only_with_simple_quantity PASSED [ 25%]
tests/test_datatypes.py::TestIntegerOnlyWithComplexTypes::test_integer_only_constraint_extracts_from_dict PASSED [ 26%]
tests/test_docs_build.py::test_mkdocs_build_strict PASSED                [ 26%]
tests/test_entity_json_validator.py::test_validate_schema_minimal_valid PASSED [ 26%]
tests/test_entity_json_validator.py::test_validate_schema_missing_packet_id PASSED [ 27%]
tests/test_entity_json_validator.py::test_validate_schema_missing_profile_name PASSED [ 27%]
tests/test_entity_json_validator.py::test_validate_schema_invalid_labels_structure PASSED [ 27%]
tests/test_entity_json_validator.py::test_validate_schema_invalid_statements_structure PASSED [ 27%]
tests/test_entity_json_validator.py::test_calculate_completeness_empty_entity PASSED [ 28%]
tests/test_entity_json_validator.py::test_calculate_completeness_labels_only PASSED [ 28%]
tests/test_entity_json_validator.py::test_calculate_completeness_labels_and_descriptions PASSED [ 28%]
tests/test_entity_json_validator.py::test_calculate_completeness_with_statements PASSED [ 28%]
tests/test_entity_json_validator.py::test_calculate_completeness_multiple_languages PASSED [ 29%]
tests/test_entity_json_validator.py::test_calculate_completeness_required_languages PASSED [ 29%]
tests/test_entity_json_validator.py::test_calculate_completeness_full_entity PASSED [ 29%]
tests/test_entity_json_validator.py::test_missing_fields_identification PASSED [ 30%]
tests/test_entity_json_validator.py::test_missing_fields_statements PASSED [ 30%]
tests/test_entity_json_validator.py::test_completeness_with_empty_statements_dict PASSED [ 30%]
tests/test_entity_json_validator.py::test_completeness_with_none_values PASSED [ 30%]
tests/test_entity_json_validator.py::test_schema_validation_with_extra_fields PASSED [ 31%]
tests/test_entity_json_validator.py::test_empty_entity_dict PASSED       [ 31%]
tests/test_init.py::test_version PASSED                                  [ 31%]
tests/test_init.py::test_auth_imports PASSED                             [ 32%]
tests/test_init.py::test_shex_imports PASSED                             [ 32%]
tests/test_init.py::test_spirit_safe_config_imports PASSED               [ 32%]
tests/test_init.py::test_mash_and_utilities_imports PASSED               [ 32%]
tests/test_init.py::test_mash_adapter_contract_imports PASSED            [ 33%]
tests/test_linkage_parsing.py::test_linkage_metadata_parsed PASSED       [ 33%]
tests/test_linkage_parsing.py::test_entity_profile_field_parsed PASSED   [ 33%]
tests/test_linkage_parsing.py::test_guidance_field_parsed PASSED         [ 33%]
tests/test_linkage_parsing.py::test_get_statement_linkages PASSED        [ 34%]
tests/test_linkage_parsing.py::test_get_linked_profile_names PASSED      [ 34%]
tests/test_linkage_parsing.py::test_get_link_definition PASSED           [ 34%]
tests/test_linkage_parsing.py::test_cardinality_validation PASSED        [ 35%]
tests/test_linkage_parsing.py::test_workflow_policy_alias PASSED         [ 35%]
tests/test_linkage_parsing.py::test_statements_without_linkage PASSED    [ 35%]
tests/test_mash.py::test_language_configuration_getter PASSED            [ 35%]
tests/test_mash.py::test_language_configuration_setter PASSED            [ 36%]
tests/test_mash.py::test_wikidata_template_summary PASSED                [ 36%]
tests/test_mash.py::test_wikidata_template_filter_properties PASSED      [ 36%]
tests/test_mash.py::test_wikidata_template_filter_qualifiers PASSED      [ 37%]
tests/test_mash.py::test_wikidata_template_filter_references PASSED      [ 37%]
tests/test_mash.py::test_wikidata_template_filter_languages_updates_entity_data PASSED [ 37%]
tests/test_mash.py::test_wikidata_template_to_dict_roundtrip PASSED      [ 37%]
tests/test_mash.py::test_strip_entity_identifiers_removes_ids PASSED     [ 38%]
tests/test_mash.py::test_get_latest_cache_timestamp_prefers_entity_modified PASSED [ 38%]
tests/test_mash.py::test_fetch_recent_entity_changes_collects_ids_and_ignores_filtered PASSED [ 38%]
tests/test_mash.py::test_refresh_entity_cache_from_recentchanges_updates_and_deletes PASSED [ 38%]
tests/test_mash.py::test_extract_sparql_blocks_returns_blocks_in_order PASSED [ 39%]
tests/test_mash.py::test_extract_first_sparql_block_raises_without_block PASSED [ 39%]
tests/test_mash.py::test_fetch_mediawiki_page_wikitext_from_revision_slots PASSED [ 39%]
tests/test_mash.py::test_wikidata_loader_snak_to_value_entity PASSED     [ 40%]
tests/test_mash.py::test_wikidata_loader_snak_to_value_string PASSED     [ 40%]
tests/test_mash.py::test_wikidata_loader_snak_to_value_novalue PASSED    [ 40%]
tests/test_mash.py::test_wikidata_template_to_shell PASSED               [ 40%]
tests/test_mash.py::test_wikidata_template_to_qsv1 PASSED                [ 41%]
tests/test_mash.py::test_wikidata_template_to_gkc_entity_profile_not_implemented PASSED [ 41%]
tests/test_mash.py::test_wikidata_property_template_summary PASSED       [ 41%]
tests/test_mash.py::test_wikidata_property_template_filter_languages PASSED [ 42%]
tests/test_mash.py::test_wikidata_property_template_to_shell PASSED      [ 42%]
tests/test_mash.py::test_wikidata_entity_schema_template_summary PASSED  [ 42%]
tests/test_mash.py::test_wikidata_entity_schema_template_filter_languages PASSED [ 42%]
tests/test_mash.py::test_wikidata_loader_load_items_empty PASSED         [ 43%]
tests/test_mash.py::test_wikibase_loader_default_batch_size_without_auth PASSED [ 43%]
tests/test_mash.py::test_wikibase_loader_default_batch_size_with_no_high_limits PASSED [ 43%]
tests/test_mash.py::test_wikibase_loader_high_batch_size_with_apihighlimits PASSED [ 44%]
tests/test_mash.py::test_wikibase_loader_batch_size_safe_with_auth_none_method PASSED [ 44%]
tests/test_mash.py::test_wikibase_loader_load_items_respects_batch_size PASSED [ 44%]
tests/test_mash.py::test_wikibase_loader_load_entities_raw_respects_batch_size PASSED [ 44%]
tests/test_mash.py::test_wikipedia_template_initialization PASSED        [ 45%]
tests/test_mash.py::test_wikipedia_template_summary PASSED               [ 45%]
tests/test_mash.py::test_wikipedia_template_to_dict PASSED               [ 45%]
tests/test_mash.py::test_wikipedia_loader_initialization PASSED          [ 45%]
tests/test_mash.py::test_wikipedia_loader_custom_user_agent PASSED       [ 46%]
tests/test_mash_adapters.py::test_wikibase_adapter_implements_protocol PASSED [ 46%]
tests/test_mash_adapters.py::test_wikipedia_adapter_implements_protocol PASSED [ 46%]
tests/test_mash_adapters.py::test_wikibase_adapter_can_load_entity_refs PASSED [ 47%]
tests/test_mash_adapters.py::test_wikibase_adapter_load_dispatches_by_prefix PASSED [ 47%]
tests/test_mash_adapters.py::test_wikibase_adapter_load_many_supports_mixed_refs PASSED [ 47%]
tests/test_mash_adapters.py::test_wikipedia_adapter_normalizes_template_prefix PASSED [ 47%]
tests/test_mash_adapters.py::test_wikipedia_adapter_load_many_returns_keyed_result PASSED [ 48%]
tests/test_mash_formatters.py::test_qsv1_formatter_new_item PASSED       [ 48%]
tests/test_mash_formatters.py::test_qsv1_formatter_exclude_properties PASSED [ 48%]
tests/test_mash_formatters.py::test_qsv1_formatter_with_entity_labels PASSED [ 49%]
tests/test_mash_formatters.py::test_qsv1_formatter_with_qualifiers_and_labels PASSED [ 49%]
tests/test_mash_formatters.py::test_qsv1_formatter_without_entity_labels PASSED [ 49%]
tests/test_mash_formatters.py::test_qsv1_formatter_with_string_values PASSED [ 49%]
tests/test_mash_formatters.py::test_qsv1_formatter_existing_item PASSED  [ 50%]
tests/test_mash_formatters.py::test_qsv1_formatter_with_date_precision PASSED [ 50%]
tests/test_mash_formatters.py::test_qsv1_formatter_with_qualifier_date_precision PASSED [ 50%]
tests/test_profile_graph.py::test_graph_created_from_manifest PASSED     [ 50%]
tests/test_profile_graph.py::test_graph_nodes_structure PASSED           [ 51%]
tests/test_profile_graph.py::test_get_neighbors PASSED                   [ 51%]
tests/test_profile_graph.py::test_get_edges PASSED                       [ 51%]
tests/test_profile_graph.py::test_get_cardinality_defaults_to_empty_dict PASSED [ 52%]
tests/test_profile_graph.py::test_traverse_depth_1 PASSED                [ 52%]
tests/test_profile_graph.py::test_traverse_depth_0 PASSED                [ 52%]
tests/test_profile_graph.py::test_traverse_with_cycle_prevention PASSED  [ 52%]
tests/test_profile_graph.py::test_validate_bidirectional_awareness PASSED [ 53%]
tests/test_profile_graph.py::test_validate_bidirectional_missing_reciprocal PASSED [ 53%]
tests/test_profiles_base.py::test_entity_profile_creation PASSED         [ 53%]
tests/test_profiles_base.py::test_entity_profile_defaults PASSED         [ 54%]
tests/test_profiles_base.py::test_entity_profile_to_dict PASSED          [ 54%]
tests/test_profiles_base.py::test_entity_profile_abstract_methods PASSED [ 54%]
tests/test_profiles_base.py::test_modulation_profile_creation PASSED     [ 54%]
tests/test_profiles_base.py::test_modulation_profile_field_specs PASSED  [ 55%]
tests/test_profiles_base.py::test_modulation_profile_validate_inputs PASSED [ 55%]
tests/test_profiles_base.py::test_modulation_profile_abstract_methods PASSED [ 55%]
tests/test_profiles_base.py::test_barrel_profile_creation PASSED         [ 55%]
tests/test_profiles_base.py::test_barrel_profile_transform PASSED        [ 56%]
tests/test_profiles_base.py::test_barrel_profile_ship PASSED             [ 56%]
tests/test_profiles_base.py::test_barrel_profile_validate_payload PASSED [ 56%]
tests/test_profiles_base.py::test_barrel_profile_to_dict PASSED          [ 57%]
tests/test_profiles_base.py::test_property_definition_creation PASSED    [ 57%]
tests/test_profiles_base.py::test_property_definition_with_qualifiers PASSED [ 57%]
tests/test_profiles_base.py::test_property_definition_to_dict PASSED     [ 57%]
tests/test_profiles_base.py::test_property_definition_validate_value PASSED [ 58%]
tests/test_profiles_validation.py::test_lenient_validation_warns_on_integer_only PASSED [ 58%]
tests/test_profiles_validation.py::test_strict_validation_errors_on_integer_only PASSED [ 58%]
tests/test_profiles_yaml.py::test_profile_loader_reads_yaml PASSED       [ 59%]
tests/test_profiles_yaml.py::test_form_schema_generator PASSED           [ 59%]
tests/test_profiles_yaml.py::test_exemplar_profile_covers_datatypes_and_prompts PASSED [ 59%]
tests/test_profiles_yaml.py::test_profile_loader_allows_missing_statement_required_flag PASSED [ 59%]
tests/test_runtime_config.py::test_runtime_config_defaults PASSED        [ 60%]
tests/test_runtime_config.py::test_runtime_config_env_overrides PASSED   [ 60%]
tests/test_runtime_config.py::test_runtime_config_ignores_wikiverse_credentials PASSED [ 60%]
tests/test_shex_integration.py::TestShExIntegration::test_validate_with_fixture_files PASSED [ 61%]
tests/test_shex_integration.py::TestShExIntegration::test_validate_with_fixture_text PASSED [ 61%]
tests/test_shex_integration.py::TestShExIntegration::test_invalid_organism_fails_validation PASSED [ 61%]
tests/test_shex_integration.py::TestShExIntegration::test_fluent_api_with_fixtures PASSED [ 61%]
tests/test_shex_integration.py::TestShExIntegration::test_compare_file_path_vs_text_loading PASSED [ 62%]
tests/test_shex_integration.py::TestFetchFromWikidata::test_validate_entity_from_wikidata PASSED [ 62%]
tests/test_shex_integration.py::TestFetchFromWikidata::test_fetch_and_save_for_offline_testing PASSED [ 62%]
tests/test_shipper.py::test_write_result_to_dict_and_json PASSED         [ 62%]
tests/test_shipper.py::test_shipper_write_raises PASSED                  [ 63%]
tests/test_shipper.py::test_wikibase_shipper_write_item_dry_run PASSED   [ 63%]
tests/test_shipper.py::test_wikibase_shipper_write_item_validate_only PASSED [ 63%]
tests/test_shipper.py::test_wikibase_shipper_write_item_submit PASSED    [ 64%]
tests/test_shipper.py::test_wikibase_shipper_write_property_submit PASSED [ 64%]
tests/test_shipper.py::test_wikibase_shipper_plan_batch_create PASSED    [ 64%]
tests/test_shipper.py::test_wikibase_shipper_plan_batch_ambiguous PASSED [ 64%]
tests/test_shipper.py::test_wikibase_shipper_plan_batch_update_and_noop PASSED [ 65%]
tests/test_shipper.py::test_wikibase_shipper_plan_batch_property_requires_datatype PASSED [ 65%]
tests/test_shipper.py::test_commons_shipper_not_implemented PASSED       [ 65%]
tests/test_shipper.py::test_osm_shipper_not_implemented PASSED           [ 66%]
tests/test_sparql.py::TestSPARQLQueryParseWikidataURL::test_parse_simple_wikidata_url PASSED [ 66%]
tests/test_sparql.py::TestSPARQLQueryParseWikidataURL::test_parse_wikidata_url_with_newlines PASSED [ 66%]
tests/test_sparql.py::TestSPARQLQueryParseWikidataURL::test_parse_wikidata_url_empty_fragment PASSED [ 66%]
tests/test_sparql.py::TestSPARQLQueryParseWikidataURL::test_parse_non_wikidata_url PASSED [ 67%]
tests/test_sparql.py::TestSPARQLQueryParseWikidataURL::test_parse_invalid_url PASSED [ 67%]
tests/test_sparql.py::TestSPARQLQueryNormalize::test_normalize_plain_query PASSED [ 67%]
tests/test_sparql.py::TestSPARQLQueryNormalize::test_normalize_wikidata_url PASSED [ 67%]
tests/test_sparql.py::TestSPARQLQueryNormalize::test_normalize_query_with_whitespace PASSED [ 68%]
tests/test_sparql.py::TestSPARQLQueryExecution::test_query_json_response PASSED [ 68%]
tests/test_sparql.py::TestSPARQLQueryExecution::test_query_csv_response PASSED [ 68%]
tests/test_sparql.py::TestSPARQLQueryExecution::test_query_with_url PASSED [ 69%]
tests/test_sparql.py::TestSPARQLQueryExecution::test_query_timeout PASSED [ 69%]
tests/test_sparql.py::TestSPARQLQueryExecution::test_query_connection_error PASSED [ 69%]
tests/test_sparql.py::TestSPARQLQueryExecution::test_query_http_error PASSED [ 69%]
tests/test_sparql.py::TestSPARQLToDataFrame::test_to_dataframe_with_pandas PASSED [ 70%]
tests/test_sparql.py::TestSPARQLToDataFrame::test_to_dataframe_without_pandas PASSED [ 70%]
tests/test_sparql.py::TestSPARQLToDictList::test_to_dict_list PASSED     [ 70%]
tests/test_sparql.py::TestSPARQLToCSV::test_to_csv PASSED                [ 71%]
tests/test_sparql.py::TestSPARQLToCSV::test_to_csv_with_file PASSED      [ 71%]
tests/test_sparql.py::TestSPARQLConvenienceFunctions::test_execute_sparql PASSED [ 71%]
tests/test_sparql.py::TestSPARQLConvenienceFunctions::test_execute_sparql_to_dataframe PASSED [ 71%]
tests/test_sparql.py::test_read_sparql_query_file PASSED                 [ 72%]
tests/test_sparql.py::test_execute_sparql_file PASSED                    [ 72%]
tests/test_sparql.py::test_paginate_query_file PASSED                    [ 72%]
tests/test_sparql.py::TestSPARQLEndpointCustomization::test_custom_endpoint PASSED [ 72%]
tests/test_sparql.py::TestSPARQLEndpointCustomization::test_custom_user_agent PASSED [ 73%]
tests/test_sparql.py::TestSPARQLEndpointCustomization::test_custom_timeout PASSED [ 73%]
tests/test_spirit_safe_config.py::test_default_spirit_safe_source_is_github PASSED [ 73%]
tests/test_spirit_safe_config.py::test_set_spirit_safe_source_local_requires_root PASSED [ 74%]
tests/test_spirit_safe_config.py::test_set_spirit_safe_source_local_updates_cache_dir PASSED [ 74%]
tests/test_spirit_safe_config.py::test_github_mode_relative_resolution PASSED [ 74%]
tests/test_spirit_safe_config.py::test_resolve_profile_path_prefers_registrant_path PASSED [ 74%]
tests/test_spirit_safe_config.py::test_resolve_profile_path_keeps_explicit_paths PASSED [ 75%]
tests/test_spirit_safe_config.py::test_hydrate_profile_lookups_supports_legacy_flat_profile_path PASSED [ 75%]
tests/test_spirit_safe_config.py::test_resolve_query_ref_prefers_profile_relative PASSED [ 75%]
tests/test_spirit_safe_config.py::test_resolve_query_ref_falls_back_to_root_relative PASSED [ 76%]
tests/test_spirit_safe_config.py::test_resolve_query_ref_raises_when_not_found PASSED [ 76%]
tests/test_spirit_safe_config.py::test_resolve_query_ref_only_tries_root_for_flat_profile_paths PASSED [ 76%]
tests/test_spirit_safe_config.py::test_list_profiles_returns_available_profiles PASSED [ 76%]
tests/test_spirit_safe_config.py::test_list_profiles_ignores_hidden_directories PASSED [ 77%]
tests/test_spirit_safe_config.py::test_profile_exists_returns_true_for_valid_profile PASSED [ 77%]
tests/test_spirit_safe_config.py::test_profile_exists_returns_false_for_missing_profile PASSED [ 77%]
tests/test_spirit_safe_config.py::test_get_profile_metadata_loads_complete_metadata PASSED [ 77%]
tests/test_spirit_safe_config.py::test_get_profile_metadata_requires_name_version_status PASSED [ 78%]
tests/test_spirit_safe_config.py::test_get_profile_metadata_raises_for_missing_profile PASSED [ 78%]
tests/test_spirit_safe_entity_profile_json.py::test_build_entity_profile_json_documents_from_cache_entities PASSED [ 78%]
tests/test_spirit_safe_entity_profile_json.py::test_export_entity_profile_json_documents_writes_qid_files PASSED [ 79%]
tests/test_spirit_safe_entity_profile_json.py::test_value_list_graph_includes_reference_and_qualifier_routes PASSED [ 79%]
tests/test_spirit_safe_entity_profile_json.py::test_reference_statement_derives_value_from_parent_statement PASSED [ 79%]
tests/test_spirit_safe_entity_profile_json.py::test_reference_statement_derived_value_respects_profile_scope PASSED [ 79%]
tests/test_spirit_safe_hydration.py::test_hydrate_profile_lookups_dry_run_dedupes PASSED [ 80%]
tests/test_spirit_safe_hydration.py::test_hydrate_profile_lookups_executes_and_writes_cache PASSED [ 80%]
tests/test_spirit_safe_hydration.py::test_lookup_fetcher_deduplicates_results PASSED [ 80%]
tests/test_spirit_safe_phase3.py::test_build_spiritsafe_manifest_document PASSED [ 81%]
tests/test_spirit_safe_phase3.py::test_export_spiritsafe_manifest PASSED [ 81%]
tests/test_spirit_safe_phase3.py::test_load_manifest_reads_new_shape PASSED [ 81%]
tests/test_spirit_safe_phase3.py::test_load_profile_reads_json_profile_document PASSED [ 81%]
tests/test_spirit_safe_phase3.py::test_load_profile_package_uses_embedded_profile_graph PASSED [ 82%]
tests/test_spirit_safe_phase3.py::test_get_profile_graph_builds_from_manifest_fixture PASSED [ 82%]
tests/test_spirit_safe_phase3.py::test_resolve_profile_link_matches_statement_uri PASSED [ 82%]
tests/test_spirit_safe_phase3.py::test_create_curation_packet_single_mode PASSED [ 83%]
tests/test_spirit_safe_phase3.py::test_create_curation_packet_bulk_mode PASSED [ 83%]
tests/test_spirit_safe_phase3.py::test_validate_packet_structure_reports_invalid_cross_reference PASSED [ 83%]
tests/test_spirit_safe_value_lists.py::test_hydrate_value_lists_from_cache_writes_query_and_cache PASSED [ 83%]
tests/test_spirit_safe_value_lists.py::test_hydrate_value_lists_keeps_existing_cache_on_failure PASSED [ 84%]
tests/test_still_charger.py::test_build_packet_expands_linked_profiles_from_graph PASSED [ 84%]
tests/test_still_charger.py::test_build_packet_value_list_routes_use_statement_uris_and_item_counts PASSED [ 84%]
tests/test_still_charger.py::test_charge_packet_by_profile_id PASSED     [ 84%]
tests/test_still_charger.py::test_charge_packet_reject_unknown_statements_without_specificationless PASSED [ 85%]
tests/test_still_charger.py::test_charge_packet_allows_unknown_statements_with_specificationless PASSED [ 85%]
tests/test_utilities_name_resolution.py::test_resolve_name_passthrough_identifier PASSED [ 85%]
tests/test_utilities_name_resolution.py::test_resolve_name_from_map_before_search PASSED [ 86%]
tests/test_utilities_name_resolution.py::test_resolve_unique_exact_item_label PASSED [ 86%]
tests/test_utilities_name_resolution.py::test_resolve_ambiguous_label_returns_none PASSED [ 86%]
tests/test_utilities_name_resolution.py::test_resolve_with_entity_type_restriction PASSED [ 86%]
tests/test_wikibase_orchestration.py::test_build_wikibase_write_plan_pipeline_without_shipper PASSED [ 87%]
tests/test_wikibase_orchestration.py::test_build_wikibase_write_plan_pipeline_with_shipper PASSED [ 87%]
tests/test_wizard_review_messages.py::test_collect_review_consequences_only_for_empty_statements PASSED [ 87%]
tests/test_wizard_review_messages.py::test_group_review_items_groups_consequences_and_notices PASSED [ 88%]
tests/test_wizard_validation_bridge.py::test_validate_inline_value_coerces_wikibase_item_qid PASSED [ 88%]
tests/test_wizard_validation_bridge.py::test_validate_entity_packet_data_reports_datatype_errors PASSED [ 88%]
tests/test_wizard_validation_bridge.py::test_validate_entity_packet_data_warns_missing_expected_reference PASSED [ 88%]
tests/wikibase/test_cache.py::test_build_entity_profile_identifiers_sparql_query PASSED [ 89%]
tests/wikibase/test_cache.py::test_extract_entity_profile_identifiers PASSED [ 89%]
tests/wikibase/test_cache.py::test_build_wikibase_cache_reconciles_and_writes_summary PASSED [ 89%]
tests/wikibase/test_cache.py::test_build_wikibase_cache_tracks_missing_ids PASSED [ 89%]
tests/wikibase/test_ontology.py::test_fetch_ontology_index_success PASSED [ 90%]
tests/wikibase/test_ontology.py::test_fetch_ontology_index_empty PASSED  [ 90%]
tests/wikibase/test_ontology.py::test_dd_ontology_index_get_ids_for_class PASSED [ 90%]
tests/wikibase/test_ontology.py::test_dd_ontology_index_frozen PASSED    [ 91%]
tests/wikibase/test_ontology.py::test_fetch_profile_ids_success PASSED   [ 91%]
tests/wikibase/test_ontology.py::test_fetch_profile_ids_empty PASSED     [ 91%]
tests/wikibase/test_ontology.py::test_build_profile_ids_sparql_query PASSED [ 91%]
tests/wikibase/test_ontology.py::test_build_discovery_sparql_query PASSED [ 92%]
tests/wikibase/test_ontology.py::test_collect_internal_item_ids_from_mainsnak PASSED [ 92%]
tests/wikibase/test_ontology.py::test_collect_internal_item_ids_from_qualifiers PASSED [ 92%]
tests/wikibase/test_ontology.py::test_collect_internal_item_ids_skips_non_entityid PASSED [ 93%]
tests/wikibase/test_ontology.py::test_collect_internal_item_ids_empty_claims PASSED [ 93%]
tests/wikibase/test_ontology.py::test_fetch_profile_graph_single_profile_no_links PASSED [ 93%]
tests/wikibase/test_ontology.py::test_fetch_profile_graph_follows_internal_links PASSED [ 93%]
tests/wikibase/test_ontology.py::test_fetch_profile_graph_missing_items_logged PASSED [ 94%]
tests/wikibase/test_ontology.py::test_fetch_profile_graph_empty_profile_ids PASSED [ 94%]
tests/wikibase/test_ontology.py::test_fetch_profile_graph_respects_max_hops PASSED [ 94%]
tests/wikibase/test_ontology.py::test_fetch_profile_graph_language_warning PASSED [ 94%]
tests/wikibase/test_ontology.py::test_fetch_profile_graph_no_warning_for_mul PASSED [ 95%]
tests/wikibase/test_ontology.py::test_get_label_for_language_found PASSED [ 95%]
tests/wikibase/test_ontology.py::test_get_label_for_language_fallback_to_mul PASSED [ 95%]
tests/wikibase/test_ontology.py::test_get_label_for_language_any_available PASSED [ 96%]
tests/wikibase/test_ontology.py::test_get_label_for_language_empty PASSED [ 96%]
tests/wikibase/test_ontology.py::test_get_monolingualtext_for_language_found PASSED [ 96%]
tests/wikibase/test_ontology.py::test_get_monolingualtext_for_language_fallback_to_mul PASSED [ 96%]
tests/wikibase/test_ontology.py::test_get_monolingualtext_for_language_empty PASSED [ 97%]
tests/wikibase/test_ontology.py::test_get_monolingualtext_skips_non_monolingualtext PASSED [ 97%]
tests/wikibase/test_ontology.py::test_resolve_statement_guidance_from_statement_item PASSED [ 97%]
tests/wikibase/test_ontology.py::test_resolve_statement_guidance_fallback_to_primitive PASSED [ 98%]
tests/wikibase/test_ontology.py::test_resolve_statement_guidance_returns_none_when_not_found PASSED [ 98%]
tests/wikibase/test_ontology.py::test_resolve_statement_guidance_missing_items_returns_none PASSED [ 98%]
tests/wikibase/test_ontology.py::test_resolve_profile_statement_guidance_prefers_profile_qualifier PASSED [ 98%]
tests/wikibase/test_ontology.py::test_resolve_profile_statement_guidance_falls_back_to_statement_item PASSED [ 99%]
tests/wikibase/test_ontology.py::test_resolve_profile_statement_guidance_falls_back_to_primitive_item PASSED [ 99%]
tests/wikibase/test_ontology.py::test_export_profile_graph_to_entity_cache_writes_entity_files PASSED [ 99%]
tests/wikibase/test_ontology.py::test_export_profile_graph_to_entity_cache_honors_ignore_ids PASSED [100%]

=============================== warnings summary ===============================
gkc/entity_profile.py:17
  /Users/sky/code/gkc/gkc/entity_profile.py:17: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class GKCEntityProfile(BaseModel):

.venv/lib/python3.12/site-packages/pyshexc/parser/ShExDocLexer.py:4
  /Users/sky/code/gkc/.venv/lib/python3.12/site-packages/pyshexc/parser/ShExDocLexer.py:4: DeprecationWarning: typing.io is deprecated, import directly from typing instead. typing.io will be removed in Python 3.12.
    from typing.io import TextIO

tests/wikibase/test_ontology.py::test_fetch_ontology_index_success
tests/wikibase/test_ontology.py::test_fetch_ontology_index_empty
  /Users/sky/code/gkc/gkc/wikibase/ontology.py:320: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    fetched_at=datetime.utcnow().isoformat() + "Z",

tests/wikibase/test_ontology.py::test_fetch_profile_graph_single_profile_no_links
tests/wikibase/test_ontology.py::test_fetch_profile_graph_follows_internal_links
tests/wikibase/test_ontology.py::test_fetch_profile_graph_missing_items_logged
tests/wikibase/test_ontology.py::test_fetch_profile_graph_empty_profile_ids
tests/wikibase/test_ontology.py::test_fetch_profile_graph_respects_max_hops
tests/wikibase/test_ontology.py::test_export_profile_graph_to_entity_cache_writes_entity_files
tests/wikibase/test_ontology.py::test_export_profile_graph_to_entity_cache_honors_ignore_ids
  /Users/sky/code/gkc/gkc/wikibase/ontology.py:386: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    fetched_at=datetime.utcnow().isoformat() + "Z",

tests/wikibase/test_ontology.py::test_export_profile_graph_to_entity_cache_writes_entity_files
tests/wikibase/test_ontology.py::test_export_profile_graph_to_entity_cache_honors_ignore_ids
  /Users/sky/code/gkc/gkc/wikibase/ontology.py:473: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    exported_at = datetime.utcnow().isoformat() + "Z"

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.12.2-final-0 _______________

Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
gkc/__init__.py                                       24      0   100%
gkc/auth.py                                          142     28    80%   137-147, 201, 222, 233, 247, 290-292, 344-347, 414-435, 549-551
gkc/bottler.py                                       173    143    17%   22-23, 35, 59-114, 129, 137, 150, 157, 164-188, 199, 212-254, 270-280, 285-289, 300-346, 350-368, 372-388
gkc/cli.py                                          1259    471    63%   90-91, 1236, 1262-1271, 1297-1300, 1304-1311, 1341-1344, 1360-1361, 1377-1382, 1422-1435, 1445, 1447, 1450, 1471, 1483, 1485, 1505-1560, 1562, 1576-1581, 1590, 1600-1601, 1611, 1613, 1616, 1645, 1651, 1666-1671, 1683, 1693-1694, 1718, 1721, 1729-1734, 1743, 1753-1754, 1762, 1780-1782, 1803-1804, 1867, 1890-1893, 1899, 1917, 1920, 1926, 1928, 1937-1939, 1960, 2028-2029, 2043, 2080-2084, 2087, 2093, 2121-2144, 2152, 2161, 2164, 2183-2184, 2210, 2270, 2275, 2280, 2286, 2331-2332, 2339-2376, 2381-2414, 2419-2465, 2471-2498, 2503-2529, 2534-2568, 2573-2615, 2620-2654, 2659-2688, 2693-2724, 2739, 2746, 2750-2753, 2769-2771, 2790-2793, 2800-2880, 2894-2895, 2898, 2902-2915, 2939-2947, 3030-3032, 3055, 3057, 3078, 3082-3083, 3086, 3090-3104, 3124-3134, 3140-3154, 3241, 3244-3246, 3256, 3271-3272, 3278, 3332-3334, 3355, 3367-3368, 3388-3400, 3440, 3452-3453, 3465, 3501-3503, 3525, 3538-3541, 3558-3595, 3598-3602, 3606
gkc/cooperage.py                                     179     53    70%   59-63, 70-81, 86, 90, 93, 97, 103, 119-124, 126, 135, 140-146, 165, 168, 171, 174, 178, 182, 188, 211, 241-242, 274-282, 291, 296-297, 338
gkc/entity_profile.py                                 18      2    89%   101, 106
gkc/fermenter.py                                     162    114    30%   75, 81-94, 117, 129-146, 157-183, 191-209, 224-245, 260, 265, 274, 295-334, 342-359, 379, 406-457, 483-507, 515-529
gkc/mash/__init__.py                                   3      0   100%
gkc/mash/core.py                                     775    267    66%   60-64, 77-87, 90-104, 111-114, 117-135, 197, 201, 205, 209, 219-223, 257, 262-263, 278, 311, 315, 336, 371, 400, 483-487, 496, 507-508, 514, 534-535, 542-543, 591-603, 632, 712, 731, 764, 895, 946, 961, 979, 984, 1002, 1099, 1109, 1111-1116, 1147, 1155-1167, 1199, 1204, 1213-1214, 1282-1287, 1304, 1313, 1359-1361, 1384-1385, 1406-1407, 1423-1426, 1436-1439, 1456-1478, 1496-1519, 1530-1554, 1570-1581, 1591-1626, 1644-1662, 1680-1705, 1732, 1736, 1744, 1747-1752, 1755-1760, 1763-1765, 1770-1781, 1873-1930, 1953, 1966, 1978, 1983, 1989, 2029
gkc/mash/protocols.py                                  8      0   100%
gkc/mash_formatters.py                                78      4    95%   90, 153-154, 165
gkc/profiles/__init__.py                               5      0   100%
gkc/profiles/base/__init__.py                          6      0   100%
gkc/profiles/base/barrel_profile.py                   13      2    85%   64, 99
gkc/profiles/base/entity_profile.py                   23      1    96%   95
gkc/profiles/base/mash_bill.py                         6      1    83%   12
gkc/profiles/base/modulation_profile.py               15      1    93%   125
gkc/profiles/base/property_definition.py              19      0   100%
gkc/profiles/forms/__init__.py                         3      0   100%
gkc/profiles/forms/draft_manager.py                   20     10    50%   23-26, 30-32, 36-37, 41
gkc/profiles/forms/streamlit_app.py                  480    386    20%   30, 34-36, 40-42, 50-52, 57, 62, 69-70, 77, 80, 93, 97, 142, 153-157, 165-203, 207-210, 214-222, 226-245, 249-263, 267-271, 275-286, 290-305, 309-312, 316-334, 338-360, 367-400, 404-435, 439-456, 460-492, 496-516, 520-541, 545-558, 562-618, 622-634, 638-705, 709-739, 743
gkc/profiles/forms/validation_bridge.py              131     59    55%   42, 65, 77, 100, 124, 128, 133, 137-146, 149-158, 162, 179-183, 205-214, 219-229, 245-246, 257-266, 269-296, 300-309, 313-357
gkc/profiles/forms/widgets.py                        119     93    22%   41-55, 62-82, 89, 102-116, 126-162, 170-208, 215-243, 250-296, 303, 316, 330-331
gkc/profiles/forms/wizard/__init__.py                  3      0   100%
gkc/profiles/forms/wizard/step_base.py                14      5    64%   31-33, 47, 62
gkc/profiles/forms/wizard/steps.py                   279    246    12%   15-22, 26-31, 35-41, 45-47, 51-53, 57, 61, 65, 69, 73, 77-80, 87-94, 98-101, 108-142, 152-209, 212-216, 223-265, 268, 275-297, 302-361, 370-401, 406-436, 441-481, 484-488
gkc/profiles/generators/__init__.py                    3      0   100%
gkc/profiles/generators/form_generator.py             22      1    95%   121
gkc/profiles/generators/pydantic_generator.py        159     58    64%   104, 107, 113, 120, 129, 136-147, 154, 160-165, 170-175, 178-183, 191, 195, 202, 207-212, 219-224, 233, 238-243, 251-252, 272, 296-301, 318-336, 351, 357, 363-364
gkc/profiles/graph.py                                 99     11    89%   21, 25, 28, 135, 144, 203-213, 357-360
gkc/profiles/loaders/__init__.py                       2      0   100%
gkc/profiles/loaders/yaml_loader.py                   33      4    88%   109-110, 131-132
gkc/profiles/models.py                               225     25    89%   38, 42, 52, 54, 58, 83, 163, 230, 238, 366, 373, 422-424, 427, 435, 522, 693, 715, 736-739, 743, 747
gkc/profiles/validation/__init__.py                    1      0   100%
gkc/profiles/validation/models.py                     13      0   100%
gkc/profiles/validation/validator.py                 136     32    76%   79, 154-155, 196, 198-202, 219, 222, 228, 237, 246, 255, 258, 265, 273-278, 286, 290, 297, 300, 312-317, 324, 327-332, 339, 342-347
gkc/profiles/validation/wikidata_normalizer.py       147     22    85%   96-104, 108-116, 123, 126-134, 155, 159, 174, 178, 184, 199, 201, 205, 214-216, 227, 244-245
gkc/profiles/validators/__init__.py                    2      0   100%
gkc/profiles/validators/entity_json_validator.py     166     58    65%   97-100, 104-105, 110-111, 114-115, 120, 129-134, 156-159, 162-168, 196-227, 236-296, 366, 404-415
gkc/runtime_config.py                                 19      0   100%
gkc/shex.py                                          103     35    66%   115, 122-130, 152-153, 160-166, 180, 195, 199, 212-214, 250-251, 255, 264, 287-298
gkc/shipper.py                                       268     57    79%   146, 168, 341, 362, 400-401, 444, 447, 456-457, 468, 479, 507-508, 589, 598, 608, 621, 741-743, 793, 796-797, 817-825, 828-830, 853-869, 905-913, 961, 1013-1014, 1022, 1038-1042
gkc/sitelinks.py                                      86     73    15%   48-51, 64-83, 101-144, 175-191, 206-224, 247-253, 274-275
gkc/sparql.py                                        145     48    67%   21-22, 104, 202-203, 370-371, 408-419, 468-496, 534-574
gkc/spirit_safe.py                                  1169    258    78%   85, 211-213, 241, 244, 255-266, 333, 341, 440-441, 491-508, 523-527, 539-543, 601, 708-734, 761, 783, 797-799, 817-820, 893, 996, 1000, 1024-1034, 1059-1067, 1116-1117, 1121, 1160-1161, 1269-1270, 1293-1294, 1312, 1318, 1325, 1335, 1486-1493, 1511, 1515, 1519, 1527, 1531, 1535, 1556, 1570, 1580, 1607, 1630, 1632, 1636, 1771, 1780-1783, 1786, 1797, 1809, 1819, 1839-1847, 1859-1865, 1882-1888, 1919, 1975-1982, 1989-1995, 2003-2009, 2035, 2042, 2053, 2057, 2090-2098, 2103, 2110-2113, 2116-2121, 2128, 2201-2206, 2215, 2242, 2246, 2249, 2256, 2262, 2271-2272, 2276-2285, 2294-2297, 2305-2318, 2469-2470, 2488, 2505-2507, 2513-2518, 2545, 2552-2557, 2567, 2578, 2583, 2591-2592, 2604, 2620, 2668-2677, 2727, 2780, 2790, 2802, 2809
gkc/still_charger.py                                 285    108    62%   59, 75, 97, 101, 104, 110-111, 138, 143, 147, 151, 156, 192, 196, 200, 204, 223-230, 235-236, 291, 355-495, 525-528, 551, 561, 568, 598-599, 607-616
gkc/utilities.py                                      35      5    86%   31, 59, 63, 144, 162
gkc/wikibase/__init__.py                               4      0   100%
gkc/wikibase/cache.py                                129     19    85%   74, 214, 218-220, 232, 236-243, 251-252, 258, 264-265
gkc/wikibase/ontology.py                             275     32    88%   172, 176-178, 186-189, 195, 198, 225, 228, 294, 398, 524-525, 532-533, 629, 636, 639, 641, 645, 650, 654-655, 747, 751, 754, 756, 760, 763
gkc/wikibase/orchestration.py                         66     34    48%   74, 78, 93, 146-243
--------------------------------------------------------------------------------
TOTAL                                               7549   2766    63%
Coverage HTML written to dir htmlcov
====================== 359 passed, 13 warnings in 25.68s =======================
✓ All tests passed

📚 Running MkDocs build check...
✓ MkDocs build passed

📦 Testing package build...
Building gkc (0.1.0)
  - Building sdist
  - Built gkc-0.1.0.tar.gz
  - Building wheel
  - Built gkc-0.1.0-py3-none-any.whl
✓ Package builds successfully

==================================
✅ All pre-merge checks passed!
==================================

You can now:
  - Create a pull request
  - Merge to main
  - Tag a release for PyPI publishing\n- ============================= test session starts ==============================
platform darwin -- Python 3.12.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/sky/code/gkc
configfile: pyproject.toml
plugins: cov-6.3.0
collected 5 items

tests/test_wizard_review_messages.py ..                                  [ 40%]
tests/test_wizard_validation_bridge.py ...                               [100%]

=============================== warnings summary ===============================
gkc/entity_profile.py:17
  /Users/sky/code/gkc/gkc/entity_profile.py:17: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class GKCEntityProfile(BaseModel):

.venv/lib/python3.12/site-packages/pyshexc/parser/ShExDocLexer.py:4
  /Users/sky/code/gkc/.venv/lib/python3.12/site-packages/pyshexc/parser/ShExDocLexer.py:4: DeprecationWarning: typing.io is deprecated, import directly from typing instead. typing.io will be removed in Python 3.12.
    from typing.io import TextIO

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.12.2-final-0 _______________

Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
gkc/__init__.py                                       24      2    92%   190, 201
gkc/auth.py                                          142    116    18%   55-56, 60, 131-165, 182-247, 258, 270-295, 323-347, 350-355, 372-374, 388-390, 399, 414-435, 457-477, 499-502, 544-553, 556-557
gkc/bottler.py                                       173    143    17%   22-23, 35, 59-114, 129, 137, 150, 157, 164-188, 199, 212-254, 270-280, 285-289, 300-346, 350-368, 372-388
gkc/cli.py                                          1259   1259     0%   6-3606
gkc/cooperage.py                                     179    151    16%   53-64, 68-81, 85-103, 113-148, 152-182, 186-190, 210-222, 234-322, 338
gkc/entity_profile.py                                 18      2    89%   101, 106
gkc/fermenter.py                                     162    114    30%   75, 81-94, 117, 129-146, 157-183, 191-209, 224-245, 260, 265, 274, 295-334, 342-359, 379, 406-457, 483-507, 515-529
gkc/mash/__init__.py                                   3      0   100%
gkc/mash/core.py                                     775    614    21%   54-67, 77-87, 90-104, 111-114, 117-135, 183-223, 228-233, 242-245, 253-279, 291-345, 366-429, 456, 475-489, 494-498, 503-508, 513-515, 520-535, 540-543, 591-603, 617-665, 705-716, 724-734, 742, 756, 764, 792, 809-812, 825, 853, 867, 880, 895, 921, 933, 946, 961, 972-984, 1000-1035, 1050-1070, 1098-1116, 1146-1167, 1198-1214, 1246-1260, 1282-1287, 1304, 1312-1322, 1348-1363, 1384-1385, 1406-1407, 1423-1426, 1436-1439, 1456-1478, 1496-1519, 1530-1554, 1570-1581, 1591-1626, 1644-1662, 1680-1705, 1727-1781, 1808, 1822, 1847-1851, 1873-1930, 1948, 1952-1957, 1961, 1965-1978, 1982-2004, 2013, 2017-2020, 2024, 2028-2034, 2038-2041
gkc/mash/protocols.py                                  8      0   100%
gkc/mash_formatters.py                                78     78     0%   6-173
gkc/profiles/__init__.py                               5      0   100%
gkc/profiles/base/__init__.py                          6      6     0%   14-20
gkc/profiles/base/barrel_profile.py                   13     13     0%   14-109
gkc/profiles/base/entity_profile.py                   23     23     0%   10-163
gkc/profiles/base/mash_bill.py                         6      6     0%   1-12
gkc/profiles/base/modulation_profile.py               15     15     0%   13-125
gkc/profiles/base/property_definition.py              19     19     0%   13-125
gkc/profiles/forms/__init__.py                         3      0   100%
gkc/profiles/forms/draft_manager.py                   20     10    50%   23-26, 30-32, 36-37, 41
gkc/profiles/forms/streamlit_app.py                  480    386    20%   30, 34-36, 40-42, 50-52, 57, 62, 69-70, 77, 80, 93, 97, 142, 153-157, 165-203, 207-210, 214-222, 226-245, 249-263, 267-271, 275-286, 290-305, 309-312, 316-334, 338-360, 367-400, 404-435, 439-456, 460-492, 496-516, 520-541, 545-558, 562-618, 622-634, 638-705, 709-739, 743
gkc/profiles/forms/validation_bridge.py              131     59    55%   42, 65, 77, 100, 124, 128, 133, 137-146, 149-158, 162, 179-183, 205-214, 219-229, 245-246, 257-266, 269-296, 300-309, 313-357
gkc/profiles/forms/widgets.py                        119     93    22%   41-55, 62-82, 89, 102-116, 126-162, 170-208, 215-243, 250-296, 303, 316, 330-331
gkc/profiles/forms/wizard/__init__.py                  3      0   100%
gkc/profiles/forms/wizard/step_base.py                14      5    64%   31-33, 47, 62
gkc/profiles/forms/wizard/steps.py                   279    246    12%   15-22, 26-31, 35-41, 45-47, 51-53, 57, 61, 65, 69, 73, 77-80, 87-94, 98-101, 108-142, 152-209, 212-216, 223-265, 268, 275-297, 302-361, 370-401, 406-436, 441-481, 484-488
gkc/profiles/generators/__init__.py                    3      0   100%
gkc/profiles/generators/form_generator.py             22     13    41%   29, 45, 54-104, 120-122
gkc/profiles/generators/pydantic_generator.py        159    141    11%   41-42, 58-84, 93-262, 265-266, 270-273, 286-288, 292-301, 318-336, 350-364
gkc/profiles/graph.py                                 99     99     0%   10-406
gkc/profiles/loaders/__init__.py                       2      0   100%
gkc/profiles/loaders/yaml_loader.py                   33     17    48%   35-36, 60-61, 84-85, 107-111, 130-132, 135-136, 140
gkc/profiles/models.py                               225     72    68%   36-42, 50-58, 80-84, 162-164, 230, 235, 238, 365-367, 372-376, 422-424, 427, 432, 435, 483-487, 516-523, 640, 645, 648, 693, 712-715, 736-739, 743, 747, 765, 782-783, 804-807
gkc/profiles/validation/__init__.py                    1      0   100%
gkc/profiles/validation/models.py                     13      0   100%
gkc/profiles/validation/validator.py                 136    109    20%   79, 99-101, 123-140, 153-155, 167-183, 188-212, 216-334, 338-347
gkc/profiles/validation/wikidata_normalizer.py       147    129    12%   90-149, 153-168, 172-194, 198-282
gkc/profiles/validators/__init__.py                    2      2     0%   8-15
gkc/profiles/validators/entity_json_validator.py     166    166     0%   8-415
gkc/runtime_config.py                                 19      5    74%   36-42
gkc/shex.py                                          103     86    17%   85-95, 109-132, 146-168, 180, 194-216, 234-237, 249-283, 287-298
gkc/shipper.py                                       268    209    22%   111, 127, 146, 168, 253, 275-277, 297-321, 340-415, 443-522, 538-541, 582-691, 723-743, 780-835, 853-869, 883, 900-920, 952-971, 1005-1027, 1038-1042, 1057-1058, 1066, 1081, 1089
gkc/sitelinks.py                                      86     73    15%   48-51, 64-83, 101-144, 175-191, 206-224, 247-253, 274-275
gkc/sparql.py                                        145    116    20%   21-22, 57-61, 84-104, 120-126, 176-203, 225-246, 269-279, 299-305, 329-330, 352-353, 368-371, 380-381, 408-419, 429-430, 468-496, 534-574
gkc/spirit_safe.py                                  1169    973    17%   67-71, 82-88, 118-124, 140, 208-213, 237-266, 286-294, 319-351, 391-395, 406, 417-418, 433-441, 460-470, 487-508, 523-527, 539-543, 571-573, 590-607, 642-669, 708-734, 752-766, 778-820, 854-893, 906-928, 943-946, 979-1074, 1110-1128, 1142-1169, 1191-1238, 1260-1299, 1311-1318, 1322-1325, 1329-1339, 1397-1401, 1405-1409, 1413-1435, 1450-1475, 1480-1501, 1506-1546, 1551-1564, 1567-1570, 1575-1596, 1601-1617, 1629-1699, 1710-1721, 1726-1744, 1761-1788, 1793-1798, 1803-1810, 1817-1820, 1828-1849, 1856-1866, 1871-1876, 1879-1889, 1892-1904, 1909-1912, 1917-1928, 1933-1936, 1939-1943, 1946-1950, 1953-1960, 1970-1982, 1987-1996, 2001-2010, 2013-2014, 2017-2022, 2032-2045, 2052-2064, 2067-2072, 2077-2082, 2089-2099, 2102-2105, 2110-2113, 2116-2121, 2124-2131, 2134-2137, 2167-2171, 2194-2220, 2235, 2241-2249, 2255-2263, 2269-2272, 2276-2285, 2289-2297, 2301-2318, 2322-2326, 2338-2399, 2421-2430, 2449-2454, 2459-2470, 2487-2533, 2541-2557, 2566-2592, 2600-2624, 2636-2641, 2651-2677, 2693-2760, 2776-2811
gkc/still_charger.py                                 285    255    11%   47-52, 57-61, 66-68, 73-77, 85-123, 131-179, 187-238, 274-327, 355-495, 505-528, 544-568, 590-660
gkc/utilities.py                                      35     30    14%   30-33, 58-68, 89-94, 127-164
gkc/wikibase/__init__.py                               4      0   100%
gkc/wikibase/cache.py                                129     96    26%   51-52, 69-81, 98-197, 213-220, 224-232, 236-243, 247-258, 262-265
gkc/wikibase/ontology.py                             275    227    17%   57, 123-124, 155-156, 171-178, 183-189, 194-205, 221-235, 245-254, 280-316, 342-351, 384-423, 456-500, 510-525, 530-533, 559-566, 590-606, 626-657, 697-710, 741-774
gkc/wikibase/orchestration.py                         66     44    33%   73-112, 146-243
--------------------------------------------------------------------------------
TOTAL                                               7549   6222    18%
Coverage HTML written to dir htmlcov
======================== 5 passed, 2 warnings in 5.94s =========================\n\n## Notes\n- This is a solid jump-off point for remaining Wizard phases (value-list integration and linked-profile statement-level flows).