### PR TITLE
Fix Wikidata-entity fixed values and wizard nested reference handling

### DIFF
--- a/gkc/profiles/forms/validation_bridge.py
+++ b/gkc/profiles/forms/validation_bridge.py
@@ -121,6 +121,64 @@ def _resolve_value_list_path(
     return source_root / cache_path
 
 
+def _empty_nested_statement_entry(value: Any = None) -> dict[str, Any]:
+    return {
+        "value": value,
+        "qualifiers": {},
+        "references": {},
+    }
+
+
+def _normalize_nested_statement_entry(entry: Any) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        return _empty_nested_statement_entry(entry)
+
+    if not any(key in entry for key in ("value", "qualifiers", "references")):
+        return _empty_nested_statement_entry(entry)
+
+    normalized = {
+        "value": entry.get("value"),
+        "qualifiers": entry.get("qualifiers", {}),
+        "references": entry.get("references", {}),
+    }
+    if not isinstance(normalized["qualifiers"], dict):
+        normalized["qualifiers"] = {}
+    if not isinstance(normalized["references"], dict):
+        normalized["references"] = {}
+    return normalized
+
+
+def _normalize_nested_statement_map(raw: Any) -> dict[str, list[dict[str, Any]]]:
+    """Normalize nested qualifier/reference packet data to URI-keyed lists."""
+    normalized: dict[str, list[dict[str, Any]]] = {}
+
+    if isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            statement_ref = entry.get("property") or entry.get("statement")
+            if not isinstance(statement_ref, str) or not statement_ref:
+                continue
+            normalized.setdefault(statement_ref, []).append(
+                _normalize_nested_statement_entry({"value": entry.get("value")})
+            )
+        return normalized
+
+    if not isinstance(raw, dict):
+        return normalized
+
+    for statement_ref, payload in raw.items():
+        if not isinstance(statement_ref, str) or not statement_ref:
+            continue
+        if isinstance(payload, list):
+            entries = [_normalize_nested_statement_entry(entry) for entry in payload]
+        else:
+            entries = [_normalize_nested_statement_entry(payload)]
+        normalized[statement_ref] = entries
+
+    return normalized
+
+
 def validate_entity_packet_data(
     *,
     entity_slot: dict[str, Any],
@@ -279,23 +337,24 @@ def validate_entity_packet_data(
                     )
                 )
 
-            qualifiers = statement_value.get("qualifiers", {})
-            if not isinstance(qualifiers, dict):
+            raw_qualifiers = statement_value.get("qualifiers", {})
+            qualifiers = _normalize_nested_statement_map(raw_qualifiers)
+            statement_value["qualifiers"] = qualifiers
+            if raw_qualifiers not in ({}, None) and not qualifiers:
                 notices.append(
                     ConformanceNotice(
                         severity="error",
                         entity_ref=entity_ref,
                         statement_ref=statement_ref,
                         code="qualifiers_shape_invalid",
-                        message="Qualifiers must be stored as a mapping.",
+                        message="Qualifiers must be stored as a URI-keyed mapping.",
                     )
                 )
-                qualifiers = {}
 
             for qualifier_ref, qualifier_def in qualifier_defs.items():
                 q_datatype = qualifier_def.get("value", {}).get("type", "string")
-                q_value = qualifiers.get(qualifier_ref)
-                if q_value in (None, "", {}, []):
+                q_entries = qualifiers.get(qualifier_ref, [])
+                if not q_entries:
                     notices.append(
                         ConformanceNotice(
                             severity="warning",
@@ -310,47 +369,91 @@ def validate_entity_packet_data(
                     )
                     continue
 
-                q_result = validate_by_datatype(q_datatype, q_value)
-                notices.extend(
-                    _validation_result_notices(
-                        q_result,
-                        entity_ref=entity_ref,
-                        statement_ref=str(qualifier_ref),
-                        code_prefix="qualifier",
-                    )
-                )
-                if q_result.valid:
-                    normalized_qualifier = q_result.value
-                    if q_datatype in {"item", "wikibase-item"}:
-                        normalized_qualifier = _merge_wikibase_item_metadata(
-                            q_value,
-                            normalized_qualifier,
+                q_max_count = qualifier_def.get("max_count")
+                if isinstance(q_max_count, int) and len(q_entries) > q_max_count:
+                    notices.append(
+                        ConformanceNotice(
+                            severity="error",
+                            entity_ref=entity_ref,
+                            statement_ref=qualifier_ref,
+                            code="qualifier_max_count_exceeded",
+                            message=(
+                                f"Qualifier has {len(q_entries)} values, "
+                                f"but max_count is {q_max_count}."
+                            ),
                         )
-                    qualifiers[qualifier_ref] = normalized_qualifier
+                    )
 
-            references = statement_value.get("references", [])
-            if not isinstance(references, list):
+                normalized_entries: list[dict[str, Any]] = []
+                for q_index, q_entry in enumerate(q_entries):
+                    q_entry_normalized = _normalize_nested_statement_entry(q_entry)
+                    normalized_entries.append(q_entry_normalized)
+                    q_value = q_entry_normalized.get("value")
+
+                    if q_value in (None, "", {}, []):
+                        notices.append(
+                            ConformanceNotice(
+                                severity="warning",
+                                entity_ref=entity_ref,
+                                statement_ref=qualifier_ref,
+                                code="qualifier_missing_value",
+                                message=(
+                                    "Qualifier entry exists but has no value "
+                                    f"({qualifier_def.get('label', qualifier_ref)}) "
+                                    f"at position {q_index + 1}."
+                                ),
+                            )
+                        )
+                        continue
+
+                    q_result = validate_by_datatype(q_datatype, q_value)
+                    notices.extend(
+                        _validation_result_notices(
+                            q_result,
+                            entity_ref=entity_ref,
+                            statement_ref=str(qualifier_ref),
+                            code_prefix="qualifier",
+                        )
+                    )
+                    if q_result.valid:
+                        normalized_qualifier = q_result.value
+                        if q_datatype in {"item", "wikibase-item"}:
+                            normalized_qualifier = _merge_wikibase_item_metadata(
+                                q_value,
+                                normalized_qualifier,
+                            )
+                        q_entry_normalized["value"] = normalized_qualifier
+
+                qualifiers[qualifier_ref] = normalized_entries
+
+            for qualifier_ref in qualifiers.keys():
+                if qualifier_ref not in qualifier_defs:
+                    notices.append(
+                        ConformanceNotice(
+                            severity="warning",
+                            entity_ref=entity_ref,
+                            statement_ref=qualifier_ref,
+                            code="qualifier_unexpected",
+                            message=f"Qualifier {qualifier_ref} is not defined in profile statement.",
+                        )
+                    )
+
+            raw_references = statement_value.get("references", {})
+            references = _normalize_nested_statement_map(raw_references)
+            statement_value["references"] = references
+            if raw_references not in ({}, None, []) and not references:
                 notices.append(
                     ConformanceNotice(
                         severity="error",
                         entity_ref=entity_ref,
                         statement_ref=statement_ref,
                         code="references_shape_invalid",
-                        message="References must be stored as a list.",
+                        message="References must be stored as a URI-keyed mapping.",
                     )
                 )
-                references = []
 
-            present_reference_props = set()
-            for ref_entry in references:
-                if not isinstance(ref_entry, dict):
-                    continue
-                ref_prop = ref_entry.get("property")
-                ref_value = ref_entry.get("value")
-                if not isinstance(ref_prop, str):
-                    continue
-                present_reference_props.add(ref_prop)
-
+            present_reference_props = set(references.keys())
+            for ref_prop, ref_entries in references.items():
                 ref_def = reference_defs.get(ref_prop)
                 if not ref_def:
                     notices.append(
@@ -365,35 +468,60 @@ def validate_entity_packet_data(
                     continue
 
                 r_datatype = ref_def.get("value", {}).get("type", "string")
-                if ref_value in (None, "", {}, []):
+                r_max_count = ref_def.get("max_count")
+                if isinstance(r_max_count, int) and len(ref_entries) > r_max_count:
                     notices.append(
                         ConformanceNotice(
-                            severity="warning",
+                            severity="error",
                             entity_ref=entity_ref,
                             statement_ref=ref_prop,
-                            code="reference_missing_value",
-                            message="Reference entry exists but has no value.",
+                            code="reference_max_count_exceeded",
+                            message=(
+                                f"Reference has {len(ref_entries)} values, "
+                                f"but max_count is {r_max_count}."
+                            ),
                         )
                     )
-                    continue
 
-                r_result = validate_by_datatype(r_datatype, ref_value)
-                notices.extend(
-                    _validation_result_notices(
-                        r_result,
-                        entity_ref=entity_ref,
-                        statement_ref=str(ref_prop),
-                        code_prefix="reference",
-                    )
-                )
-                if r_result.valid:
-                    normalized_reference = r_result.value
-                    if r_datatype in {"item", "wikibase-item"}:
-                        normalized_reference = _merge_wikibase_item_metadata(
-                            ref_value,
-                            normalized_reference,
+                normalized_entries: list[dict[str, Any]] = []
+                for ref_index, ref_entry in enumerate(ref_entries):
+                    ref_entry_normalized = _normalize_nested_statement_entry(ref_entry)
+                    normalized_entries.append(ref_entry_normalized)
+                    ref_value = ref_entry_normalized.get("value")
+                    if ref_value in (None, "", {}, []):
+                        notices.append(
+                            ConformanceNotice(
+                                severity="warning",
+                                entity_ref=entity_ref,
+                                statement_ref=ref_prop,
+                                code="reference_missing_value",
+                                message=(
+                                    "Reference entry exists but has no value "
+                                    f"at position {ref_index + 1}."
+                                ),
+                            )
                         )
-                    ref_entry["value"] = normalized_reference
+                        continue
+
+                    r_result = validate_by_datatype(r_datatype, ref_value)
+                    notices.extend(
+                        _validation_result_notices(
+                            r_result,
+                            entity_ref=entity_ref,
+                            statement_ref=str(ref_prop),
+                            code_prefix="reference",
+                        )
+                    )
+                    if r_result.valid:
+                        normalized_reference = r_result.value
+                        if r_datatype in {"item", "wikibase-item"}:
+                            normalized_reference = _merge_wikibase_item_metadata(
+                                ref_value,
+                                normalized_reference,
+                            )
+                        ref_entry_normalized["value"] = normalized_reference
+
+                references[ref_prop] = normalized_entries
 
             for ref_prop, ref_def in reference_defs.items():
                 if ref_prop not in present_reference_props:

--- a/gkc/profiles/forms/wizard/steps.py
+++ b/gkc/profiles/forms/wizard/steps.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import urllib.request
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -75,6 +76,88 @@ def _statement_consequence(statement_def: dict[str, Any]) -> str:
 
 def _statement_label(statement_def: dict[str, Any]) -> str:
     return statement_def.get("label") or _statement_key(statement_def).split("/")[-1]
+
+
+def _empty_statement_entry(value: Any = None) -> dict[str, Any]:
+    return {
+        "value": value,
+        "qualifiers": {},
+        "references": {},
+    }
+
+
+def _normalize_statement_entry(entry: Any) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        return _empty_statement_entry(entry)
+
+    if not any(key in entry for key in ("value", "qualifiers", "references")):
+        return _empty_statement_entry(entry)
+
+    normalized = {
+        "value": entry.get("value"),
+        "qualifiers": entry.get("qualifiers", {}),
+        "references": entry.get("references", {}),
+    }
+    if not isinstance(normalized["qualifiers"], dict):
+        normalized["qualifiers"] = {}
+    if not isinstance(normalized["references"], dict):
+        normalized["references"] = {}
+    return normalized
+
+
+def _coerce_nested_statement_map(raw: Any) -> dict[str, list[dict[str, Any]]]:
+    """Normalize nested qualifier/reference storage to URI-keyed statement lists."""
+    normalized: dict[str, list[dict[str, Any]]] = {}
+
+    if isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            statement_ref = entry.get("property") or entry.get("statement")
+            if not isinstance(statement_ref, str) or not statement_ref:
+                continue
+            normalized.setdefault(statement_ref, []).append(
+                _normalize_statement_entry({"value": entry.get("value")})
+            )
+        return normalized
+
+    if not isinstance(raw, dict):
+        return normalized
+
+    for statement_ref, payload in raw.items():
+        if not isinstance(statement_ref, str) or not statement_ref:
+            continue
+
+        if isinstance(payload, list):
+            entries = [_normalize_statement_entry(entry) for entry in payload]
+        else:
+            entries = [_normalize_statement_entry(payload)]
+
+        normalized[statement_ref] = entries
+
+    return normalized
+
+
+def _ensure_nested_statement_map(
+    statement_value: dict[str, Any],
+    field_name: str,
+) -> dict[str, list[dict[str, Any]]]:
+    normalized = _coerce_nested_statement_map(statement_value.get(field_name))
+    statement_value[field_name] = normalized
+    return normalized
+
+
+def _has_parent_derived_value(statement_def: dict[str, Any]) -> bool:
+    value_block = statement_def.get("value", {})
+    return value_block.get("value_source") == "statement_value"
+
+
+def _has_meaningful_value(value: Any) -> bool:
+    if value in (None, "", [], {}):
+        return False
+    if isinstance(value, dict):
+        return any(_has_meaningful_value(member) for member in value.values())
+    return True
 
 
 def _is_fixed(statement_def: dict[str, Any]) -> bool:
@@ -247,16 +330,12 @@ def _statement_value_list_candidates(
     Returns a tuple of (candidates, error_message).
     """
     value_block = statement_def.get("value", {})
-    statement_ref = _statement_key(statement_def)
-
-    packet = st.session_state.get("packet", {})
-    route_map = packet.get("value_list_routes", {}) if isinstance(packet, dict) else {}
-    route = route_map.get(statement_ref, {}) if isinstance(route_map, dict) else {}
 
     cache_ref = value_block.get("value_list_reference")
-    if not isinstance(cache_ref, str) or not cache_ref:
-        cache_ref = route.get("cache_path") if isinstance(route, dict) else None
-
+    # Value-list behavior is statement-local in JSON profile contracts.
+    # Do not infer from packet-level route maps when the statement omits
+    # value_list_reference, otherwise one statement's constrained picker can
+    # incorrectly bleed into every use of the same statement URI.
     if not isinstance(cache_ref, str) or not cache_ref:
         return [], None
 
@@ -531,14 +610,14 @@ class StatementsStep(Step):
 
         draft_data["statements"].setdefault(stmt_key, [])
         current_values = draft_data["statements"][stmt_key]
+        draft_data["statements"][stmt_key] = [
+            _normalize_statement_entry(entry) for entry in current_values
+        ]
+        current_values = draft_data["statements"][stmt_key]
 
         if _is_fixed(statement_def) and not current_values:
             current_values.append(
-                {
-                    "value": _initial_fixed_value(statement_def),
-                    "qualifiers": {},
-                    "references": [],
-                }
+                _empty_statement_entry(_initial_fixed_value(statement_def))
             )
 
         auto_expand = (
@@ -575,16 +654,20 @@ class StatementsStep(Step):
                             st.rerun()
 
                     self._render_value_input(statement_def, value_data, idx, is_fixed)
+                    parent_value = value_data.get("value")
                     self._render_qualifiers(statement_def, value_data, idx)
-                    self._render_references(statement_def, value_data, idx)
+                    self._render_references(
+                        statement_def,
+                        value_data,
+                        idx,
+                        parent_value=parent_value,
+                    )
 
             max_count = statement_def.get("max_count")
             can_add_more = (max_count is None) or (len(current_values) < max_count)
             if not is_fixed and can_add_more:
                 if st.button(f"➕ Add {stmt_label}", key=f"add_stmt_{stmt_key}"):
-                    current_values.append(
-                        {"value": None, "qualifiers": {}, "references": []}
-                    )
+                    current_values.append(_empty_statement_entry())
                     st.rerun()
 
     def _render_value_input(
@@ -632,75 +715,184 @@ class StatementsStep(Step):
         if not qualifiers:
             return
 
-        st.write("**Qualifiers**")
-        value_data.setdefault("qualifiers", {})
-
-        for qualifier_def in qualifiers:
-            if not isinstance(qualifier_def, dict):
-                continue
-            qual_key = _statement_key(qualifier_def)
-            qual_label = _statement_label(qualifier_def)
-            qual_dtype = _value_datatype(qualifier_def.get("value", {}))
-            current = value_data["qualifiers"].get(qual_key)
-
-            widget_kwargs = _value_list_widget_kwargs(qualifier_def)
-            original_value = WidgetFactory.render_widget(
-                datatype=qual_dtype,
-                label=qual_label,
-                value=current,
-                key=f"qual_{_statement_key(statement_def)}_{qual_key}_{idx}",
-                help_text=_statement_prompt(qualifier_def),
-                **widget_kwargs,
-            )
-            value_data["qualifiers"][qual_key] = _normalize_rendered_value(
-                datatype=qual_dtype,
-                value=original_value,
-                statement_ref=qual_key,
-            )
+        self._render_nested_statement_section(
+            section_label="Qualifiers",
+            category_label="qualifier",
+            field_name="qualifiers",
+            parent_statement_def=statement_def,
+            nested_defs=qualifiers,
+            value_data=value_data,
+            idx=idx,
+            parent_value=value_data.get("value"),
+        )
 
     def _render_references(
-        self, statement_def: dict[str, Any], value_data: dict[str, Any], idx: int
+        self,
+        statement_def: dict[str, Any],
+        value_data: dict[str, Any],
+        idx: int,
+        *,
+        parent_value: Any,
     ) -> None:
         references = statement_def.get("references", [])
         if not references:
             return
 
-        st.write("**References**")
-        value_data.setdefault("references", [])
+        self._render_nested_statement_section(
+            section_label="References",
+            category_label="reference",
+            field_name="references",
+            parent_statement_def=statement_def,
+            nested_defs=references,
+            value_data=value_data,
+            idx=idx,
+            parent_value=parent_value,
+        )
 
-        by_ref_key = {
-            r.get("property"): r
-            for r in value_data["references"]
-            if isinstance(r, dict)
-        }
+    def _render_nested_statement_section(
+        self,
+        *,
+        section_label: str,
+        category_label: str,
+        field_name: str,
+        parent_statement_def: dict[str, Any],
+        nested_defs: list[dict[str, Any]],
+        value_data: dict[str, Any],
+        idx: int,
+        parent_value: Any,
+    ) -> None:
+        st.write(f"**{section_label}**")
+        st.caption(f"Choose which {category_label} statements to add for this value.")
 
-        updated: list[dict[str, Any]] = []
-        for ref_def in references:
-            if not isinstance(ref_def, dict):
+        nested_values = _ensure_nested_statement_map(value_data, field_name)
+        parent_stmt_key = _statement_key(parent_statement_def)
+
+        for nested_def in nested_defs:
+            if not isinstance(nested_def, dict):
                 continue
 
-            ref_key = _statement_key(ref_def)
-            ref_label = _statement_label(ref_def)
-            ref_dtype = _value_datatype(ref_def.get("value", {}))
-            existing = by_ref_key.get(ref_key, {"property": ref_key, "value": None})
-            widget_kwargs = _value_list_widget_kwargs(ref_def)
-
-            ref_value = WidgetFactory.render_widget(
-                datatype=ref_dtype,
-                label=ref_label,
-                value=existing.get("value"),
-                key=f"ref_{_statement_key(statement_def)}_{ref_key}_{idx}",
-                help_text=_statement_prompt(ref_def),
-                **widget_kwargs,
-            )
-            updated.append({"property": ref_key, "value": ref_value})
-            updated[-1]["value"] = _normalize_rendered_value(
-                datatype=ref_dtype,
-                value=ref_value,
-                statement_ref=ref_key,
+            nested_key = _statement_key(nested_def)
+            nested_label = _statement_label(nested_def)
+            entries = nested_values.setdefault(nested_key, [])
+            max_count = nested_def.get("max_count")
+            can_add_more = (max_count is None) or (len(entries) < max_count)
+            derived_from_parent = _has_parent_derived_value(nested_def)
+            parent_ready = _has_meaningful_value(parent_value)
+            add_disabled = not can_add_more or (
+                derived_from_parent and not parent_ready
             )
 
-        value_data["references"] = updated
+            add_help = _statement_prompt(nested_def) or _statement_guidance(nested_def)
+            if st.button(
+                f"Add {nested_label} {category_label}",
+                key=f"add_{field_name}_{parent_stmt_key}_{nested_key}_{idx}",
+                disabled=add_disabled,
+                help=add_help,
+            ):
+                entry = _empty_statement_entry()
+                if derived_from_parent and parent_ready:
+                    entry["value"] = deepcopy(parent_value)
+                entries.append(entry)
+                st.rerun()
+
+            if derived_from_parent and not parent_ready and not entries:
+                st.caption(
+                    f"{nested_label} becomes available after the statement value is set."
+                )
+
+            for nested_idx, entry in enumerate(entries):
+                normalized_entry = _normalize_statement_entry(entry)
+                entries[nested_idx] = normalized_entry
+
+                with st.container(border=True):
+                    c1, c2 = st.columns([5, 1])
+                    with c1:
+                        st.markdown(
+                            f"**{nested_label} {category_label} {nested_idx + 1}**"
+                        )
+                    with c2:
+                        if st.button(
+                            "🗑️",
+                            key=(
+                                f"delete_{field_name}_{parent_stmt_key}_{nested_key}_"
+                                f"{idx}_{nested_idx}"
+                            ),
+                        ):
+                            entries.pop(nested_idx)
+                            st.rerun()
+
+                    self._render_nested_value_input(
+                        nested_def=nested_def,
+                        nested_entry=normalized_entry,
+                        widget_key=(
+                            f"{field_name}_{parent_stmt_key}_{nested_key}_{idx}_{nested_idx}"
+                        ),
+                        parent_value=parent_value,
+                    )
+
+    def _render_nested_value_input(
+        self,
+        *,
+        nested_def: dict[str, Any],
+        nested_entry: dict[str, Any],
+        widget_key: str,
+        parent_value: Any,
+    ) -> None:
+        prompt = _statement_prompt(nested_def)
+        if prompt:
+            st.caption(prompt)
+
+        guidance = _statement_guidance(nested_def)
+        if guidance:
+            with st.popover("ℹ️ Guidance"):
+                st.write(guidance)
+
+        if _is_fixed(nested_def):
+            fixed_value = _initial_fixed_value(nested_def)
+            st.text_input(
+                "Value",
+                value=str(fixed_value or ""),
+                key=f"fixed_{widget_key}",
+                disabled=True,
+            )
+            nested_entry["value"] = fixed_value
+            return
+
+        value_block = nested_def.get("value", {})
+        dtype = _value_datatype(value_block)
+        current_value = nested_entry.get("value")
+        disabled = False
+
+        if _has_parent_derived_value(nested_def):
+            nested_entry["value"] = (
+                deepcopy(parent_value) if _has_meaningful_value(parent_value) else None
+            )
+            current_value = nested_entry["value"]
+            disabled = True
+            st.info("This value is derived from the parent statement value.")
+
+        widget_kwargs = _value_list_widget_kwargs(nested_def)
+        original_value = WidgetFactory.render_widget(
+            datatype=dtype,
+            label="Value",
+            value=current_value,
+            key=f"value_{widget_key}",
+            help_text=prompt,
+            disabled=disabled,
+            **widget_kwargs,
+        )
+
+        if disabled:
+            nested_entry["value"] = (
+                deepcopy(parent_value) if _has_meaningful_value(parent_value) else None
+            )
+            return
+
+        nested_entry["value"] = _normalize_rendered_value(
+            datatype=dtype,
+            value=original_value,
+            statement_ref=_statement_key(nested_def),
+        )
 
     def validate(self, draft_data: dict[str, Any]) -> dict[str, list[str]]:
         warnings: dict[str, list[str]] = {}

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -1373,6 +1373,7 @@ class EntityProfileJsonBuilder:
     ALIAS_GUIDANCE = "P187"
 
     SAME_AS = "P212"
+    WIKIDATA_ENTITY_URL = "P5"
     GKC_ENTITY_PROFILE_CLASS = "Q3"
     GKC_VALUE_LIST_CLASS = "Q7"
     WIKIDATA_ENTITY_CLASS = "Q52"
@@ -1804,9 +1805,7 @@ class EntityProfileJsonBuilder:
                 claim.get("qualifiers", {}), self.HAS_VALUE
             )
             effective = overlay if overlay else intrinsic
-            linkages.append(
-                (statement_id, self._dedupe_preserve_order(effective))
-            )
+            linkages.append((statement_id, self._dedupe_preserve_order(effective)))
         return linkages
 
     def _build_profile_statements(
@@ -2217,7 +2216,13 @@ class EntityProfileJsonBuilder:
                 payload["value_list_reference"] = f"cache/queries/{target_id}.json"
 
             if self.WIKIDATA_ENTITY_CLASS in type_ids:
-                for url in self._entity_string_claim_values(target_doc, self.SAME_AS):
+                wikidata_urls = self._dedupe_preserve_order(
+                    self._entity_string_claim_values(target_doc, self.SAME_AS)
+                    + self._entity_string_claim_values(
+                        target_doc, self.WIKIDATA_ENTITY_URL
+                    )
+                )
+                for url in wikidata_urls:
                     qid = self._extract_wikidata_qid_from_url(url)
                     if qid:
                         value_list.append({"item": qid, "itemLabel": target_label})
@@ -2517,19 +2522,12 @@ class EntityProfileJsonBuilder:
             qualifiers, self.APPLIES_TO_STATEMENT
         )
 
-        profile_matches = (
-            not applies_to_profiles
-            or (
-                current_profile_id is not None
-                and current_profile_id in applies_to_profiles
-            )
+        profile_matches = not applies_to_profiles or (
+            current_profile_id is not None and current_profile_id in applies_to_profiles
         )
-        statement_matches = (
-            not applies_to_statements
-            or (
-                parent_statement_id is not None
-                and parent_statement_id in applies_to_statements
-            )
+        statement_matches = not applies_to_statements or (
+            parent_statement_id is not None
+            and parent_statement_id in applies_to_statements
         )
         return profile_matches and statement_matches
 

--- a/tests/test_spirit_safe_entity_profile_json.py
+++ b/tests/test_spirit_safe_entity_profile_json.py
@@ -281,6 +281,101 @@ def test_value_list_graph_includes_reference_and_qualifier_routes(tmp_path):
     ]
 
 
+def test_profile_statement_has_value_link_to_wikidata_entity_emits_fixed_value_list(
+    tmp_path,
+):
+    """P161 links to Q52-typed entities should emit fixed value list entries."""
+
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+
+    profile_payload = {
+        "entity_id": "Q4",
+        "entity": {
+            "labels": {"mul": {"value": "Example profile"}},
+            "descriptions": {"mul": {"value": "Example profile"}},
+            "aliases": {},
+            "claims": {
+                "P1": [_build_entity_claim_entity_id("Q3")],
+                "P188": [_build_entity_claim_monolingual("Enter label")],
+                "P189": [_build_entity_claim_monolingual("Enter description")],
+                "P190": [_build_entity_claim_monolingual("Enter aliases")],
+                "P157": [
+                    {
+                        "mainsnak": {
+                            "datavalue": {
+                                "value": {"id": "Q16"},
+                            }
+                        },
+                        "qualifiers": {
+                            "P161": [_build_qualifier_entity_id("Q54")],
+                        },
+                    }
+                ],
+            },
+        },
+    }
+    (cache_entities_dir / "Q4.json").write_text(
+        json.dumps(profile_payload), encoding="utf-8"
+    )
+
+    statement_payloads = {
+        "Q16": {
+            "entity_id": "Q16",
+            "entity": {
+                "labels": {"mul": {"value": "instance of"}},
+                "claims": {
+                    "P5": [
+                        _build_entity_claim_string("http://www.wikidata.org/entity/P31")
+                    ],
+                    "P194": [_build_entity_claim_entity_id("Q52")],
+                    "P171": [_build_entity_claim_monolingual("Statement prompt")],
+                },
+            },
+        },
+        "Q54": {
+            "entity_id": "Q54",
+            "entity": {
+                "labels": {
+                    "mul": {
+                        "value": "federally recognized Native American tribe in the United States"
+                    }
+                },
+                "claims": {
+                    "P1": [_build_entity_claim_entity_id("Q52")],
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/Q7840353"
+                        )
+                    ],
+                },
+            },
+        },
+        "Q52": {
+            "entity_id": "Q52",
+            "entity": {
+                "labels": {"mul": {"value": "Wikidata Entity"}},
+                "claims": {},
+            },
+        },
+    }
+
+    for entity_id, payload in statement_payloads.items():
+        (cache_entities_dir / f"{entity_id}.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    docs = build_entity_profile_json_documents(cache_entities_dir)
+    value_payload = docs[0]["statements"][0]["value"]
+
+    assert value_payload["value_list"] == [
+        {
+            "item": "Q7840353",
+            "itemLabel": "federally recognized Native American tribe in the United States",
+        }
+    ]
+
+
 def test_reference_statement_derives_value_from_parent_statement(tmp_path):
     """Nested reference should expose statement_value source when P213 matches parent."""
 
@@ -520,7 +615,9 @@ def test_statement_level_value_claim_respects_p163_parent_scope(tmp_path):
             "entity": {
                 "labels": {"mul": {"value": "instance of"}},
                 "claims": {
-                    "P5": [_build_entity_claim_string("http://www.wikidata.org/entity/P31")],
+                    "P5": [
+                        _build_entity_claim_string("http://www.wikidata.org/entity/P31")
+                    ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
                     "P171": [_build_entity_claim_monolingual("Statement prompt")],
                 },
@@ -531,7 +628,11 @@ def test_statement_level_value_claim_respects_p163_parent_scope(tmp_path):
             "entity": {
                 "labels": {"mul": {"value": "applies to jurisdiction"}},
                 "claims": {
-                    "P5": [_build_entity_claim_string("http://www.wikidata.org/entity/P1001")],
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P1001"
+                        )
+                    ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
                     "P171": [_build_entity_claim_monolingual("Qualifier prompt")],
                     "P161": [
@@ -621,7 +722,11 @@ def test_profile_level_p158_claim_overrides_targeted_nested_statement_only(tmp_p
                         "mainsnak": {"datavalue": {"value": {"id": "Q41"}}},
                         "qualifiers": {
                             "P163": [_build_qualifier_entity_id("Q16")],
-                            "P171": [_build_qualifier_monolingual("Override qualifier prompt")],
+                            "P171": [
+                                _build_qualifier_monolingual(
+                                    "Override qualifier prompt"
+                                )
+                            ],
                         },
                     }
                 ],
@@ -638,7 +743,9 @@ def test_profile_level_p158_claim_overrides_targeted_nested_statement_only(tmp_p
             "entity": {
                 "labels": {"mul": {"value": "instance of"}},
                 "claims": {
-                    "P5": [_build_entity_claim_string("http://www.wikidata.org/entity/P31")],
+                    "P5": [
+                        _build_entity_claim_string("http://www.wikidata.org/entity/P31")
+                    ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
                     "P171": [_build_entity_claim_monolingual("Statement prompt")],
                     "P158": [
@@ -653,9 +760,15 @@ def test_profile_level_p158_claim_overrides_targeted_nested_statement_only(tmp_p
             "entity": {
                 "labels": {"mul": {"value": "applies to jurisdiction"}},
                 "claims": {
-                    "P5": [_build_entity_claim_string("http://www.wikidata.org/entity/P1001")],
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P1001"
+                        )
+                    ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
-                    "P171": [_build_entity_claim_monolingual("Default qualifier prompt")],
+                    "P171": [
+                        _build_entity_claim_monolingual("Default qualifier prompt")
+                    ],
                 },
             },
         },
@@ -664,9 +777,15 @@ def test_profile_level_p158_claim_overrides_targeted_nested_statement_only(tmp_p
             "entity": {
                 "labels": {"mul": {"value": "point in time"}},
                 "claims": {
-                    "P5": [_build_entity_claim_string("http://www.wikidata.org/entity/P585")],
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P585"
+                        )
+                    ],
                     "P194": [_build_entity_claim_entity_id("Q55")],
-                    "P171": [_build_entity_claim_monolingual("Untouched qualifier prompt")],
+                    "P171": [
+                        _build_entity_claim_monolingual("Untouched qualifier prompt")
+                    ],
                 },
             },
         },
@@ -741,7 +860,9 @@ def test_profile_level_max_count_overrides_statement_level_baseline(tmp_path):
             "entity": {
                 "labels": {"mul": {"value": "instance of"}},
                 "claims": {
-                    "P5": [_build_entity_claim_string("http://www.wikidata.org/entity/P31")],
+                    "P5": [
+                        _build_entity_claim_string("http://www.wikidata.org/entity/P31")
+                    ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
                     "P171": [_build_entity_claim_monolingual("Statement prompt")],
                     "P182": [_build_entity_claim_quantity("+3")],
@@ -753,7 +874,11 @@ def test_profile_level_max_count_overrides_statement_level_baseline(tmp_path):
             "entity": {
                 "labels": {"mul": {"value": "part of"}},
                 "claims": {
-                    "P5": [_build_entity_claim_string("http://www.wikidata.org/entity/P361")],
+                    "P5": [
+                        _build_entity_claim_string(
+                            "http://www.wikidata.org/entity/P361"
+                        )
+                    ],
                     "P194": [_build_entity_claim_entity_id("Q52")],
                     "P171": [_build_entity_claim_monolingual("Statement prompt")],
                     "P182": [_build_entity_claim_quantity("+2")],

--- a/tests/test_wizard_validation_bridge.py
+++ b/tests/test_wizard_validation_bridge.py
@@ -113,3 +113,136 @@ def test_validate_entity_packet_data_warns_missing_expected_reference() -> None:
     assert any(
         n.code == "reference_missing" and n.severity == "warning" for n in notices
     )
+
+
+def test_validate_entity_packet_data_accepts_statement_shaped_nested_entries() -> None:
+    statement_ref = "https://datadistillery.wikibase.cloud/entity/Q19"
+    qualifier_ref = "https://datadistillery.wikibase.cloud/entity/Q27"
+    reference_ref = "https://datadistillery.wikibase.cloud/entity/Q29"
+
+    packet = {
+        "value_list_routes": {},
+        "entities": [
+            {
+                "id": "ent-001",
+                "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+                "statements": [
+                    {
+                        "entity": statement_ref,
+                        "label": "official website",
+                        "value": {"type": "url"},
+                        "max_count": 1,
+                        "qualifiers": [
+                            {
+                                "entity": qualifier_ref,
+                                "label": "language of work or name",
+                                "value": {"type": "wikibase-item"},
+                                "max_count": 1,
+                            }
+                        ],
+                        "references": [
+                            {
+                                "entity": reference_ref,
+                                "label": "reference URL",
+                                "value": {"type": "url"},
+                                "max_count": 1,
+                            }
+                        ],
+                    }
+                ],
+                "data": {
+                    "statements": {
+                        statement_ref: [
+                            {
+                                "value": "https://example.org",
+                                "qualifiers": {
+                                    qualifier_ref: [
+                                        {
+                                            "value": {
+                                                "id": "Q1860",
+                                                "item": "http://www.wikidata.org/entity/Q1860",
+                                                "itemLabel": "English",
+                                            }
+                                        }
+                                    ]
+                                },
+                                "references": {
+                                    reference_ref: [
+                                        {"value": "https://example.org/source"}
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                },
+            }
+        ],
+    }
+
+    notices = validate_entity_packet_data(
+        entity_slot=packet["entities"][0],
+        packet=packet,
+        source_root=None,
+    )
+
+    assert not any(n.code.endswith("shape_invalid") for n in notices)
+    assert not any(n.severity == "error" for n in notices)
+
+
+def test_validate_entity_packet_data_reports_nested_reference_max_count() -> None:
+    statement_ref = "https://datadistillery.wikibase.cloud/entity/Q21"
+    reference_ref = "https://datadistillery.wikibase.cloud/entity/Q29"
+
+    packet = {
+        "value_list_routes": {},
+        "entities": [
+            {
+                "id": "ent-001",
+                "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+                "statements": [
+                    {
+                        "entity": statement_ref,
+                        "label": "member count",
+                        "value": {"type": "quantity"},
+                        "max_count": 1,
+                        "qualifiers": [],
+                        "references": [
+                            {
+                                "entity": reference_ref,
+                                "label": "reference URL",
+                                "value": {"type": "url"},
+                                "max_count": 1,
+                            }
+                        ],
+                    }
+                ],
+                "data": {
+                    "statements": {
+                        statement_ref: [
+                            {
+                                "value": {"amount": "+100", "unit": "1"},
+                                "qualifiers": {},
+                                "references": {
+                                    reference_ref: [
+                                        {"value": "https://example.org/1"},
+                                        {"value": "https://example.org/2"},
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                },
+            }
+        ],
+    }
+
+    notices = validate_entity_packet_data(
+        entity_slot=packet["entities"][0],
+        packet=packet,
+        source_root=Path("/tmp"),
+    )
+
+    assert any(
+        n.code == "reference_max_count_exceeded" and n.severity == "error"
+        for n in notices
+    )

--- a/tests/test_wizard_value_list_integration.py
+++ b/tests/test_wizard_value_list_integration.py
@@ -10,6 +10,7 @@ from gkc.profiles.forms.validation_bridge import (
     validate_inline_value,
 )
 from gkc.profiles.forms.wizard.steps import (
+    _coerce_nested_statement_map,
     _extract_value_list_candidates,
     _filter_value_list_candidates,
     _materialize_value_list_cache,
@@ -133,7 +134,62 @@ def test_materialize_value_list_cache_from_local_source(
         )
 
 
-def test_value_list_widget_kwargs_uses_packet_route_for_nested_statement(
+def test_value_list_widget_kwargs_uses_statement_local_value_list_reference(
+    monkeypatch, tmp_path: Path
+) -> None:
+    spirit_safe_root = tmp_path / "SpiritSafe"
+    source_file = spirit_safe_root / "cache" / "queries" / "Q28.json"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(
+        '{"items": [{"item": "http://www.wikidata.org/entity/Q1", "itemLabel": "Universe"}]}',
+        encoding="utf-8",
+    )
+
+    original_source = gkc.get_spirit_safe_source()
+    original_session = dict(st.session_state)
+    gkc.set_spirit_safe_source(mode="local", local_root=spirit_safe_root)
+
+    try:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        st.session_state.clear()
+        st.session_state["packet"] = {
+            "value_list_routes": {
+                "https://datadistillery.wikibase.cloud/entity/Q30": {
+                    "cache_path": "cache/queries/Q28.json"
+                }
+            }
+        }
+        st.session_state["source_root"] = str(spirit_safe_root)
+
+        widget_kwargs = _value_list_widget_kwargs(
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q30",
+                "label": "stated in",
+                "value": {
+                    "type": "wikibase-item",
+                    "value_list_reference": "cache/queries/Q28.json",
+                },
+            }
+        )
+
+        assert widget_kwargs["all_item_options_count"] == 1
+        assert (
+            widget_kwargs["item_options"][0]["item"]
+            == "http://www.wikidata.org/entity/Q1"
+        )
+        assert widget_kwargs["item_options"][0]["itemLabel"] == "Universe"
+    finally:
+        st.session_state.clear()
+        st.session_state.update(original_session)
+        gkc.set_spirit_safe_source(
+            mode=original_source.mode,
+            github_repo=original_source.github_repo,
+            github_ref=original_source.github_ref,
+            local_root=original_source.local_root,
+        )
+
+
+def test_value_list_widget_kwargs_does_not_fallback_to_route_only(
     monkeypatch, tmp_path: Path
 ) -> None:
     spirit_safe_root = tmp_path / "SpiritSafe"
@@ -168,12 +224,7 @@ def test_value_list_widget_kwargs_uses_packet_route_for_nested_statement(
             }
         )
 
-        assert widget_kwargs["all_item_options_count"] == 1
-        assert (
-            widget_kwargs["item_options"][0]["item"]
-            == "http://www.wikidata.org/entity/Q1"
-        )
-        assert widget_kwargs["item_options"][0]["itemLabel"] == "Universe"
+        assert widget_kwargs == {}
     finally:
         st.session_state.clear()
         st.session_state.update(original_session)
@@ -183,3 +234,37 @@ def test_value_list_widget_kwargs_uses_packet_route_for_nested_statement(
             github_ref=original_source.github_ref,
             local_root=original_source.local_root,
         )
+
+
+def test_coerce_nested_statement_map_from_legacy_reference_list() -> None:
+    statement_ref = "https://datadistillery.wikibase.cloud/entity/Q29"
+
+    normalized = _coerce_nested_statement_map(
+        [
+            {"property": statement_ref, "value": "https://example.org/source"},
+            {"property": statement_ref, "value": "https://example.org/backup"},
+        ]
+    )
+
+    assert list(normalized.keys()) == [statement_ref]
+    assert [entry["value"] for entry in normalized[statement_ref]] == [
+        "https://example.org/source",
+        "https://example.org/backup",
+    ]
+
+
+def test_coerce_nested_statement_map_from_legacy_qualifier_scalar_map() -> None:
+    statement_ref = "https://datadistillery.wikibase.cloud/entity/Q27"
+
+    normalized = _coerce_nested_statement_map(
+        {
+            statement_ref: {
+                "id": "Q1860",
+                "item": "http://www.wikidata.org/entity/Q1860",
+                "itemLabel": "English",
+            }
+        }
+    )
+
+    assert list(normalized.keys()) == [statement_ref]
+    assert normalized[statement_ref][0]["value"]["id"] == "Q1860"


### PR DESCRIPTION
## Summary
- Fix profile JSON generation for `has value` links to Wikidata Entity items so fixed values are emitted from linked Wikidata URLs.
- Keep wizard qualifier/reference handling statement-scoped with explicit add-per-statement UX and statement-shaped nested storage.
- Prevent value-list picker bleed across statement contexts by requiring statement-local `value.value_list_reference`.

## Key Changes
- `gkc/spirit_safe.py`
  - Updated value payload assembly to emit fixed `value_list` entries when `has value` points to a Wikidata Entity item, including Q4 `instance of` behavior.
- `gkc/profiles/forms/wizard/steps.py`
  - Refactored qualifier/reference UI to add statements explicitly per qualifier/reference definition.
  - Migrated nested state to URI-keyed statement entries.
  - Limited value-list pickers to explicit statement-local `value_list_reference` only.
- `gkc/profiles/forms/validation_bridge.py`
  - Added normalization and validation for statement-shaped nested qualifier/reference entries and nested max-count checks.

## Tests
- Added and updated regression coverage in:
  - `tests/test_spirit_safe_entity_profile_json.py`
  - `tests/test_wizard_validation_bridge.py`
  - `tests/test_wizard_value_list_integration.py`

## Validation Run
- Full pre-merge validation passed:
  - `./scripts/pre-merge-check.sh`
