### PR TITLE
Implement language completeness gating and export diagnostics

### DIFF
--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -460,6 +460,13 @@ def _build_parser() -> argparse.ArgumentParser:
             "(writes <output>/<QID>.json). If omitted, prints JSON to stdout"
         ),
     )
+    profile_export_json.add_argument(
+        "--summary-output",
+        help=(
+            "Optional summary JSON path to write/merge profile export diagnostics "
+            "(defaults to <cache_entities_dir>/../refresh/last_run_summary.json)"
+        ),
+    )
     _add_profile_source_args(profile_export_json)
     profile_export_json.set_defaults(
         handler=_handle_profile_export_json,
@@ -2100,6 +2107,20 @@ def _handle_profile_export_json(args: argparse.Namespace) -> dict[str, Any]:
                 output_dir=args.output,
                 profile_ids=selected_profile_ids or None,
             )
+
+            summary_output = _resolve_profile_export_summary_output(
+                cache_entities_dir=cache_entities_dir,
+                requested_summary_output=args.summary_output,
+            )
+            summary_output_file: Optional[str] = None
+            if summary_output is not None:
+                summary_output_file = _merge_profile_export_summary(
+                    summary_path=summary_output,
+                    export_result=export_result,
+                    requested_profile_ids=selected_profile_ids,
+                    cache_entities_dir=cache_entities_dir,
+                )
+
             message = (
                 "Exported JSON entity profiles to "
                 f"{export_result.output_dir} ({len(export_result.written_ids)} files)"
@@ -2110,7 +2131,14 @@ def _handle_profile_export_json(args: argparse.Namespace) -> dict[str, Any]:
                 "profile_ids_requested": selected_profile_ids,
                 "written_count": len(export_result.written_ids),
                 "written_ids": export_result.written_ids,
+                "skipped_count": len(export_result.skipped_ids),
+                "skipped_ids": export_result.skipped_ids,
+                "failure_count": len(export_result.failures),
+                "failures": export_result.failures,
+                "language_filtering": export_result.language_filtering,
             }
