### PR TITLE
feat(wizard): add value-list type-ahead for packet-routed item statements

### DIFF
--- a/gkc/profiles/forms/validation_bridge.py
+++ b/gkc/profiles/forms/validation_bridge.py
@@ -18,6 +18,24 @@ from gkc.fermenter import (
 )
 
 
+def _merge_wikibase_item_metadata(original: Any, normalized: Any) -> Any:
+    """Preserve wizard-selected URI/label metadata after datatype normalization."""
+    if not isinstance(normalized, dict):
+        return normalized
+
+    merged = dict(normalized)
+    if isinstance(original, dict):
+        item_uri = original.get("item")
+        item_label = original.get("itemLabel")
+        if isinstance(item_uri, str) and item_uri:
+            merged["item"] = item_uri
+        if isinstance(item_label, str) and item_label:
+            merged["itemLabel"] = item_label
+    elif isinstance(original, str) and original.startswith(("http://", "https://")):
+        merged["item"] = original
+    return merged
+
+
 def _validation_result_notices(
     result: ValidationResult,
     *,
@@ -73,7 +91,10 @@ def validate_inline_value(
     )
 
     if result.valid:
-        return result.value, notices
+        normalized = result.value
+        if datatype in {"item", "wikibase-item"}:
+            normalized = _merge_wikibase_item_metadata(value, normalized)
+        return normalized, notices
     return value, notices
 
 
@@ -239,7 +260,13 @@ def validate_entity_packet_data(
             )
 
             if datatype_result.valid:
-                statement_value["value"] = datatype_result.value
+                normalized_value = datatype_result.value
+                if datatype in {"item", "wikibase-item"}:
+                    normalized_value = _merge_wikibase_item_metadata(
+                        candidate,
+                        normalized_value,
+                    )
+                statement_value["value"] = normalized_value
 
             if value_list_path is not None and datatype_result.valid:
                 list_result = validate_value_from_list(candidate, value_list_path)
@@ -293,7 +320,13 @@ def validate_entity_packet_data(
                     )
                 )
                 if q_result.valid:
-                    qualifiers[qualifier_ref] = q_result.value
+                    normalized_qualifier = q_result.value
+                    if q_datatype in {"item", "wikibase-item"}:
+                        normalized_qualifier = _merge_wikibase_item_metadata(
+                            q_value,
+                            normalized_qualifier,
+                        )
+                    qualifiers[qualifier_ref] = normalized_qualifier
 
             references = statement_value.get("references", [])
             if not isinstance(references, list):
@@ -354,7 +387,13 @@ def validate_entity_packet_data(
                     )
                 )
                 if r_result.valid:
-                    ref_entry["value"] = r_result.value
+                    normalized_reference = r_result.value
+                    if r_datatype in {"item", "wikibase-item"}:
+                        normalized_reference = _merge_wikibase_item_metadata(
+                            ref_value,
+                            normalized_reference,
+                        )
+                    ref_entry["value"] = normalized_reference
 
             for ref_prop, ref_def in reference_defs.items():
                 if ref_prop not in present_reference_props:

--- a/gkc/profiles/forms/widgets.py
+++ b/gkc/profiles/forms/widgets.py
@@ -57,8 +57,51 @@ class WidgetFactory:
     @staticmethod
     def _render_item(
         label: str, value: Any, key: str, help_text: str, disabled: bool, **kwargs
+    ) -> Any:
+        """Render widget for wikibase-item datatype.
+
+        Supports two modes:
+        - Expert mode (default): QID text input.
+        - Value-list mode: searchable selectbox returning URI+label metadata.
+        """
+        item_options = kwargs.get("item_options")
+        if isinstance(item_options, list) and item_options:
+            return WidgetFactory._render_item_value_list_mode(
+                label,
+                value,
+                key,
+                help_text,
+                disabled,
+                item_options,
+                kwargs.get("all_item_options_count"),
+            )
+
+        return WidgetFactory._render_item_expert_mode(
+            label,
+            value,
+            key,
+            help_text,
+            disabled,
+        )
+
+    @staticmethod
+    def _qid_from_uri(uri: str) -> Optional[str]:
+        if not isinstance(uri, str) or not uri:
+            return None
+        candidate = uri.rsplit("/", 1)[-1] if "/" in uri else uri
+        if re.match(r"^Q\d+$", candidate):
+            return candidate
+        return None
+
+    @staticmethod
+    def _render_item_expert_mode(
+        label: str,
+        value: Any,
+        key: str,
+        help_text: str,
+        disabled: bool,
     ) -> str:
