### PR TITLE
fix(fermenter): validate_value_from_list items-format cache and full URI support

### DIFF
--- a/gkc/fermenter.py
+++ b/gkc/fermenter.py
@@ -387,22 +387,102 @@ def validate_by_datatype(datatype: str, value: Any) -> ValidationResult:
 # ============================================================================
 
 
+def _normalize_item_to_uri(value: Any) -> Optional[str]:
+    """Normalize an item value to a full Wikidata entity URI.
+
+    Supports:
+    - Full URI string: "http://www.wikidata.org/entity/Q12345"
+    - Wizard dict with "item" key: {"item": "<full URI>", "itemLabel": "..."}
+    - Wikibase dict with "id" key: {"id": "Q12345", ...}
+    - Bare QID string: "Q12345"
+    """
+    if isinstance(value, str):
+        if value.startswith("http://") or value.startswith("https://"):
+            return value
+        if value.startswith("Q") and value[1:].isdigit():
+            return f"http://www.wikidata.org/entity/{value}"
+    if isinstance(value, dict):
+        # Wizard format: {"item": "<full URI>", "itemLabel": "..."}
+        item_field = value.get("item")
+        if isinstance(item_field, str):
+            return _normalize_item_to_uri(item_field)
+        # Wikibase snakvalue format: {"id": "Q12345", ...}
+        id_field = value.get("id")
+        if isinstance(id_field, str):
+            return _normalize_item_to_uri(id_field)
+    return None
+
+
+def _extract_cache_uris_and_labels(
+    cache_data: dict,
+) -> tuple[set[str], list[tuple[str, str]]]:
+    """Extract item URIs and (uri, label) pairs from a SpiritSafe cache artifact.
+
+    Supports both formats:
+    - SpiritSafe items format: {"items": [{"item": "<uri>", "itemLabel": "<label>"}]}
+    - Raw SPARQL bindings format: {"results": {"bindings": [{"item": {"value": "<uri>"}, ...}]}}
+    """
+    uris: set[str] = set()
+    uri_labels: list[tuple[str, str]] = []
+
+    # SpiritSafe materialized items format
+    for entry in cache_data.get("items", []):
+        if not isinstance(entry, dict):
+            continue
+        uri = entry.get("item", "")
+        if isinstance(uri, str) and uri:
+            uris.add(uri)
+            label = entry.get("itemLabel", "")
+            if isinstance(label, str) and label:
+                uri_labels.append((uri, label.lower()))
+
+    # Raw SPARQL results-bindings format (hydration pipeline intermediate)
+    for binding in cache_data.get("results", {}).get("bindings", []):
+        if not isinstance(binding, dict):
+            continue
+        item_node = binding.get("item")
+        if isinstance(item_node, dict):
+            uri = item_node.get("value", "")
+            if isinstance(uri, str) and uri:
+                uris.add(uri)
+                label_node = binding.get("itemLabel", {})
+                label = (
+                    label_node.get("value", "") if isinstance(label_node, dict) else ""
+                )
+                if label:
+                    uri_labels.append((uri, label.lower()))
+
+    return uris, uri_labels
+
+
 def validate_value_from_list(
     value: Any, value_list_path: Path, match_policy: str = "strict"
 ) -> ValidationResult:
     """Validate a candidate item value against a cached value list.
 
     Args:
-        value: The value to validate (typically a QID string or dict)
-        value_list_path: Path to the cached value list JSON file
-        match_policy: "strict" (exact QID match) or "fuzzy" (label match fallback)
+        value: The item value to validate. Accepts:
+            - Full Wikidata URI string: "http://www.wikidata.org/entity/Q12345"
+            - Wizard dict: {"item": "<full URI>", "itemLabel": "..."}
+            - Wikibase snakvalue dict: {"id": "Q12345", ...}
+            - Bare QID string: "Q12345"
+        value_list_path: Path to the cached value list JSON file.
+        match_policy: "strict" (URI/QID exact match) or "fuzzy" (label match fallback).
 
     Returns:
         ValidationResult with valid=True if value is in the list, False otherwise.
 
-    If the cache file is absent, returns an error ConformanceNotice rather than
-    attempting live resolution (offline-first design).
+    If the value is empty/None, returns valid=True with no errors (unentered fields
+    are not a validation error at this layer; presence requirements are enforced
+    upstream by the packet validation logic).
+
+    If the cache file is absent, returns a ValidationResult with an error rather
+    than attempting live resolution (offline-first design).
     """