+            if summary_output_file:
+                details["summary_output_file"] = summary_output_file
             return {
                 "command": args.command_path,
                 "ok": True,
@@ -2144,6 +2172,63 @@ def _handle_profile_export_json(args: argparse.Namespace) -> dict[str, Any]:
         raise CLIError(str(exc)) from exc
     finally:
         _restore_source_override(previous_source, source_overridden)
+
+
+def _resolve_profile_export_summary_output(
+    *,
+    cache_entities_dir: Path,
+    requested_summary_output: Optional[str],
+) -> Optional[Path]:
+    if requested_summary_output:
+        return Path(requested_summary_output)
+
+    return cache_entities_dir.resolve().parent / "refresh" / "last_run_summary.json"
+
+
+def _merge_profile_export_summary(
+    *,
+    summary_path: Path,
+    export_result: Any,
+    requested_profile_ids: list[str],
+    cache_entities_dir: Path,
+) -> str:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    base_payload: dict[str, Any] = {}
+    if summary_path.exists():
+        try:
+            parsed = json.loads(summary_path.read_text(encoding="utf-8"))
+            if isinstance(parsed, dict):
+                base_payload = parsed
+        except Exception:
+            base_payload = {}
+
+    metadata = base_payload.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    metadata.setdefault("cache_dir", str(cache_entities_dir.resolve()))
+    base_payload["metadata"] = metadata
+
+    profile_export = {
+        "summary": {
+            "requested_count": len(requested_profile_ids),
+            "written_count": len(export_result.written_ids),
+            "skipped_count": len(export_result.skipped_ids),
+            "failure_count": len(export_result.failures),
+            "language_filtered_count": len(export_result.language_filtering),
+        },
+        "requested_profile_ids": requested_profile_ids,
+        "written_ids": export_result.written_ids,
+        "skipped_ids": export_result.skipped_ids,
+        "failures": export_result.failures,
+        "language_filtering": export_result.language_filtering,
+        "output_dir": export_result.output_dir,
+    }
+    base_payload["profile_export"] = profile_export
+
+    summary_path.write_text(json.dumps(base_payload, indent=2), encoding="utf-8")
+    return str(summary_path.resolve())
 
 
 def _handle_profile_lookups_hydrate(args: argparse.Namespace) -> dict[str, Any]:

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -1402,14 +1402,46 @@ class EntityProfileJsonBuilder:
 
     def build_all(self) -> list[dict[str, Any]]:
         """Build JSON documents for every cache entity typed as a profile."""
+        return self.build_all_with_report()["documents"]
+
+    def build_all_with_report(self) -> dict[str, Any]:
+        """Build JSON profile documents and collect language-policy diagnostics."""
         results: list[dict[str, Any]] = []
+        skipped_profiles: list[dict[str, Any]] = []
+        language_filtering: list[dict[str, Any]] = []
+
         for doc in self._cache_index.values():
             if self._is_profile_item(doc):
-                results.append(self.build_one(doc))
-        return results
+                try:
+                    built, filtering_report = self._build_one_with_language_policy(doc)
+                    results.append(built)
+                    if filtering_report.get("excluded_languages"):
+                        language_filtering.append(filtering_report)
+                except EntityProfileLanguageCoverageError as exc:
+                    skipped_profiles.append(
+                        {
+                            "profile_id": exc.profile_id,
+                            "code": "mul_language_coverage_failed",
+                            "message": str(exc),
+                            "missing_paths": exc.missing_paths,
+                        }
+                    )
+
+        return {
+            "documents": results,
+            "skipped_profiles": skipped_profiles,
+            "language_filtering": language_filtering,
+        }
 
     def build_one(self, wikibase_item: dict[str, Any]) -> dict[str, Any]:
         """Build one JSON profile document from a single cache entity."""
+        built, _ = self._build_one_with_language_policy(wikibase_item)
+        return built
+
+    def _build_one_with_language_policy(
+        self, wikibase_item: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Build one JSON profile and enforce profile language completeness policy."""
         entity_uri = f"{self.entity_prefix}{wikibase_item.get('entity_id', '')}"
 
         identification = {
@@ -1432,12 +1464,187 @@ class EntityProfileJsonBuilder:
             entity_uri=entity_uri,
         )
 
-        return {
+        profile_doc = {
             "entity": entity_uri,
             "identification": identification,
             "statements": statements,
             "metadata": metadata,
         }
+
+        return self._apply_language_completeness_policy(profile_doc)
+
+    def _apply_language_completeness_policy(
+        self, profile_doc: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        profile_id = str(profile_doc.get("entity", "")).rstrip("/").split("/")[-1]
+        candidates = set(self._collect_languages(profile_doc))
+        candidates.add("mul")
+
+        missing_by_language: dict[str, list[str]] = {}
+        for language in sorted(candidates):
+            missing = self._missing_language_coverage(profile_doc, language)
+            if missing:
+                missing_by_language[language] = missing
+
+        mul_missing = missing_by_language.get("mul", [])
+        if mul_missing:
+            raise EntityProfileLanguageCoverageError(
+                profile_id=profile_id or "<unknown>",
+                missing_paths=mul_missing,
+            )
+
+        allowed_languages = {"mul"}
+        excluded_languages: list[dict[str, Any]] = []
+        for language in sorted(candidates):
+            if language == "mul":
+                continue
+            missing = missing_by_language.get(language, [])
+            if missing:
+                excluded_languages.append(
+                    {
+                        "language": language,
+                        "missing_paths": missing,
+                    }
+                )
+                continue
+            allowed_languages.add(language)
+
+        self._prune_profile_languages(profile_doc, allowed_languages)
+        self._recompute_profile_languages(profile_doc)
+
+        return profile_doc, {
+            "profile_id": profile_id,
+            "excluded_languages": excluded_languages,
+        }
+
+    def _missing_language_coverage(
+        self, profile_doc: dict[str, Any], language: str
+    ) -> list[str]:
+        missing: list[str] = []
+
+        metadata = profile_doc.get("metadata", {})
+        identification = profile_doc.get("identification", {})
+
+        labels = metadata.get("labels", {}) if isinstance(metadata, dict) else {}
+        descriptions = (
+            metadata.get("descriptions", {}) if isinstance(metadata, dict) else {}
+        )
+        aliases = metadata.get("aliases", {}) if isinstance(metadata, dict) else {}
+
+        if not self._metadata_has_label(labels, language):
+            missing.append(f"metadata.labels.{language}")
+
+        if not self._metadata_has_description(descriptions, language):
+            if language == "mul":
+                missing.append("metadata.descriptions.mul_or_en")
+            else:
+                missing.append(f"metadata.descriptions.{language}")
+
+        if aliases and not self._metadata_has_alias(aliases, language):
+            missing.append(f"metadata.aliases.{language}")
+
+        if not self._identification_has_prompt(identification, "labels", language):
+            missing.append(f"identification.labels.{language}.prompt")
+
+        if not self._identification_has_prompt(
+            identification, "descriptions", language
+        ):
+            missing.append(f"identification.descriptions.{language}.prompt")
+
+        if not self._identification_has_prompt(identification, "aliases", language):
+            missing.append(f"identification.aliases.{language}.prompt")
+
+        statements = profile_doc.get("statements", [])
+        for statement in self._iter_statement_nodes(statements):
+            entity = statement.get("entity", "<unknown>")
+            messages = statement.get("messages", {})
+            if not isinstance(messages, dict):
+                missing.append(f"statement:{entity}.messages.{language}.prompt")
+                continue
+            prompt = messages.get(language, {}).get("prompt")
+            if not isinstance(prompt, str) or not prompt.strip():
+                missing.append(f"statement:{entity}.messages.{language}.prompt")
+
+        return sorted(set(missing))
+
+    def _metadata_has_label(self, labels: Any, language: str) -> bool:
+        return isinstance(labels, dict) and isinstance(labels.get(language), str)
+
+    def _metadata_has_description(self, descriptions: Any, language: str) -> bool:
+        if not isinstance(descriptions, dict):
+            return False
+        if language == "mul":
+            mul_value = descriptions.get("mul")
+            en_value = descriptions.get("en")
+            return isinstance(mul_value, str) or isinstance(en_value, str)
+        return isinstance(descriptions.get(language), str)
+
+    def _metadata_has_alias(self, aliases: Any, language: str) -> bool:
+        if not isinstance(aliases, dict):
+            return False
+        values = aliases.get(language)
+        return isinstance(values, list) and any(
+            isinstance(value, str) and value.strip() for value in values
+        )
+
+    def _identification_has_prompt(
+        self, identification: Any, section_name: str, language: str
+    ) -> bool:
+        if not isinstance(identification, dict):
+            return False
+        section = identification.get(section_name, {})
+        if not isinstance(section, dict):
+            return False
+        payload = section.get(language, {})
+        if not isinstance(payload, dict):
+            return False
+        prompt = payload.get("prompt")
+        return isinstance(prompt, str) and bool(prompt.strip())
+
+    def _prune_profile_languages(
+        self, profile_doc: dict[str, Any], allowed_languages: set[str]
+    ) -> None:
+        identification = profile_doc.get("identification", {})
+        if isinstance(identification, dict):
+            for field_name in ("labels", "descriptions", "aliases"):
+                section = identification.get(field_name)
+                if isinstance(section, dict):
+                    for language in list(section.keys()):
+                        if language not in allowed_languages:
+                            section.pop(language, None)
+
+        metadata = profile_doc.get("metadata", {})
+        if isinstance(metadata, dict):
+            for field_name in ("labels", "descriptions", "aliases"):
+                section = metadata.get(field_name)
+                if isinstance(section, dict):
+                    for language in list(section.keys()):
+                        if language not in allowed_languages:
+                            section.pop(language, None)
+
+        statements = profile_doc.get("statements", [])
+        for statement in self._iter_statement_nodes(statements):
+            messages = statement.get("messages")
+            if isinstance(messages, dict):
+                for language in list(messages.keys()):
+                    if language not in allowed_languages:
+                        messages.pop(language, None)
+
+    def _recompute_profile_languages(self, profile_doc: dict[str, Any]) -> None:
+        metadata = profile_doc.get("metadata", {})
+        if not isinstance(metadata, dict):
+            return
+        metadata["languages"] = self._collect_languages(
+            {
+                "identification": profile_doc.get("identification", {}),
+                "statements": profile_doc.get("statements", []),
+                "metadata": {
+                    "labels": metadata.get("labels", {}),
+                    "descriptions": metadata.get("descriptions", {}),
+                    "aliases": metadata.get("aliases", {}),
+                },
+            }
+        )
 
     def _build_profile_metadata(
         self,
@@ -2142,12 +2349,27 @@ class EntityProfileJsonBuilder:
         )
 
 
+class EntityProfileLanguageCoverageError(ValueError):
+    """Raised when a profile fails required language completeness coverage."""
+
+    def __init__(self, profile_id: str, missing_paths: list[str]) -> None:
+        self.profile_id = profile_id
+        self.missing_paths = sorted(set(missing_paths))
+        super().__init__(
+            f"Profile '{profile_id}' failed required mul language coverage: "
+            + ", ".join(self.missing_paths)
+        )
+
+
 @dataclass(frozen=True)
 class EntityProfileJsonExportResult:
     """Summary of JSON entity profile export writes."""
 
     output_dir: str
     written_ids: list[str]
+    skipped_ids: list[str] = field(default_factory=list)
+    failures: list[dict[str, Any]] = field(default_factory=list)
+    language_filtering: list[dict[str, Any]] = field(default_factory=list)
 
 
 def build_entity_profile_json_documents(
@@ -2191,10 +2413,12 @@ def export_entity_profile_json_documents(
     Returns:
         Export result summary.
     """
-    documents = build_entity_profile_json_documents(
+    builder = EntityProfileJsonBuilder(
         cache_entities_dir=cache_entities_dir,
         entity_prefix=entity_prefix,
     )
+    build_result = builder.build_all_with_report()
+    documents = build_result["documents"]
 
     requested_ids = set(profile_ids or [])
     if requested_ids:
@@ -2220,6 +2444,15 @@ def export_entity_profile_json_documents(
     return EntityProfileJsonExportResult(
         output_dir=str(out_dir.resolve()),
         written_ids=sorted(written_ids),
+        skipped_ids=sorted(
+            [
+                str(item.get("profile_id"))
+                for item in build_result["skipped_profiles"]
+                if item.get("profile_id")
+            ]
+        ),
+        failures=build_result["skipped_profiles"],
+        language_filtering=build_result["language_filtering"],
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1589,7 +1589,8 @@ def test_profile_export_json_writes_output_directory(capsys, tmp_path):
                 "entity_id": "Q4",
                 "entity": {
                     "labels": {
-                        "en": {"value": "Tribal Government in the United States"}
+                        "mul": {"value": "Tribal Government in the United States"},
+                        "en": {"value": "Tribal Government in the United States"},
                     },
                     "descriptions": {"en": {"value": "Example profile"}},
                     "aliases": {},
@@ -1600,6 +1601,42 @@ def test_profile_export_json_writes_output_directory(capsys, tmp_path):
                                     "datavalue": {
                                         "value": {
                                             "id": "Q3",
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "P188": [
+                            {
+                                "mainsnak": {
+                                    "datavalue": {
+                                        "value": {
+                                            "text": "Enter label",
+                                            "language": "mul",
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "P189": [
+                            {
+                                "mainsnak": {
+                                    "datavalue": {
+                                        "value": {
+                                            "text": "Enter description",
+                                            "language": "mul",
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "P190": [
+                            {
+                                "mainsnak": {
+                                    "datavalue": {
+                                        "value": {
+                                            "text": "Enter aliases",
+                                            "language": "mul",
                                         }
                                     }
                                 }

--- a/tests/test_spirit_safe_entity_profile_json.py
+++ b/tests/test_spirit_safe_entity_profile_json.py
@@ -40,6 +40,19 @@ def _build_entity_claim_string(value: str) -> dict:
     }
 
 
+def _build_entity_claim_monolingual(text: str, language: str = "mul") -> dict:
+    return {
+        "mainsnak": {
+            "datavalue": {
+                "value": {
+                    "text": text,
+                    "language": language,
+                }
+            }
+        }
+    }
+
+
 def test_build_entity_profile_json_documents_from_cache_entities(tmp_path):
     """Build returns JSON entity profile docs for cache entities typed as Q3."""
     cache_entities_dir = tmp_path / "cache" / "entities"
@@ -48,11 +61,17 @@ def test_build_entity_profile_json_documents_from_cache_entities(tmp_path):
     payload = {
         "entity_id": "Q4",
         "entity": {
-            "labels": {"en": {"value": "Tribal Government in the United States"}},
+            "labels": {
+                "mul": {"value": "Tribal Government in the United States"},
+                "en": {"value": "Tribal Government in the United States"},
+            },
             "descriptions": {"en": {"value": "Example profile"}},
             "aliases": {},
             "claims": {
                 "P1": [_build_entity_claim_entity_id("Q3")],
+                "P188": [_build_entity_claim_monolingual("Enter label")],
+                "P189": [_build_entity_claim_monolingual("Enter description")],
+                "P190": [_build_entity_claim_monolingual("Enter aliases")],
             },
         },
     }
@@ -73,11 +92,17 @@ def test_export_entity_profile_json_documents_writes_qid_files(tmp_path):
     payload = {
         "entity_id": "Q4",
         "entity": {
-            "labels": {"en": {"value": "Tribal Government in the United States"}},
+            "labels": {
+                "mul": {"value": "Tribal Government in the United States"},
+                "en": {"value": "Tribal Government in the United States"},
+            },
             "descriptions": {"en": {"value": "Example profile"}},
             "aliases": {},
             "claims": {
                 "P1": [_build_entity_claim_entity_id("Q3")],
+                "P188": [_build_entity_claim_monolingual("Enter label")],
+                "P189": [_build_entity_claim_monolingual("Enter description")],
+                "P190": [_build_entity_claim_monolingual("Enter aliases")],
             },
         },
     }
@@ -109,6 +134,9 @@ def test_value_list_graph_includes_reference_and_qualifier_routes(tmp_path):
             "aliases": {},
             "claims": {
                 "P1": [_build_entity_claim_entity_id("Q3")],
+                "P188": [_build_entity_claim_monolingual("Enter label")],
+                "P189": [_build_entity_claim_monolingual("Enter description")],
+                "P190": [_build_entity_claim_monolingual("Enter aliases")],
                 "P157": [
                     {
                         "mainsnak": {
@@ -139,6 +167,7 @@ def test_value_list_graph_includes_reference_and_qualifier_routes(tmp_path):
                         _build_entity_claim_string("http://www.wikidata.org/entity/P31")
                     ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
+                    "P171": [_build_entity_claim_monolingual("Statement prompt")],
                 },
             },
         },
@@ -154,6 +183,7 @@ def test_value_list_graph_includes_reference_and_qualifier_routes(tmp_path):
                     ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
                     "P161": [_build_entity_claim_entity_id("Q28")],
+                    "P171": [_build_entity_claim_monolingual("Reference prompt")],
                 },
             },
         },
@@ -169,6 +199,7 @@ def test_value_list_graph_includes_reference_and_qualifier_routes(tmp_path):
                     ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
                     "P161": [_build_entity_claim_entity_id("Q43")],
+                    "P171": [_build_entity_claim_monolingual("Qualifier prompt")],
                 },
             },
         },
@@ -231,6 +262,9 @@ def test_reference_statement_derives_value_from_parent_statement(tmp_path):
             "aliases": {},
             "claims": {
                 "P1": [_build_entity_claim_entity_id("Q3")],
+                "P188": [_build_entity_claim_monolingual("Enter label")],
+                "P189": [_build_entity_claim_monolingual("Enter description")],
+                "P190": [_build_entity_claim_monolingual("Enter aliases")],
                 "P157": [
                     {
                         "mainsnak": {
@@ -262,6 +296,9 @@ def test_reference_statement_derives_value_from_parent_statement(tmp_path):
                         )
                     ],
                     "P194": [_build_entity_claim_entity_id("Q54")],
+                    "P171": [
+                        _build_entity_claim_monolingual("Official website prompt")
+                    ],
                 },
             },
         },
@@ -277,6 +314,7 @@ def test_reference_statement_derives_value_from_parent_statement(tmp_path):
                     ],
                     "P194": [_build_entity_claim_entity_id("Q54")],
                     "P213": [_build_entity_claim_entity_id("Q19")],
+                    "P171": [_build_entity_claim_monolingual("Reference URL prompt")],
                 },
             },
         },
@@ -320,6 +358,9 @@ def test_reference_statement_derived_value_respects_profile_scope(tmp_path):
             "aliases": {},
             "claims": {
                 "P1": [_build_entity_claim_entity_id("Q3")],
+                "P188": [_build_entity_claim_monolingual("Enter label")],
+                "P189": [_build_entity_claim_monolingual("Enter description")],
+                "P190": [_build_entity_claim_monolingual("Enter aliases")],
                 "P157": [
                     {
                         "mainsnak": {
@@ -351,6 +392,9 @@ def test_reference_statement_derived_value_respects_profile_scope(tmp_path):
                         )
                     ],
                     "P194": [_build_entity_claim_entity_id("Q54")],
+                    "P171": [
+                        _build_entity_claim_monolingual("Official website prompt")
+                    ],
                 },
             },
         },
@@ -377,6 +421,7 @@ def test_reference_statement_derived_value_respects_profile_scope(tmp_path):
                             },
                         }
                     ],
+                    "P171": [_build_entity_claim_monolingual("Reference URL prompt")],
                 },
             },
         },
@@ -402,3 +447,90 @@ def test_reference_statement_derived_value_respects_profile_scope(tmp_path):
     assert len(references) == 1
     assert "value_source" not in references[0]["value"]
     assert "value_source_statement" not in references[0]["value"]
+
+
+def test_export_json_skips_profile_when_mul_language_coverage_fails(tmp_path):
+    """Invalid mul coverage should skip writing profile and report failure."""
+
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "entity_id": "Q4",
+        "entity": {
+            "labels": {"mul": {"value": "Tribal Government in the United States"}},
+            "descriptions": {"en": {"value": "Example profile"}},
+            "aliases": {},
+            "claims": {
+                "P1": [_build_entity_claim_entity_id("Q3")],
+                "P188": [_build_entity_claim_monolingual("Enter label")],
+                "P189": [_build_entity_claim_monolingual("Enter description")],
+                # Intentionally missing P190 mul prompt.
+            },
+        },
+    }
+    (cache_entities_dir / "Q4.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    output_dir = tmp_path / "profiles"
+    result = export_entity_profile_json_documents(cache_entities_dir, output_dir)
+
+    assert result.written_ids == []
+    assert result.skipped_ids == ["Q4"]
+    assert len(result.failures) == 1
+    assert result.failures[0]["profile_id"] == "Q4"
+    assert "identification.aliases.mul.prompt" in result.failures[0]["missing_paths"]
+    assert not (output_dir / "Q4.json").exists()
+
+
+def test_export_json_filters_incomplete_non_mul_language(tmp_path):
+    """Incomplete non-mul languages should be excluded from written JSON profile."""
+
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "entity_id": "Q4",
+        "entity": {
+            "labels": {
+                "mul": {"value": "Tribal Government in the United States"},
+                "es": {"value": "Gobierno tribal en los Estados Unidos"},
+            },
+            "descriptions": {
+                "en": {"value": "Example profile"},
+                "es": {"value": "Perfil de ejemplo"},
+            },
+            "aliases": {},
+            "claims": {
+                "P1": [_build_entity_claim_entity_id("Q3")],
+                "P188": [
+                    _build_entity_claim_monolingual("Enter label", "mul"),
+                    _build_entity_claim_monolingual("Ingrese etiqueta", "es"),
+                ],
+                "P189": [
+                    _build_entity_claim_monolingual("Enter description", "mul"),
+                    _build_entity_claim_monolingual("Ingrese descripcion", "es"),
+                ],
+                # Include only mul alias prompt so es is filtered as incomplete.
+                "P190": [_build_entity_claim_monolingual("Enter aliases", "mul")],
+            },
+        },
+    }
+    (cache_entities_dir / "Q4.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    output_dir = tmp_path / "profiles"
+    result = export_entity_profile_json_documents(cache_entities_dir, output_dir)
+
+    assert result.written_ids == ["Q4"]
+    assert result.skipped_ids == []
+    assert len(result.language_filtering) == 1
+    assert result.language_filtering[0]["profile_id"] == "Q4"
+    excluded = {
+        entry["language"]
+        for entry in result.language_filtering[0]["excluded_languages"]
+    }
+    assert "es" in excluded
+
+    written = json.loads((output_dir / "Q4.json").read_text(encoding="utf-8"))
+    assert written["metadata"]["languages"] == ["mul"]
+    assert "es" not in written["identification"]["labels"]
+    assert "es" not in written["metadata"]["labels"]


### PR DESCRIPTION
## Summary
- enforce mul-first language completeness during Wikibase cache to Entity Profile JSON materialization
- skip profiles that fail required mul coverage and emit actionable failure diagnostics
- filter incomplete non-mul languages from profile output and recompute metadata.languages
- extend profile export CLI with summary merge support into cache/refresh/last_run_summary.json

## Validation
- poetry run pytest tests/test_spirit_safe_entity_profile_json.py tests/test_cli.py::test_profile_export_json_writes_output_directory -q
- ./scripts/pre-merge-check.sh

## Issue
- closes #153