-        """Render widget for wikibase-item datatype (MVP: QID text input)."""
+        """Render QID text entry for unconstrained item fields."""
         qid_value = value if value else ""
 
         # Extract QID if value is a dict with 'id' key
@@ -79,6 +122,96 @@ class WidgetFactory:
             if not re.match(r"^Q\d+$", result):
                 st.warning(f"⚠️ Expected QID format (e.g., Q12345), got: {result}")
 
+        return result
+
+    @staticmethod
+    def _render_item_value_list_mode(
+        label: str,
+        value: Any,
+        key: str,
+        help_text: str,
+        disabled: bool,
+        item_options: list[dict[str, str]],
+        all_item_options_count: Any,
+    ) -> dict[str, str]:
+        """Render searchable item selector for value-list constrained statements."""
+        by_uri: dict[str, dict[str, str]] = {}
+        ordered_uris: list[str] = []
+        for candidate in item_options:
+            if not isinstance(candidate, dict):
+                continue
+            uri = candidate.get("item")
+            if not isinstance(uri, str) or not uri:
+                continue
+            if uri in by_uri:
+                continue
+            by_uri[uri] = {
+                "item": uri,
+                "itemLabel": (
+                    candidate.get("itemLabel", "")
+                    if isinstance(candidate.get("itemLabel"), str)
+                    else ""
+                ),
+            }
+            ordered_uris.append(uri)
+
+        if not ordered_uris:
+            st.warning(
+                "⚠️ Value list is configured but no selectable items were loaded."
+            )
+            return {"id": ""}
+
+        current_uri: Optional[str] = None
+        if isinstance(value, dict):
+            if isinstance(value.get("item"), str):
+                current_uri = value["item"]
+            elif isinstance(value.get("id"), str):
+                current_uri = f"http://www.wikidata.org/entity/{value['id']}"
+        elif isinstance(value, str) and value.startswith(("http://", "https://")):
+            current_uri = value
+        elif isinstance(value, str) and value.startswith("Q"):
+            current_uri = f"http://www.wikidata.org/entity/{value}"
+
+        if current_uri and current_uri not in by_uri:
+            by_uri[current_uri] = {
+                "item": current_uri,
+                "itemLabel": "Current value",
+            }
+            ordered_uris.insert(0, current_uri)
+
+        default_index = 0
+        if current_uri and current_uri in ordered_uris:
+            default_index = ordered_uris.index(current_uri)
+
+        if isinstance(all_item_options_count, int) and all_item_options_count > len(
+            ordered_uris
+        ):
+            st.caption(
+                f"Showing {len(ordered_uris)} matches out of {all_item_options_count} value-list entries."
+            )
+
+        selected_uri = st.selectbox(
+            label,
+            ordered_uris,
+            index=default_index,
+            key=key,
+            help=help_text,
+            disabled=disabled,
+            format_func=lambda uri: (
+                f"{by_uri[uri]['itemLabel']} ({WidgetFactory._qid_from_uri(uri) or uri})"
+                if by_uri[uri].get("itemLabel")
+                else (WidgetFactory._qid_from_uri(uri) or uri)
+            ),
+        )
+
+        selected = by_uri[selected_uri]
+        qid = WidgetFactory._qid_from_uri(selected_uri)
+        result: dict[str, str] = {
+            "item": selected_uri,
+            "itemLabel": selected.get("itemLabel", ""),
+        }
+        if qid:
+            result["id"] = qid
         return result
 
     @staticmethod

