### PR TITLE
Wizard: route value-list pickers through nested refs/quals

### DIFF
--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -2044,6 +2044,12 @@ def _handle_profile_form(args: argparse.Namespace) -> dict[str, Any]:
         # Set environment variables for Streamlit app to read
         env = os.environ.copy()
         env["GKC_WIZARD_PROFILE"] = profile_entity
+        source_config = gkc.get_spirit_safe_source()
+        env["GKC_SPIRIT_SAFE_SOURCE_MODE"] = source_config.mode
+        env["GKC_SPIRIT_SAFE_GITHUB_REPO"] = source_config.github_repo
+        env["GKC_SPIRIT_SAFE_GITHUB_REF"] = source_config.github_ref
+        if source_config.local_root is not None:
+            env["GKC_SPIRIT_SAFE_LOCAL_ROOT"] = str(source_config.local_root)
         if args.qid:
             env["GKC_WIZARD_QID"] = args.qid
         if args.packet:

--- a/gkc/profiles/forms/streamlit_app.py
+++ b/gkc/profiles/forms/streamlit_app.py
@@ -635,6 +635,22 @@ def render_step_content() -> None:
 
 
 def _load_packet_from_env_or_profile() -> None:
+    source_mode = os.environ.get("GKC_SPIRIT_SAFE_SOURCE_MODE")
+    if source_mode in {"github", "local"}:
+        source_kwargs: dict[str, Any] = {
+            "mode": source_mode,
+            "github_repo": os.environ.get(
+                "GKC_SPIRIT_SAFE_GITHUB_REPO", gkc.DEFAULT_SPIRIT_SAFE_GITHUB_REPO
+            ),
+            "github_ref": os.environ.get("GKC_SPIRIT_SAFE_GITHUB_REF", "main"),
+        }
+        if source_mode == "local":
+            local_root = os.environ.get("GKC_SPIRIT_SAFE_LOCAL_ROOT")
+            if local_root:
+                source_kwargs["local_root"] = local_root
+
+        gkc.set_spirit_safe_source(**source_kwargs)
+
     env_packet = os.environ.get("GKC_WIZARD_PACKET")
     env_profile = os.environ.get("GKC_WIZARD_PROFILE")
 