+    # Empty/unentered values pass through — presence enforcement is handled upstream.
+    if value in (None, "", {}, []):
+        return ValidationResult(valid=True, value=value)
+
     if not value_list_path.exists():
         return ValidationResult(
             valid=False,
@@ -417,45 +497,36 @@ def validate_value_from_list(
             valid=False, value=value, errors=[f"Failed to load value list cache: {e}"]
         )
 
-    # Normalize the incoming value to a QID if needed
-    if isinstance(value, dict) and "id" in value:
-        target_qid = value["id"]
-    elif isinstance(value, str) and value.startswith("Q"):
-        target_qid = value
-    else:
+    target_uri = _normalize_item_to_uri(value)
+    if target_uri is None:
         return ValidationResult(
             valid=False,
             value=value,
-            errors=[f"Cannot normalize value to QID for list matching: {value}"],
+            errors=[f"Cannot normalize value to item URI for list matching: {value!r}"],
         )
 
-    # Extract QIDs from cache
-    cache_qids = set()
-    if isinstance(cache_data, dict) and "results" in cache_data:
-        for item in cache_data["results"].get("bindings", []):
-            if "item" in item:
-                item_uri = item["item"].get("value", "")
-                qid = item_uri.split("/")[-1] if item_uri else None
-                if qid:
-                    cache_qids.add(qid)
+    cache_uris, uri_labels = _extract_cache_uris_and_labels(cache_data)
 
-    if target_qid in cache_qids:
+    if target_uri in cache_uris:
         return ValidationResult(valid=True, value=value)
 
-    # Fuzzy match by label if policy allows
     if match_policy == "fuzzy":
+        # Fuzzy: check if any cache label matches a label on the incoming value
         target_label = None
-        if isinstance(value, dict) and "label" in value:
-            target_label = value["label"].lower()
+        if isinstance(value, dict):
+            raw_label = value.get("itemLabel") or value.get("label")
+            if isinstance(raw_label, str):
+                target_label = raw_label.lower()
 
         if target_label:
-            for item in cache_data.get("results", {}).get("bindings", []):
-                item_label = item.get("itemLabel", {}).get("value", "").lower()
-                if item_label == target_label:
+            for _uri, cached_label in uri_labels:
+                if cached_label == target_label:
                     return ValidationResult(valid=True, value=value)
 
     return ValidationResult(
-        valid=False, value=value, errors=[f"Value {target_qid} not found in value list"]
+        valid=False,
+        value=value,
+        errors=[f"Value {target_uri} not found in value list"],
     )
 
 

--- a/tests/test_fermenter_value_list.py
+++ b/tests/test_fermenter_value_list.py
@@ -1,0 +1,239 @@
+"""Tests for validate_value_from_list in gkc.fermenter.
+
+Covers both SpiritSafe materialized items format and raw SPARQL bindings format,
+plus all value input shapes the wizard and downstream consumers can produce.
+"""
+
+import json
+from pathlib import Path
+
+from gkc.fermenter import validate_value_from_list
+
+# Known URIs from the Q28 fixture
+URI_HIT = "http://www.wikidata.org/entity/Q137668723"
+URI_HIT_LABEL = "Indian Entities Recognized and Eligible To Receive Services from the United States Bureau of Indian Affairs (April 04, 2008)"
+URI_HIT_2 = "http://www.wikidata.org/entity/Q138391266"
+URI_MISS = "http://www.wikidata.org/entity/Q999999999"
+QID_HIT = "Q137668723"
+QID_MISS = "Q999999999"
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "spiritsafe"
+    / "cache"
+    / "queries"
+    / "Q28.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# items-format (SpiritSafe materialized cache) — strict match
+# ---------------------------------------------------------------------------
+
+
+def test_items_format_full_uri_hit():
+    """Full Wikidata URI that exists in items list → valid."""
+    result = validate_value_from_list(URI_HIT, FIXTURE_PATH)
+    assert result.valid is True
+    assert not result.errors
+
+
+def test_items_format_full_uri_miss():
+    """Full Wikidata URI that does not exist in items list → invalid with message."""
+    result = validate_value_from_list(URI_MISS, FIXTURE_PATH)
+    assert result.valid is False
+    assert any(URI_MISS in err for err in result.errors)
+
+
+def test_items_format_qid_string_hit():
+    """Bare QID string that maps to a present URI → valid (expert-mode input)."""
+    result = validate_value_from_list(QID_HIT, FIXTURE_PATH)
+    assert result.valid is True
+    assert not result.errors
+
+
+def test_items_format_qid_string_miss():
+    """Bare QID string that does not map to any cache URI → invalid."""
+    result = validate_value_from_list(QID_MISS, FIXTURE_PATH)
+    assert result.valid is False
+    assert result.errors
+
+
+def test_items_format_wizard_dict_hit():
+    """Wizard-style dict with 'item' full URI → valid."""
+    value = {"item": URI_HIT, "itemLabel": URI_HIT_LABEL}
+    result = validate_value_from_list(value, FIXTURE_PATH)
+    assert result.valid is True
+    assert not result.errors
+
+
+def test_items_format_wizard_dict_miss():
+    """Wizard-style dict with unknown URI → invalid."""
+    value = {"item": URI_MISS, "itemLabel": "Unknown Tribe"}
+    result = validate_value_from_list(value, FIXTURE_PATH)
+    assert result.valid is False
+    assert result.errors
+
+
+def test_items_format_wikibase_snakvalue_dict_hit():
+    """Wikibase snakvalue dict with 'id' key → valid (QID normalised to URI)."""
+    value = {"id": QID_HIT, "entity-type": "item", "numeric-id": 137668723}
+    result = validate_value_from_list(value, FIXTURE_PATH)
+    assert result.valid is True
+    assert not result.errors
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy label match — items format
+# ---------------------------------------------------------------------------
+
+
+def test_items_format_fuzzy_label_hit():
+    """Fuzzy match on itemLabel in items list → valid."""
+    value = {"item": URI_MISS, "itemLabel": URI_HIT_LABEL}
+    result = validate_value_from_list(value, FIXTURE_PATH, match_policy="fuzzy")
+    assert result.valid is True
+
+
+def test_items_format_fuzzy_label_miss():
+    """Fuzzy match with label not in list → invalid."""
+    value = {
+        "item": URI_MISS,
+        "itemLabel": "Completely Unknown Tribe That Does Not Exist",
+    }
+    result = validate_value_from_list(value, FIXTURE_PATH, match_policy="fuzzy")
+    assert result.valid is False
+    assert result.errors
+
+
+# ---------------------------------------------------------------------------
+# Raw SPARQL bindings format (hydration pipeline intermediate)
+# ---------------------------------------------------------------------------
+
+
+def test_sparql_bindings_format_hit(tmp_path: Path):
+    """URI present in raw SPARQL results.bindings format → valid."""
+    cache_file = tmp_path / "Q99.json"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "results": {
+                    "bindings": [
+                        {
+                            "item": {"type": "uri", "value": URI_HIT},
+                            "itemLabel": {"type": "literal", "value": URI_HIT_LABEL},
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = validate_value_from_list(URI_HIT, cache_file)
+    assert result.valid is True
+
+
+def test_sparql_bindings_format_miss(tmp_path: Path):
+    """URI absent in raw SPARQL results.bindings format → invalid."""
+    cache_file = tmp_path / "Q99.json"
+    cache_file.write_text(
+        json.dumps(
+            {"results": {"bindings": [{"item": {"type": "uri", "value": URI_HIT}}]}}
+        ),
+        encoding="utf-8",
+    )
+    result = validate_value_from_list(URI_MISS, cache_file)
+    assert result.valid is False
+
+
+def test_sparql_bindings_format_fuzzy_hit(tmp_path: Path):
+    """Fuzzy label match against SPARQL bindings format → valid."""
+    cache_file = tmp_path / "Q99.json"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "results": {
+                    "bindings": [
+                        {
+                            "item": {"type": "uri", "value": URI_HIT},
+                            "itemLabel": {"type": "literal", "value": URI_HIT_LABEL},
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    value = {"item": URI_MISS, "itemLabel": URI_HIT_LABEL}
+    result = validate_value_from_list(value, cache_file, match_policy="fuzzy")
+    assert result.valid is True
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_cache_missing(tmp_path: Path):
+    """Cache file absent → error ValidationResult (offline-first)."""
+    missing = tmp_path / "nonexistent.json"
+    result = validate_value_from_list(URI_HIT, missing)
+    assert result.valid is False
+    assert any("unavailable" in err for err in result.errors)
+
+
+def test_cache_corrupt(tmp_path: Path):
+    """Corrupt cache file → error ValidationResult."""
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("{not valid json", encoding="utf-8")
+    result = validate_value_from_list(URI_HIT, bad_file)
+    assert result.valid is False
+    assert result.errors
+
+
+def test_empty_none_value():
+    """None input → valid with no errors (presence is enforced upstream)."""
+    result = validate_value_from_list(None, FIXTURE_PATH)
+    assert result.valid is True
+    assert not result.errors
+
+
+def test_empty_string_value():
+    """Empty string input → valid with no errors (presence is enforced upstream)."""
+    result = validate_value_from_list("", FIXTURE_PATH)
+    assert result.valid is True
+    assert not result.errors
+
+
+def test_empty_dict_value():
+    """Empty dict input → valid with no errors."""
+    result = validate_value_from_list({}, FIXTURE_PATH)
+    assert result.valid is True
+    assert not result.errors
+
+
+def test_unnormalizable_value():
+    """Value that cannot be resolved to a URI → error ValidationResult."""
+    result = validate_value_from_list(12345, FIXTURE_PATH)
+    assert result.valid is False
+    assert result.errors
+
+
+def test_items_and_bindings_both_present(tmp_path: Path):
+    """Cache with both items list and results.bindings — URI from either is accepted."""
+    cache_file = tmp_path / "combo.json"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "items": [{"item": URI_HIT, "itemLabel": URI_HIT_LABEL}],
+                "results": {
+                    "bindings": [{"item": {"type": "uri", "value": URI_HIT_2}}]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert validate_value_from_list(URI_HIT, cache_file).valid is True
+    assert validate_value_from_list(URI_HIT_2, cache_file).valid is True
+    assert validate_value_from_list(URI_MISS, cache_file).valid is False


### PR DESCRIPTION
## Summary

Fixes silent validation failures in `validate_value_from_list` that caused every real-world value list check to return `valid=False` regardless of whether the value was actually present in the cache.

## Root Causes Fixed

**Bug 1 - Wrong cache format**: The old implementation read `cache_data["results"]["bindings"]` (raw SPARQL wire format), but every SpiritSafe materialized cache artifact uses `cache_data["items"]` list format. No real value ever matched.

**Bug 2 - Wrong value normalization**: The old implementation compared values as stripped QIDs (e.g. `"Q12345"`), but the wizard stores full Wikidata entity URIs (e.g. `"http://www.wikidata.org/entity/Q12345"`). Even if the format bug were fixed, values would never match.

## Changes

### `gkc/fermenter.py`

- `_normalize_item_to_uri()` - Converts all incoming value shapes to a canonical full Wikidata URI:
  - Full URI string - returned as-is
  - `"Q12345"` string - expanded to `"http://www.wikidata.org/entity/Q12345"`
  - `{"item": uri, ...}` dict (wizard format) - recurse on `uri`
  - `{"id": qid, ...}` dict (Wikibase snakvalue format) - recurse on `qid`
  - Anything else - `None` (unnormalizable, fails validation)

- `_extract_cache_uris_and_labels()` - Reads both cache formats:
  - SpiritSafe `"items"` list: `entry["item"]` URI, `entry["itemLabel"]` plain string label
  - Raw SPARQL `"results.bindings"`: `binding["item"]["value"]` URI, `binding["itemLabel"]["value"]` label

- `validate_value_from_list()` - Updated to use the two helpers above; short-circuits empty/None as valid (presence enforcement is upstream in `validate_entity_packet_data`).

### `tests/test_fermenter_value_list.py`

19 tests covering:
- `items` format: full URI hit/miss, QID string hit/miss, wizard dict hit/miss, Wikibase snakvalue dict hit
- `items` format fuzzy: label hit/miss
- SPARQL bindings format: strict hit/miss, fuzzy hit
- Edge cases: cache missing, corrupt JSON, None/empty/empty-dict input, unnormalizable value, both formats present in one file

## Related

Closes the pre-flight blocker identified in issue #144 Phase D comments. Phase D wizard UI work (type-ahead filtering on `wikibase-item` inputs in `StatementsStep`) can proceed after this merges.