--- a/gkc/profiles/forms/wizard/steps.py
+++ b/gkc/profiles/forms/wizard/steps.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import streamlit as st
@@ -99,6 +101,126 @@ def _value_datatype(value_block: dict[str, Any]) -> str:
     if dtype == "globe-coordinate":
         return "globecoordinate"
     return dtype
+
+
+def _source_root_path() -> Path | None:
+    raw_source_root = st.session_state.get("source_root")
+    if isinstance(raw_source_root, str) and raw_source_root:
+        return Path(raw_source_root)
+    if isinstance(raw_source_root, Path):
+        return raw_source_root
+    return None
+
+
+def _extract_value_list_candidates(cache_data: dict[str, Any]) -> list[dict[str, str]]:
+    """Extract normalized item candidates from SpiritSafe cache payloads."""
+    candidates: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for entry in cache_data.get("items", []):
+        if not isinstance(entry, dict):
+            continue
+        item_uri = entry.get("item")
+        if not isinstance(item_uri, str) or not item_uri or item_uri in seen:
+            continue
+        label = entry.get("itemLabel")
+        candidates.append(
+            {
+                "item": item_uri,
+                "itemLabel": label if isinstance(label, str) else "",
+            }
+        )
+        seen.add(item_uri)
+
+    for binding in cache_data.get("results", {}).get("bindings", []):
+        if not isinstance(binding, dict):
+            continue
+        item_node = binding.get("item")
+        if not isinstance(item_node, dict):
+            continue
+        item_uri = item_node.get("value")
+        if not isinstance(item_uri, str) or not item_uri or item_uri in seen:
+            continue
+        label_node = binding.get("itemLabel")
+        label = (
+            label_node.get("value")
+            if isinstance(label_node, dict) and isinstance(label_node.get("value"), str)
+            else ""
+        )
+        candidates.append({"item": item_uri, "itemLabel": label})
+        seen.add(item_uri)
+
+    return candidates
+
+
+def _value_list_search_text(candidate: dict[str, str]) -> str:
+    item_uri = candidate.get("item", "")
+    qid = item_uri.rsplit("/", 1)[-1] if "/" in item_uri else item_uri
+    return f"{candidate.get('itemLabel', '')} {qid} {item_uri}".lower()
+
+
+def _filter_value_list_candidates(
+    candidates: list[dict[str, str]], query: str, limit: int = 200
+) -> list[dict[str, str]]:
+    """Filter candidates for responsive type-ahead browsing."""
+    normalized_query = query.strip().lower()
+    if not normalized_query:
+        return candidates[:limit]
+
+    filtered: list[dict[str, str]] = []
+    for candidate in candidates:
+        if normalized_query in _value_list_search_text(candidate):
+            filtered.append(candidate)
+            if len(filtered) >= limit:
+                break
+    return filtered
+
+
+def _statement_value_list_candidates(
+    statement_def: dict[str, Any],
+) -> tuple[list[dict[str, str]], str | None]:
+    """Resolve and load value-list candidates for one statement.
+
+    Returns a tuple of (candidates, error_message).
+    """
+    value_block = statement_def.get("value", {})
+    statement_ref = _statement_key(statement_def)
+
+    packet = st.session_state.get("packet", {})
+    route_map = packet.get("value_list_routes", {}) if isinstance(packet, dict) else {}
+    route = route_map.get(statement_ref, {}) if isinstance(route_map, dict) else {}
+
+    cache_ref = value_block.get("value_list_reference")
+    if not isinstance(cache_ref, str) or not cache_ref:
+        cache_ref = route.get("cache_path") if isinstance(route, dict) else None
+
+    if not isinstance(cache_ref, str) or not cache_ref:
+        return [], None
+
+    source_root = _source_root_path()
+    if source_root is None:
+        return [], "Value list route is configured but source root is unavailable."
+
+    cache_path = source_root / cache_ref
+    if not cache_path.exists():
+        return [], f"Value list cache file not found: {cache_path}"
+
+    cache_store = st.session_state.setdefault("value_list_cache", {})
+    cache_key = str(cache_path)
+    if cache_key in cache_store:
+        return cache_store[cache_key], None
+
+    try:
+        cache_payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return [], f"Failed to read value list cache at {cache_path}: {exc}"
+
+    if not isinstance(cache_payload, dict):
+        return [], f"Value list cache payload must be a JSON object: {cache_path}"
+
+    candidates = _extract_value_list_candidates(cache_payload)
+    cache_store[cache_key] = candidates
+    return candidates, None
 
 
 class IdentificationStep(Step):