--- a/gkc/profiles/forms/widgets.py
+++ b/gkc/profiles/forms/widgets.py
@@ -5,9 +5,116 @@ MVP scope: All wikibase-item properties use QID text input (no autocomplete).
 """
 
 import re
+from html import escape
 from typing import Any, Dict, Optional
 
 import streamlit as st
+
+
+@st.dialog(
+    "Select Wikidata item",
+    width="large",
+    dismissible=True,
+    on_dismiss="rerun",
+)
+def _wikidata_item_picker_dialog(
+    *,
+    widget_key: str,
+    help_text: str | None,
+    ordered_uris: list[str],
+    by_uri: dict[str, dict[str, str]],
+    selected_uri_key: str,
+    disabled: bool,
+) -> None:
+    """Render modal picker for hydrated Wikidata value lists."""
+    search_key = f"{widget_key}_search"
+    page_key = f"{widget_key}_page"
+    last_query_key = f"{widget_key}_last_query"
+    page_size = 50
+
+    search_query = st.text_input(
+        "Search",
+        key=search_key,
+        help=help_text,
+        placeholder="Type label, QID, or URI",
+        disabled=disabled,
+    )
+    if page_key not in st.session_state:
+        st.session_state[page_key] = 0
+
+    if st.session_state.get(last_query_key) != search_query:
+        st.session_state[page_key] = 0
+        st.session_state[last_query_key] = search_query
+
+    normalized_query = search_query.strip().lower()
+    if normalized_query:
+        filtered_uris = [
+            uri
+            for uri in ordered_uris
+            if normalized_query
+            in (
+                f"{by_uri[uri].get('itemLabel', '')} "
+                f"{WidgetFactory._qid_from_uri(uri) or ''} {uri}"
+            ).lower()
+        ]
+    else:
+        filtered_uris = ordered_uris
+
+    total_filtered = len(filtered_uris)
+    if total_filtered == 0:
+        st.warning("No items match your search.")
+        return
+
+    max_page = max(0, (total_filtered - 1) // page_size)
+    page_index = min(st.session_state.get(page_key, 0), max_page)
+    st.session_state[page_key] = page_index
+
+    start = page_index * page_size
+    end = min(start + page_size, total_filtered)
+    page_uris = filtered_uris[start:end]
+
+    nav_col1, nav_col2, nav_col3 = st.columns([1, 2, 1])
+    with nav_col1:
+        if st.button(
+            "Previous",
+            key=f"{widget_key}_prev_page",
+            disabled=disabled or page_index <= 0,
+        ):
+            st.session_state[page_key] = max(0, page_index - 1)
+            st.rerun()
+    with nav_col2:
+        st.caption(f"Showing {start + 1}-{end} of {total_filtered} matched items")
+    with nav_col3:
+        if st.button(
+            "Next",
+            key=f"{widget_key}_next_page",
+            disabled=disabled or page_index >= max_page,
+        ):
+            st.session_state[page_key] = min(max_page, page_index + 1)
+            st.rerun()
+
+    for offset, uri in enumerate(page_uris):
+        item = by_uri[uri]
+        qid = WidgetFactory._qid_from_uri(uri) or uri
+        label_text = item.get("itemLabel") or qid
+
+        row_col1, row_col2, row_col3 = st.columns([1, 6, 2])
+        with row_col1:
+            if st.button(
+                "Select",
+                key=f"{widget_key}_pick_{start + offset}",
+                disabled=disabled,
+            ):
+                st.session_state[selected_uri_key] = uri
+                st.rerun()
+        with row_col2:
+            st.markdown(f"**{label_text}**")
+            st.caption(qid)
+        with row_col3:
+            st.markdown(
+                f'<a href="{escape(uri)}" target="_blank">Open in Wikidata</a>',
+                unsafe_allow_html=True,
+            )
 
 
 class WidgetFactory:
@@ -134,7 +241,7 @@ class WidgetFactory:
         item_options: list[dict[str, str]],
         all_item_options_count: Any,
     ) -> dict[str, str]:
-        """Render searchable item selector for value-list constrained statements."""
+        """Render a value-list picker with fixed search and browse pagination."""
         by_uri: dict[str, dict[str, str]] = {}
         ordered_uris: list[str] = []
         for candidate in item_options:
@@ -179,32 +286,53 @@ class WidgetFactory:
             }
             ordered_uris.insert(0, current_uri)
 
-        default_index = 0
-        if current_uri and current_uri in ordered_uris:
-            default_index = ordered_uris.index(current_uri)
+        selected_uri_key = f"{key}_selected_uri"
+        if selected_uri_key not in st.session_state:
+            st.session_state[selected_uri_key] = current_uri
 
-        if isinstance(all_item_options_count, int) and all_item_options_count > len(
-            ordered_uris
-        ):
-            st.caption(
-                f"Showing {len(ordered_uris)} matches out of {all_item_options_count} value-list entries."
+        selected_uri = st.session_state.get(selected_uri_key)
+        if selected_uri not in by_uri:
+            selected_uri = current_uri if current_uri in by_uri else None
+            st.session_state[selected_uri_key] = selected_uri
+
+        if selected_uri is not None:
+            selected = by_uri[selected_uri]
+            selected_qid = WidgetFactory._qid_from_uri(selected_uri) or selected_uri
+            st.info(
+                f"Selected item: {selected.get('itemLabel') or selected_qid} ({selected_qid})"
             )
+        else:
+            selected = None
+            st.caption("No Wikidata item selected yet.")
 
-        selected_uri = st.selectbox(
-            label,
-            ordered_uris,
-            index=default_index,
-            key=key,
-            help=help_text,
-            disabled=disabled,
-            format_func=lambda uri: (
-                f"{by_uri[uri]['itemLabel']} ({WidgetFactory._qid_from_uri(uri) or uri})"
-                if by_uri[uri].get("itemLabel")
-                else (WidgetFactory._qid_from_uri(uri) or uri)
-            ),
+        button_label = (
+            "Change Wikidata item"
+            if selected_uri is not None
+            else "Choose Wikidata item"
         )
+        button_col, clear_col = st.columns([3, 1])
+        with button_col:
+            if st.button(button_label, key=f"{key}_open_picker", disabled=disabled):
+                _wikidata_item_picker_dialog(
+                    widget_key=key,
+                    help_text=help_text,
+                    ordered_uris=ordered_uris,
+                    by_uri=by_uri,
+                    selected_uri_key=selected_uri_key,
+                    disabled=disabled,
+                )
+        with clear_col:
+            if st.button(
+                "Clear",
+                key=f"{key}_clear_picker",
+                disabled=disabled or selected_uri is None,
+            ):
+                st.session_state[selected_uri_key] = None
+                st.rerun()
 
-        selected = by_uri[selected_uri]
+        if selected_uri is None or selected is None:
+            return {}
+
         qid = WidgetFactory._qid_from_uri(selected_uri)
         result: dict[str, str] = {
             "item": selected_uri,

--- a/gkc/profiles/forms/wizard/steps.py
+++ b/gkc/profiles/forms/wizard/steps.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import urllib.request
 from pathlib import Path
 from typing import Any
 
 import streamlit as st
 
+import gkc
 from gkc.profiles.forms.validation_bridge import validate_inline_value
 from gkc.profiles.forms.widgets import WidgetFactory
 from gkc.profiles.forms.wizard.step_base import Step
@@ -112,6 +114,65 @@ def _source_root_path() -> Path | None:
     return None
 
 
+def _wizard_value_list_cache_root() -> Path:
+    """Return the local cache root used by wizard value-list operations."""
+    source = gkc.get_spirit_safe_source()
+    repo_slug = source.github_repo.replace("/", "_")
+    if source.mode == "local" and source.local_root is not None:
+        # Keep local-mode cache names deterministic by source path hash.
+        source_id = str(source.local_root).replace("/", "_").strip("_")
+    else:
+        source_id = source.github_ref
+
+    cache_root = Path.home() / ".cache" / "gkc" / "wizard" / repo_slug / source_id
+    cache_root.mkdir(parents=True, exist_ok=True)
+    return cache_root
+
+
+def _materialize_value_list_cache(cache_ref: str) -> tuple[Path | None, str | None]:
+    """Materialize a value-list artifact into local wizard cache.
+
+    Returns (local_path, error_message).
+    """
+    cache_ref_clean = cache_ref.lstrip("/")
+    local_cache_path = _wizard_value_list_cache_root() / cache_ref_clean
+    local_cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if local_cache_path.exists():
+        return local_cache_path, None
+
+    source = gkc.get_spirit_safe_source()
+
+    # Prefer direct local file copy when local source root is available.
+    source_root = _source_root_path()
+    if source_root is not None:
+        candidate = source_root / cache_ref_clean
+        if candidate.exists():
+            local_cache_path.write_text(
+                candidate.read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            return local_cache_path, None
+
+    # Fallback: resolve from configured SpiritSafe source (usually GitHub raw URL).
+    try:
+        resolved = source.resolve_relative(cache_ref_clean)
+    except Exception as exc:
+        return None, f"Unable to resolve value-list source for {cache_ref_clean}: {exc}"
+
+    try:
+        if isinstance(resolved, Path):
+            if not resolved.exists():
+                return None, f"Value list cache file not found: {resolved}"
+            content = resolved.read_text(encoding="utf-8")
+        else:
+            with urllib.request.urlopen(str(resolved), timeout=10) as response:
+                content = response.read().decode("utf-8")
+        local_cache_path.write_text(content, encoding="utf-8")
+        return local_cache_path, None
+    except Exception as exc:
+        return None, f"Failed to materialize value list cache {cache_ref_clean}: {exc}"
+
+
 def _extract_value_list_candidates(cache_data: dict[str, Any]) -> list[dict[str, str]]:
     """Extract normalized item candidates from SpiritSafe cache payloads."""
     candidates: list[dict[str, str]] = []
@@ -160,18 +221,20 @@ def _value_list_search_text(candidate: dict[str, str]) -> str:
 
 
 def _filter_value_list_candidates(
-    candidates: list[dict[str, str]], query: str, limit: int = 200
+    candidates: list[dict[str, str]], query: str, limit: int | None = None
 ) -> list[dict[str, str]]:
     """Filter candidates for responsive type-ahead browsing."""
     normalized_query = query.strip().lower()
     if not normalized_query:
+        if limit is None:
+            return candidates
         return candidates[:limit]
 
     filtered: list[dict[str, str]] = []
     for candidate in candidates:
         if normalized_query in _value_list_search_text(candidate):
             filtered.append(candidate)
-            if len(filtered) >= limit:
+            if limit is not None and len(filtered) >= limit:
                 break
     return filtered
 
@@ -197,13 +260,11 @@ def _statement_value_list_candidates(
     if not isinstance(cache_ref, str) or not cache_ref:
         return [], None
 
-    source_root = _source_root_path()
-    if source_root is None:
-        return [], "Value list route is configured but source root is unavailable."
-
-    cache_path = source_root / cache_ref
-    if not cache_path.exists():
-        return [], f"Value list cache file not found: {cache_path}"
+    cache_path, cache_error = _materialize_value_list_cache(cache_ref)
+    if cache_error:
+        return [], cache_error
+    if cache_path is None:
+        return [], f"Value list cache for {cache_ref} could not be materialized."
 
     cache_store = st.session_state.setdefault("value_list_cache", {})
     cache_key = str(cache_path)
@@ -221,6 +282,50 @@ def _statement_value_list_candidates(
     candidates = _extract_value_list_candidates(cache_payload)
     cache_store[cache_key] = candidates
     return candidates, None
+
+
+def _value_list_widget_kwargs(statement_def: dict[str, Any]) -> dict[str, Any]:
+    """Build widget kwargs for statements constrained by hydrated value lists."""
+    dtype = _value_datatype(statement_def.get("value", {}))
+    if dtype not in {"item", "wikibase-item"}:
+        return {}
+
+    candidates, list_error = _statement_value_list_candidates(statement_def)
+    if list_error:
+        st.error(list_error)
+    if not candidates:
+        return {}
+
+    return {
+        "item_options": candidates,
+        "all_item_options_count": len(candidates),
+    }
+
+
+def _normalize_rendered_value(
+    *,
+    datatype: str,
+    value: Any,
+    statement_ref: str,
+) -> Any:
+    """Normalize widget output while preserving explicit item metadata."""
+    normalized, notices = validate_inline_value(
+        datatype=datatype,
+        value=value,
+        entity_ref=st.session_state.get("active_entity_id", "unknown"),
+        statement_ref=statement_ref,
+    )
+    if (
+        datatype in {"item", "wikibase-item"}
+        and isinstance(value, dict)
+        and isinstance(normalized, dict)
+    ):
+        if isinstance(value.get("item"), str):
+            normalized["item"] = value["item"]
+        if isinstance(value.get("itemLabel"), str):
+            normalized["itemLabel"] = value["itemLabel"]
+    del notices
+    return normalized
 
 
 class IdentificationStep(Step):
@@ -504,22 +609,7 @@ class StatementsStep(Step):
             value_data["value"] = fixed_value
             return
 
-        widget_kwargs: dict[str, Any] = {}
-        if dtype in {"item", "wikibase-item"}:
-            candidates, list_error = _statement_value_list_candidates(statement_def)
-            if list_error:
-                st.error(list_error)
-            if candidates:
-                search_query = st.text_input(
-                    "Search value list",
-                    key=f"value_search_{_statement_key(statement_def)}_{idx}",
-                    placeholder="Type to filter by label, QID, or URI",
-                )
-                filtered = _filter_value_list_candidates(candidates, search_query)
-                if not filtered:
-                    st.warning("No value-list matches found for current search.")
-                widget_kwargs["item_options"] = filtered
-                widget_kwargs["all_item_options_count"] = len(candidates)
+        widget_kwargs = _value_list_widget_kwargs(statement_def)
 
         original_value = WidgetFactory.render_widget(
             datatype=dtype,
@@ -529,26 +619,11 @@ class StatementsStep(Step):
             help_text=_statement_prompt(statement_def),
             **widget_kwargs,
         )
-        value_data["value"] = original_value
-
-        normalized, notices = validate_inline_value(
+        value_data["value"] = _normalize_rendered_value(
             datatype=dtype,
-            value=value_data["value"],
-            entity_ref=st.session_state.get("active_entity_id", "unknown"),
+            value=original_value,
             statement_ref=_statement_key(statement_def),
         )
-        if (
-            dtype in {"item", "wikibase-item"}
-            and isinstance(original_value, dict)
-            and isinstance(normalized, dict)
-        ):
-            if isinstance(original_value.get("item"), str):
-                normalized["item"] = original_value["item"]
-            if isinstance(original_value.get("itemLabel"), str):
-                normalized["itemLabel"] = original_value["itemLabel"]
-        value_data["value"] = normalized
-        # Inline entry applies coercion but defers conformance messaging to review phase.
-        del notices
 
     def _render_qualifiers(
         self, statement_def: dict[str, Any], value_data: dict[str, Any], idx: int
@@ -568,22 +643,20 @@ class StatementsStep(Step):
             qual_dtype = _value_datatype(qualifier_def.get("value", {}))
             current = value_data["qualifiers"].get(qual_key)
 
-            value_data["qualifiers"][qual_key] = WidgetFactory.render_widget(
+            widget_kwargs = _value_list_widget_kwargs(qualifier_def)
+            original_value = WidgetFactory.render_widget(
                 datatype=qual_dtype,
                 label=qual_label,
                 value=current,
                 key=f"qual_{_statement_key(statement_def)}_{qual_key}_{idx}",
                 help_text=_statement_prompt(qualifier_def),
+                **widget_kwargs,
             )
-
-            normalized, notices = validate_inline_value(
+            value_data["qualifiers"][qual_key] = _normalize_rendered_value(
                 datatype=qual_dtype,
-                value=value_data["qualifiers"][qual_key],
-                entity_ref=st.session_state.get("active_entity_id", "unknown"),
+                value=original_value,
                 statement_ref=qual_key,
             )
-            value_data["qualifiers"][qual_key] = normalized
-            del notices
 
     def _render_references(
         self, statement_def: dict[str, Any], value_data: dict[str, Any], idx: int
@@ -610,6 +683,7 @@ class StatementsStep(Step):
             ref_label = _statement_label(ref_def)
             ref_dtype = _value_datatype(ref_def.get("value", {}))
             existing = by_ref_key.get(ref_key, {"property": ref_key, "value": None})
+            widget_kwargs = _value_list_widget_kwargs(ref_def)
 
             ref_value = WidgetFactory.render_widget(
                 datatype=ref_dtype,
@@ -617,16 +691,14 @@ class StatementsStep(Step):
                 value=existing.get("value"),
                 key=f"ref_{_statement_key(statement_def)}_{ref_key}_{idx}",
                 help_text=_statement_prompt(ref_def),
-            )
-            normalized, notices = validate_inline_value(
-                datatype=ref_dtype,
-                value=ref_value,
-                entity_ref=st.session_state.get("active_entity_id", "unknown"),
-                statement_ref=ref_key,
+                **widget_kwargs,
             )
             updated.append({"property": ref_key, "value": ref_value})
-            updated[-1]["value"] = normalized
-            del notices
+            updated[-1]["value"] = _normalize_rendered_value(
+                datatype=ref_dtype,
+                value=ref_value,
+                statement_ref=ref_key,
+            )
 
         value_data["references"] = updated
 

--- a/tests/test_wizard_value_list_integration.py
+++ b/tests/test_wizard_value_list_integration.py
@@ -1,5 +1,10 @@
 """Tests for wizard value-list integration helpers and metadata preservation."""
 
+from pathlib import Path
+
+import streamlit as st
+
+import gkc
 from gkc.profiles.forms.validation_bridge import (
     _merge_wikibase_item_metadata,
     validate_inline_value,
@@ -7,6 +12,8 @@ from gkc.profiles.forms.validation_bridge import (
 from gkc.profiles.forms.wizard.steps import (
     _extract_value_list_candidates,
     _filter_value_list_candidates,
+    _materialize_value_list_cache,
+    _value_list_widget_kwargs,
 )
 
 
@@ -93,3 +100,86 @@ def test_validate_inline_value_keeps_item_metadata() -> None:
     assert normalized["id"] == "Q42"
     assert normalized["item"] == "http://www.wikidata.org/entity/Q42"
     assert normalized["itemLabel"] == "Douglas Adams"
+
+
+def test_materialize_value_list_cache_from_local_source(
+    monkeypatch, tmp_path: Path
+) -> None:
+    spirit_safe_root = tmp_path / "SpiritSafe"
+    source_file = spirit_safe_root / "cache" / "queries" / "Q28.json"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        '{"items": [{"item": "http://www.wikidata.org/entity/Q42", "itemLabel": "Douglas Adams"}]}',
+        encoding="utf-8",
+    )
+
+    original_source = gkc.get_spirit_safe_source()
+    gkc.set_spirit_safe_source(mode="local", local_root=spirit_safe_root)
+
+    try:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        local_path, error = _materialize_value_list_cache("cache/queries/Q28.json")
+
+        assert error is None
+        assert local_path is not None
+        assert local_path.exists()
+        assert "Douglas Adams" in local_path.read_text(encoding="utf-8")
+    finally:
+        gkc.set_spirit_safe_source(
+            mode=original_source.mode,
+            github_repo=original_source.github_repo,
+            github_ref=original_source.github_ref,
+            local_root=original_source.local_root,
+        )
+
+
+def test_value_list_widget_kwargs_uses_packet_route_for_nested_statement(
+    monkeypatch, tmp_path: Path
+) -> None:
+    spirit_safe_root = tmp_path / "SpiritSafe"
+    source_file = spirit_safe_root / "cache" / "queries" / "Q28.json"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        '{"items": [{"item": "http://www.wikidata.org/entity/Q1", "itemLabel": "Universe"}]}',
+        encoding="utf-8",
+    )
+
+    original_source = gkc.get_spirit_safe_source()
+    original_session = dict(st.session_state)
+    gkc.set_spirit_safe_source(mode="local", local_root=spirit_safe_root)
+
+    try:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        st.session_state.clear()
+        st.session_state["packet"] = {
+            "value_list_routes": {
+                "https://datadistillery.wikibase.cloud/entity/Q30": {
+                    "cache_path": "cache/queries/Q28.json"
+                }
+            }
+        }
+        st.session_state["source_root"] = str(spirit_safe_root)
+
+        widget_kwargs = _value_list_widget_kwargs(
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q30",
+                "label": "stated in",
+                "value": {"type": "wikibase-item"},
+            }
+        )
+
+        assert widget_kwargs["all_item_options_count"] == 1
+        assert (
+            widget_kwargs["item_options"][0]["item"]
+            == "http://www.wikidata.org/entity/Q1"
+        )
+        assert widget_kwargs["item_options"][0]["itemLabel"] == "Universe"
+    finally:
+        st.session_state.clear()
+        st.session_state.update(original_session)
+        gkc.set_spirit_safe_source(
+            mode=original_source.mode,
+            github_repo=original_source.github_repo,
+            github_ref=original_source.github_ref,
+            local_root=original_source.local_root,
+        )


### PR DESCRIPTION
Summary:
- extend hydrated value-list picker support to nested references and qualifiers
- unify inline normalization for item metadata preservation across top-level, qualifier, and reference values
- add regression coverage for packet-routed nested value-list widget kwargs

Validation:
- ./scripts/pre-merge-check.sh

Notes:
- intentionally leaves issue #144 open for continued MVP work
