### PR TITLE
Profile-level ref/qualifier overrides supersede statement defaults

### DIFF
--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -2011,31 +2011,37 @@ class EntityProfileJsonBuilder:
         current_profile_id: Optional[str],
         parent_statement_id: Optional[str],
     ) -> list[dict[str, Any]]:
-        """Resolve nested statement specs with partial profile-level override semantics."""
+        """Resolve nested statement specs with profile-level supersede semantics.
+
+        When profile-level override claims (P158/P211 with P163) are present for a
+        statement, they fully supersede the underlying statement entity's defaults.
+        Statement-level defaults are only used when no profile-level overrides exist.
+        """
 
         candidates: list[dict[str, Any]] = []
         order = 0
 
-        for claim in statement_claims:
-            if not self._claim_applies_in_context(
-                claim,
-                current_profile_id=current_profile_id,
-                parent_statement_id=parent_statement_id,
-            ):
-                continue
-            entity_id = self._claim_entity_id(claim)
-            if not entity_id:
-                continue
-            candidates.append(
-                {
-                    "entity_id": entity_id,
-                    "overlay_qualifiers": claim.get("qualifiers", {}),
-                    "source_rank": 1,
-                    "scope_rank": self._claim_scope_rank(claim),
-                    "order": order,
-                }
-            )
-            order += 1
+        if not profile_override_claims:
+            for claim in statement_claims:
+                if not self._claim_applies_in_context(
+                    claim,
+                    current_profile_id=current_profile_id,
+                    parent_statement_id=parent_statement_id,
+                ):
+                    continue
+                entity_id = self._claim_entity_id(claim)
+                if not entity_id:
+                    continue
+                candidates.append(
+                    {
+                        "entity_id": entity_id,
+                        "overlay_qualifiers": claim.get("qualifiers", {}),
+                        "source_rank": 1,
+                        "scope_rank": self._claim_scope_rank(claim),
+                        "order": order,
+                    }
+                )
+                order += 1
 
         for entity_id in claim_level_overlay_ids:
             candidates.append(

--- a/tests/test_spirit_safe_entity_profile_json.py
+++ b/tests/test_spirit_safe_entity_profile_json.py
@@ -695,8 +695,14 @@ def test_statement_level_value_claim_respects_p163_parent_scope(tmp_path):
     assert qualifier["value"]["value_list_reference"] == "cache/queries/Q43.json"
 
 
-def test_profile_level_p158_claim_overrides_targeted_nested_statement_only(tmp_path):
-    """Profile-level P158 claim should override only the targeted nested statement spec."""
+def test_profile_level_p158_claim_supersedes_statement_level_defaults(tmp_path):
+    """Profile-level P158 claim should fully supersede all statement-level qualifier defaults.
+
+    When a profile carries P158 (has qualifier) claims targeting a specific statement
+    via P163 (applies to statement), those override claims replace the entire set of
+    qualifier defaults from the underlying statement entity — not just the same-entity
+    entries.  Statement-level defaults that lack a profile counterpart are dropped.
+    """
 
     cache_entities_dir = tmp_path / "cache" / "entities"
     cache_entities_dir.mkdir(parents=True, exist_ok=True)
@@ -814,9 +820,9 @@ def test_profile_level_p158_claim_overrides_targeted_nested_statement_only(tmp_p
     qualifiers = docs[0]["statements"][0]["qualifiers"]
     by_entity = {entry["entity"].rsplit("/", 1)[-1]: entry for entry in qualifiers}
 
-    assert set(by_entity.keys()) == {"Q41", "Q42"}
+    # Profile override (Q41) is present; statement-default Q42 is dropped entirely.
+    assert set(by_entity.keys()) == {"Q41"}
     assert by_entity["Q41"]["messages"]["mul"]["prompt"] == "Override qualifier prompt"
-    assert by_entity["Q42"]["messages"]["mul"]["prompt"] == "Untouched qualifier prompt"
 
 
 def test_profile_level_max_count_overrides_statement_level_baseline(tmp_path):


### PR DESCRIPTION
Closes #162

## Summary

When a profile carries `has reference` (P211) or `has qualifier` (P158) claims that target a specific statement via `applies to statement` (P163), those profile-level claims now fully replace any default reference or qualifier entries from the underlying GKC Entity Statement item.

## Problem

The previous blending behaviour kept statement-level defaults that had no matching entity ID in the profile override set. For example, if a statement entity defined references [Q29, Q30] and the profile only overrode Q30, Q29 would survive even though the profile had expressed an explicit opinion about what references should be used.

## Fix

In `_resolve_statement_spec_entries`, statement-level candidates are now skipped entirely when `profile_override_claims` is non-empty. Profile knowledge is authoritative; statement defaults are only consulted when the profile has nothing to say.

`claim_level_overlay_ids` (inline qualifiers on P157 claims) are preserved alongside profile overrides — both are profile-level specifications.

## Changes

- `gkc/spirit_safe.py` — `_resolve_statement_spec_entries`: guard statement-default processing behind `if not profile_override_claims`
- `tests/test_spirit_safe_entity_profile_json.py` — updated and renamed the test that previously asserted the blend behaviour to assert the new supersede semantics

## Validation

`scripts/pre-merge-check.sh` — full pass (lint, format, tests, docs, package build)