@@ -382,13 +504,32 @@ class StatementsStep(Step):
             value_data["value"] = fixed_value
             return
 
-        value_data["value"] = WidgetFactory.render_widget(
+        widget_kwargs: dict[str, Any] = {}
+        if dtype in {"item", "wikibase-item"}:
+            candidates, list_error = _statement_value_list_candidates(statement_def)
+            if list_error:
+                st.error(list_error)
+            if candidates:
+                search_query = st.text_input(
+                    "Search value list",
+                    key=f"value_search_{_statement_key(statement_def)}_{idx}",
+                    placeholder="Type to filter by label, QID, or URI",
+                )
+                filtered = _filter_value_list_candidates(candidates, search_query)
+                if not filtered:
+                    st.warning("No value-list matches found for current search.")
+                widget_kwargs["item_options"] = filtered
+                widget_kwargs["all_item_options_count"] = len(candidates)
+
+        original_value = WidgetFactory.render_widget(
             datatype=dtype,
             label="Value",
             value=current_value,
             key=f"value_{_statement_key(statement_def)}_{idx}",
             help_text=_statement_prompt(statement_def),
+            **widget_kwargs,
         )
+        value_data["value"] = original_value
 
         normalized, notices = validate_inline_value(
             datatype=dtype,
@@ -396,6 +537,15 @@ class StatementsStep(Step):
             entity_ref=st.session_state.get("active_entity_id", "unknown"),
             statement_ref=_statement_key(statement_def),
         )
+        if (
+            dtype in {"item", "wikibase-item"}
+            and isinstance(original_value, dict)
+            and isinstance(normalized, dict)
+        ):
+            if isinstance(original_value.get("item"), str):
+                normalized["item"] = original_value["item"]
+            if isinstance(original_value.get("itemLabel"), str):
+                normalized["itemLabel"] = original_value["itemLabel"]
         value_data["value"] = normalized
         # Inline entry applies coercion but defers conformance messaging to review phase.
         del notices

--- a/tests/test_wizard_value_list_integration.py
+++ b/tests/test_wizard_value_list_integration.py
@@ -1,0 +1,95 @@
+"""Tests for wizard value-list integration helpers and metadata preservation."""
+
+from gkc.profiles.forms.validation_bridge import (
+    _merge_wikibase_item_metadata,
+    validate_inline_value,
+)
+from gkc.profiles.forms.wizard.steps import (
+    _extract_value_list_candidates,
+    _filter_value_list_candidates,
+)
+
+
+def test_extract_value_list_candidates_supports_items_and_bindings() -> None:
+    payload = {
+        "items": [
+            {
+                "item": "http://www.wikidata.org/entity/Q42",
+                "itemLabel": "Douglas Adams",
+            }
+        ],
+        "results": {
+            "bindings": [
+                {
+                    "item": {"value": "http://www.wikidata.org/entity/Q1"},
+                    "itemLabel": {"value": "Universe"},
+                }
+            ]
+        },
+    }
+
+    candidates = _extract_value_list_candidates(payload)
+
+    assert len(candidates) == 2
+    assert candidates[0]["item"] == "http://www.wikidata.org/entity/Q42"
+    assert candidates[0]["itemLabel"] == "Douglas Adams"
+    assert candidates[1]["item"] == "http://www.wikidata.org/entity/Q1"
+    assert candidates[1]["itemLabel"] == "Universe"
+
+
+def test_filter_value_list_candidates_matches_label_qid_and_uri() -> None:
+    candidates = [
+        {
+            "item": "http://www.wikidata.org/entity/Q42",
+            "itemLabel": "Douglas Adams",
+        },
+        {
+            "item": "http://www.wikidata.org/entity/Q1",
+            "itemLabel": "Universe",
+        },
+    ]
+
+    assert len(_filter_value_list_candidates(candidates, "doug")) == 1
+    assert len(_filter_value_list_candidates(candidates, "Q1")) == 1
+    assert (
+        len(_filter_value_list_candidates(candidates, "wikidata.org/entity/q42")) == 1
+    )
+
+
+def test_merge_wikibase_item_metadata_preserves_uri_and_label() -> None:
+    original = {
+        "id": "Q42",
+        "item": "http://www.wikidata.org/entity/Q42",
+        "itemLabel": "Douglas Adams",
+    }
+    normalized = {
+        "entity-type": "item",
+        "numeric-id": 42,
+        "id": "Q42",
+    }
+
+    merged = _merge_wikibase_item_metadata(original, normalized)
+
+    assert merged["id"] == "Q42"
+    assert merged["item"] == "http://www.wikidata.org/entity/Q42"
+    assert merged["itemLabel"] == "Douglas Adams"
+
+
+def test_validate_inline_value_keeps_item_metadata() -> None:
+    value = {
+        "id": "Q42",
+        "item": "http://www.wikidata.org/entity/Q42",
+        "itemLabel": "Douglas Adams",
+    }
+
+    normalized, notices = validate_inline_value(
+        datatype="wikibase-item",
+        value=value,
+        entity_ref="ent-001",
+        statement_ref="https://datadistillery.wikibase.cloud/entity/Q16",
+    )
+
+    assert not any(n.severity == "error" for n in notices)
+    assert normalized["id"] == "Q42"
+    assert normalized["item"] == "http://www.wikidata.org/entity/Q42"
+    assert normalized["itemLabel"] == "Douglas Adams"


### PR DESCRIPTION
## Summary

Implements the next Phase D wizard step now that the Validation Agent fix is merged: packet-routed value-list type-ahead for `wikibase-item` inputs in statement forms.

## What Changed

- `gkc/profiles/forms/wizard/steps.py`
  - Added value-list cache resolution from statement context via packet `value_list_routes` + `source_root`
  - Added candidate extraction that supports both SpiritSafe materialized `items` format and raw SPARQL `results.bindings` format
  - Added client-side filtering helpers for type-ahead behavior
  - Wired item statement rendering to show a search field + filtered value-list options when a route exists
  - Preserved selected URI/label metadata on inline normalization paths

- `gkc/profiles/forms/widgets.py`
  - Upgraded item widget rendering:
    - **Value-list mode** for routed statements (searchable selectbox)
    - **Expert mode** fallback for unrouted statements (existing QID text input)
  - Value-list selections now return structured payload including `item` URI, `itemLabel`, and derived `id` (QID)

- `gkc/profiles/forms/validation_bridge.py`
  - Added metadata preservation helper so item URI/label survive datatype normalization in both inline and review-time passes

- `tests/test_wizard_value_list_integration.py`
  - Added tests for:
    - candidate extraction from both cache payload formats
    - query filtering across label/QID/URI
    - URI/label metadata preservation during inline validation

## Validation

- `poetry run pytest tests/test_wizard_value_list_integration.py tests/test_wizard_validation_bridge.py -q`
- `./scripts/pre-merge-check.sh`
