### PR TITLE
refactor: implement curation packet phase A contract

### DIFF
--- a/docs/architecture/DataDistillery-Wikibase.md
+++ b/docs/architecture/DataDistillery-Wikibase.md
@@ -34,7 +34,7 @@ These components are designed to work together as a layered model where profiles
 Purpose:
 Defines an entity-shaped curation surface, including identification prompts and statement composition for packet and wizard workflows.
 
-Required profile-level identification messaging includes:
+Profile-level identification messaging fields include:
 
 - `label prompt` (P188)
 - `label guidance` (P185)
@@ -150,7 +150,7 @@ flowchart TD
 Purpose:
 Represents a reusable statement primitive used for claims, qualifiers, and references.
 
-Required statement-level configuration currently includes:
+Expected statement-level configuration commonly includes:
 
 - `statement type` (P194), linked to a Wikibase Property Template.
 - `same as` (P5), used for canonical cross-system URI/PID mappings.
@@ -264,6 +264,29 @@ Core principles:
 - Profile-level directives should capture entity-context specialization.
 - Resolution behavior must be deterministic and auditable.
 
+### Conformance Semantics
+
+Fermenter conformance is target-state oriented, not strict required-field enforcement.
+
+In this model:
+
+- Profile statements represent expected curation coverage for an entity type.
+- Runtime validation/coercion accepts partial and incomplete entities as normal operating reality.
+- Missing expected statements, qualifiers, or references produce actionable conformance notices with severity, not automatic hard-failure by default.
+- Hard-failure behavior is policy-driven and should be applied only where explicitly configured.
+
+Cardinality interpretation:
+
+- `max count` (P182) defines upper-bound target semantics.
+- Lower-bound expectation is effectively zero in current operating practice unless an explicit minimum policy is introduced.
+- `novalue`/unbounded forms remain valid where modeled.
+
+Validation and coercion must stay statement-instance scoped:
+
+- Notice and resolution logic is anchored to the active profile statement instance.
+- Optional parent-statement scope (`applies to statement`, P163) and profile scope (`applies to profile`, P205) determine contextual applicability.
+- This preserves deterministic behavior across wizard, CLI, and batch packet workflows while supporting incremental curation improvement.
+
 ### Scoping and Rule Resolution
 
 For statement-level directives that include applicability qualifiers:
@@ -291,9 +314,13 @@ Property-template error messages are directly applicable defaults for statements
 
 ### Foundation Modeling
 
-- Foundation ontology definitions are represented as machine-readable profiles in `gkc/wikibase/foundation_profiles/`.
-- `gkc wikibase audit` validates conformance against those profiles.
-- `gkc wikibase init` performs creation planning and optional writes for missing foundation terms.
+Legacy `foundation_profiles` artifacts are non-authoritative for the current Profiles V2 and Fermenter V1 direction.
+
+Current contract:
+
+- Live Data Distillery Wikibase semantics are the authoritative source for semantic identifiers and relationships.
+- SpiritSafe artifacts remain the authoritative runtime materialization for offline execution.
+- `gkc wikibase audit` and related workflows remain useful operational tools, but they should not be treated as the primary semantic authority contract.
 
 ### Operational Modes
 

--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -37,6 +37,7 @@ Responsibility:
 - Hydrate value-list cache artifacts from extracted SPARQL queries.
 - Export profile JSON artifacts for downstream packet assembly and hydration.
 - Provide profile graph metadata and profile-loading utilities.
+- Publish artifact metadata needed to compare long-lived curation packets against the SpiritSafe state from which they were minted.
 
 Out of scope:
 
@@ -88,6 +89,7 @@ Responsibility:
 - Provide atomic datatype validators and coercion primitives.
 - Enforce fixed values, value-list constraints, and reference-level constraints.
 - Enforce derived-value constraints (for example, reference/qualifier values sourced from parent statement values).
+- Validate packet-level compatibility and lifecycle conformance for long-lived curation packets.
 - Emit shared `ConformanceNotice` records with actionable feedback.
 
 Out of scope:
@@ -206,6 +208,16 @@ Current anchor surface:
 4. `sparql` executes paginated query hydration to `cache/queries/QID.json`.
 5. Failed hydration does not overwrite an existing cache file for that value list.
 
+### Flow 2.8: Packet Re-entry and Forward Migration (Planned)
+
+1. `still_charger` or another caller loads a previously minted curation packet.
+2. `fermenter` validates packet type/shape first; structural/type failures are hard blockers.
+3. `spirit_safe` provides current profile/value-list artifact metadata for compatibility comparison.
+4. `wikibase` may provide current semantic revision context when network-backed comparison is available.
+5. `fermenter` classifies drift (`patch_compatible`, `minor_compatible`, `migration_required`, `breaking`) and applies approved migration transforms when available.
+6. `fermenter` re-validates the packet after migration and emits compatibility notices plus migration report data.
+7. Downstream write-planning and shipping proceed only if the packet remains structurally valid and any required migration succeeded.
+
 ### Flow 3: Semantic Projection for Runtime Artifacts
 
 1. `mash` retrieves semantic entities and related metadata.
@@ -229,6 +241,7 @@ Current anchor surface:
 - Keep SpiritSafe runtime contracts stable and testable.
 - Preserve offline-first behavior: network-backed enhancement must not break cache-only operation.
 - Preserve JSON profile export determinism (stable ordering and artifact path shape).
+- Treat packet type/shape conformance as the primary hard blocker; other conformance failures should default to actionable notices unless policy explicitly escalates them.
 
 ## Decision Matrix for New Work
 
@@ -252,6 +265,7 @@ When adding new functionality, assign ownership using this matrix:
 - Wikibase orchestration should continue preferring composition over new transport abstractions.
 - Cross-module tests should identify failure source by layer (read, transform, payload-shape, write, orchestration).
 - Curation packet v2 contract migration from profile-name keys to entity-URI keys remains unfinished and is the next high-risk integration step.
+- Packet compatibility metadata, change classification, and forward-migration rules for long-lived offline packets remain to be implemented.
 
 ## Theoretical Design Notes
 

--- a/docs/gkc/entity-json-schema.md
+++ b/docs/gkc/entity-json-schema.md
@@ -1,777 +1,245 @@
-# GKC Entity JSON Schema
+# GKC Entity JSON and Curation Packet Contract
 
-**Purpose:** Define the canonical internal data format for entity curation within the GKC Wizard and broader Data Distillery ecosystem. This schema bridges [profile](./profiles.md) definitions (YAML) with curator input (form data, bulk data, API data) and eventual serialization (Wikidata JSON, Wikimedia Commons JSON, etc. distributed to Global Knowledge Commons partners).
+**Purpose:** Define the current JSON contracts used across the Data Distillery flow:
 
----
+1. Data Distillery Wikibase semantics materialized into SpiritSafe JSON Entity Profiles.
+2. JSON Entity Profiles assembled into curation packet scaffolds.
+3. Curation packets charged with data, validated/coerced, and prepared for shipping.
 
-## Overview
+This document replaces older profile-name and YAML-era schema language where it no longer matches runtime behavior.
 
-The **GKC Entity JSON** is a JSON object representing a single entity being curated through Data Distillery actions. When multiple related entities are created in sequence (e.g., primary tribal government + linked office entity), they exist as an array of GKC Entity JSON objects within a **GKC Curation Packet**.
+## Current Contract Scope
 
-### Key Principles
+This page documents the active packet/profile contract used by:
 
-1. **Profile-driven structure**: Shape and validation rules derive from profile YAML
-2. **Multilingual support**: All text fields use Wikidata's language-keyed model
-3. **Normalization-ready**: Data stored in clean, coerced form (no raw user input pollution)
-4. **Completeness trackable**: Can calculate progress as `completed_fields / required_fields`
-5. **Round-trip capable**: Can load from disk, edit in wizard, save back to disk
-6. **Transitive references**: Links to other entities in same packet use packet IDs (resolved to QIDs during shipping)
+- `gkc.spirit_safe` for loading JSON Entity Profiles.
+- `gkc.still_charger` for packet scaffold assembly and charging.
+- `gkc.fermenter` and wizard validation bridge for value conformance.
+- `gkc.wikibase` and `gkc.shipper` for downstream write planning and execution.
 
----
+## Pipeline Overview
 
-## Schema Definition
+The current pipeline is:
 
-### Entity Metadata
+1. Data Distillery Wikibase semantics are captured in SpiritSafe cache artifacts.
+2. `gkc.spirit_safe` exports JSON Entity Profiles under `profiles/<QID>.json`.
+3. `gkc.still_charger.build_curation_packet_from_json_profile(...)` builds a packet scaffold.
+4. `gkc.still_charger.charge_curation_packet(...)` and related flows fill packet entity data.
+5. Validation/coercion runs on packet values and emits conformance notices.
+6. Bottling transforms packet content to destination-specific payloads.
+7. Shipping sends destination-specific payloads to Commons Partners (Wikidata, etc.).
+
+## Canonical Identity Rules
+
+- Canonical profile and statement identity is URI-first.
+- QIDs are convenience forms derived from URI tails.
+- Labels are display content and are not join keys.
+- Cross-entity references inside packets use packet-local entity IDs until shipping resolves external IDs.
+
+## JSON Entity Profile Contract
+
+A JSON Entity Profile document (for example `profiles/Q4.json`) includes:
+
+- `entity`: profile URI.
+- `identification`: label/description/alias prompts and guidance by language.
+- `statements`: statement specifications used to scaffold packet entities.
+- `metadata`: profile graph, value-list graph, export metadata, and descriptive fields.
+
+### Statement Specification Shape
+
+Each entry in `statements[]` typically includes:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `entity` | string | Statement URI |
+| `label` | string | Human-readable statement label |
+| `io_map` | array | Mapping to destination properties (for example Wikidata PID URI) |
+| `value` | object | Value contract including datatype and optional value-list/profile linkage |
+| `messages` | object | Prompt/guidance/error messaging payload |
+| `max_count` | number | Upper-bound cardinality target |
+| `qualifiers` | array | Nested statement specs for qualifiers |
+| `references` | array | Nested statement specs for references |
+
+Within `value`, profiles may include derived-default hints for nested statements:
+
+- `value_source: statement_value`
+- `value_source_statement: <parent statement URI>`
+
+These are consumed by downstream wizard/validation paths and are not UI-only fields.
+
+## Curation Packet Scaffold Contract
+
+The active scaffold contract produced by `build_curation_packet_from_json_profile(...)` is:
 
 ```json
 {
-  "packet_id": "ent-001-primary",
-  "profile_name": "TribalGovernmentUS",
-  "username": "skybristol",
-  "status": "in_progress",
-  "created_at": "2026-03-02T14:32:00Z",
-  "creation_path": "primary",
-  
-  "labels": { },
-  "descriptions": { },
-  "aliases": { },
-  "statements": { },
-  "sitelinks": { }
+  "packet_id": "pkt-<uuid>",
+  "operation_mode": "new",
+  "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+  "entities": [],
+  "cross_references": [],
+  "value_list_routes": {}
 }
 ```
 
-#### Entity Metadata Fields
+### Packet Fields
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `packet_id` | string | ✅ | Unique identifier within curation packet (e.g., "ent-001-primary", "ent-002-office") |
-| `profile_name` | string | ✅ | Profile used for curation (e.g., "TribalGovernmentUS") |
-| `username` | string | ✅ | Curator username from `WIKIVERSE_USERNAME` env var (needed for later authentication) |
-| `status` | string | ✅ | Current entity lifecycle: `in_progress`, `ready_to_resolve_refs`, `waiting_for_qid` (post-creation) |
-| `created_at` | string (ISO 8601) | ✅ | Timestamp entity was first created in packet |
-| `creation_path` | string | ✅ | Breadcrumb showing where entity was created: `primary` (root) or `primary.field_id` (from sub-wizard) |
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `packet_id` | string | Yes | Packet-local identifier |
+| `operation_mode` | string | Yes | Current mode (`new` in scaffold builder) |
+| `profile_entity` | string | Yes | Primary profile URI used to mint packet |
+| `entities` | array | Yes | Entity slots in this packet |
+| `cross_references` | array | Yes | URI-aware profile graph edges mapped to entity IDs |
+| `value_list_routes` | object | Yes | Statement URI keyed value-list route metadata |
+| `minted_from` | object | No (recommended) | Provenance and compatibility metadata |
+| `compatibility_status` | string | No | Re-entry compatibility outcome |
+| `migration_report` | object | No | Migration actions and warnings |
 
----
+### Entity Slot Scaffold Shape
 
-## Multilingual Text Fields
-
-Following Wikidata's model, text fields use language-keyed dictionaries:
-
-```json
-{
-  "labels": {
-    "en": "Cherokee Nation",
-    "chr": "ᎳᎫᎿ ᎠᏰᎲ"
-  },
-  "descriptions": {
-    "en": "Federally recognized Native American tribe",
-    "chr": ""
-  },
-  "aliases": {
-    "en": ["Cherokee", "Cherokee Tribe"],
-    "chr": []
-  }
-}
-```
-
-### Multilingual Field Definitions
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `labels` | `dict[lang_code, string]` | `{}` | Primary names in each language (max 1 per language) |
-| `descriptions` | `dict[lang_code, string]` | `{}` | Short definitions in each language (empty string if not provided) |
-| `aliases` | `dict[lang_code, list[string]]` | `{}` | Alternative names per language (empty array if none provided) |
-
-**Language Codes**: Any Wikimedia-supported language code (e.g., `en`, `chr`, `nv`, `es`)
-
-**Completeness Rules**:
-- Progress tracking includes: `2 (base) + num_languages_in_profile * 2`
-- Required languages (from profile): must have non-empty label + description
-- Optional languages: any provided are counted toward completion
-
----
-
-## Statements
-
-### Structure
+Each entry in `entities[]` includes:
 
 ```json
 {
-  "statements": {
-    "instance_of": [
-      {
-        "value": "Q7840353",
-        "qualifiers": {
-          "point_in_time": [
-            {
-              "value": "2020-01-15"
-            }
-          ]
-        },
-        "references": [
-          {
-            "stated_in": "Q4168174",
-            "reference_url": "https://example.com/source"
-          }
-        ]
-      }
-    ],
-    "member_count": [
-      {
-        "value": {
-          "amount": 150000,
-          "unit": null
-        },
-        "qualifiers": {},
-        "references": [
-          {
-            "stated_in": "Q123456"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-### Statement Object
-
-```json
-{
-  "value": <datatype-specific>,
-  "qualifiers": {
-    "<property_id>": [
-      {
-        "value": <datatype-specific>,
-        "qualifiers": {}  // Qualifiers can nest; typically empty
-      }
-    ]
-  },
-  "references": [
+  "id": "ent-001",
+  "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+  "data": {},
+  "statements": [
     {
-      "<property_id>": <datatype-specific>,
-      "<property_id>": <datatype-specific>
-    }
-  ],
-  "validation_issues": [
-    {
-      "severity": "warning",
-      "message": "...",
-      "suggestion": "..."
+      "entity": "https://datadistillery.wikibase.cloud/entity/Q16",
+      "value": {"type": "wikibase-item"},
+      "qualifiers": [],
+      "references": []
     }
   ]
 }
 ```
 
-### Datatype-Specific Values
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `id` | string | Yes | Packet-local entity slot ID (`ent-###`) |
+| `profile_entity` | string | Yes | Profile URI for this slot |
+| `data` | object | Yes | Charged curator/source data payload |
+| `statements` | array | Yes | Statement scaffold copied from profile JSON |
 
-#### Item (wikibase-item)
-```json
-"value": "Q7840353"  // QID as string; validation ensures Q-prefixed format
-```
+## Charged Entity Data Contract
 
-#### String (string)
-```json
-"value": "Some text content"
-```
+After charging, `entity.data` is populated with normalized content.
 
-#### Time (time)
-Stored in normalized format with precision:
-```json
-"value": {
-  "value": "+2020-01-15T00:00:00Z",  // ISO 8601 with precision
-  "precision": 11  // Wikidata precision level: 9=year, 10=month, 11=day
-}
-```
+Common fields:
 
-#### Quantity (quantity)
-```json
-"value": {
-  "amount": 150000,
-  "unit": null  // null if unitless; else Q-string if unit exists
-}
-```
+- `labels`
+- `descriptions`
+- `aliases`
+- `statements`
 
-#### Monolingual Text (monolingualtext)
-```json
-"value": {
-  "language": "en",
-  "text": "Cherokee Nation"
-}
-```
+`data.statements` is keyed by statement URI, not by display label.
 
-#### URL (url)
-```json
-"value": "https://example.com/source"
-```
-
-#### External ID (external-id)
-```json
-"value": "12345"  // As string; no Q-prefix
-```
-
-#### Commons Media (commonsMedia)
-```json
-"value": "File:Example.jpg"
-```
-
-#### Globe Coordinate (globe-coordinate)
-```json
-"value": {
-  "latitude": 35.5,
-  "longitude": -95.3
-}
-```
-
----
-
-## Sitelinks
+Example:
 
 ```json
 {
-  "sitelinks": {
-    "enwiki": "Cherokee_Nation",
-    "chrwiki": "ᎳᎫᎿ_ᎠᏰᎲ"
-  }
-}
-```
-
-Follows Wikidata's sitelink model: `<language_project>: <article_title>`
-
----
-
-## Completeness Calculation
-
-### Formula
-
-```
-required_fields_total = 2 + num_statements + (2 * num_profile_languages)
-completed_fields = count(non_empty_labels_in_required_languages) 
-                 + count(non_empty_descriptions_in_required_languages)
-                 + count(statements_with_at_least_one_value)
-
-progress_pct = completed_fields / required_fields_total * 100
-progress_text = f"{completed_fields} of {required_fields_total} required elements"
-```
-
-### Example
-
-Profile: `TribalGovernmentUS` with:
-- 2 required languages (en, chr)
-- 8 statements
-
-```
-required_fields_total = 2 + 8 + (2 * 2) = 14
-
-// After curator fills:
-// - en label ✅
-// - en description ✅
-// - chr label ❌
-// - chr description ❌
-// - instance_of statement ✅
-// - member_count statement ✅
-// - (remaining 6 statements unfilled)
-
-completed_fields = 4  // (en labels + en desc + 2 statements)
-progress = "4 of 14 required elements" (29%)
-```
-
----
-
-## Validation Rules
-
-### Schema Compliance
-
-- All metadata fields present (null allowed for `status` in some contexts)
-- Labels/descriptions/aliases structured as language-keyed dicts
-- Statements keyed by property ID with array values
-- All values conform to datatype rules (validated by the Validation Agent)
-
-### Completeness Validation
-
-- Required languages: must have non-empty label + description
-- Required statements: at minimum one value per required statement
-- Cross-entity references: must reference valid `packet_id` in same packet (or omitted if not yet resolved)
-
-### Transitive Reference Resolution (Post-Shipping)
-
-When shipping to Wikidata:
-1. Create secondary entities first (depth-first traversal)
-2. Collect returned QIDs
-3. Hydrate cross-entity references in primary entity with resolved QIDs
-4. Create primary entity with hydrated references
-
----
-
-## Multi-Entity Curation Packets
-
-When multiple related entities are curated together (e.g., tribal government + executive office), they exist as a **Curation Packet** containing multiple GKC Entity JSON objects.
-
-### Packet Structure
-
-```json
-{
-  "packet_version": "1.0.0",
-  "created_at": "2026-03-02T14:32:00Z",
-  "entities": [
-    {
-      "packet_id": "ent-001-primary",
-      "profile_name": "TribalGovernmentUS",
-      "creation_path": "primary",
-      "statements": {
-        "office_held_by_head_of_state": [
-          {
-            "value": "ent-002-office",  // References packet_id of related entity
-            "qualifiers": {},
-            "references": [...]
-          }
-        ]
-      }
+  "data": {
+    "labels": {
+      "en": "Cherokee Nation"
     },
-    {
-      "packet_id": "ent-002-office",
-      "profile_name": "OfficeHeldByHeadOfState",
-      "creation_path": "primary.office_held_by_head_of_state",
-      "statements": { ... }
-    }
-  ]
-}
-```
-
-### Packet Metadata Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `packet_version` | string | Schema version (for migrations); current: "1.0.0" |
-| `created_at` | string (ISO 8601) | When packet was created |
-| `entities` | array | Array of GKC Entity JSON objects |
-
-### Cross-Entity References via `packet_id`
-
-Entities within a packet reference each other using **packet-local identifiers** rather than Wikidata QIDs:
-
-- **During curation**: Statement values use `packet_id` strings (e.g., `"ent-002-office"`)
-- **After shipping**: Shipper resolves `packet_id` → QID and replaces values before creating Wikidata items
-
-**Example workflow:**
-
-1. User creates tribal government entity (`ent-001-primary`)
-2. User creates office entity via sub-wizard (`ent-002-office`)
-3. Tribal government's `office_held_by_head_of_state` statement has value `"ent-002-office"`
-4. Shipper creates office first → receives QID `Q999888`
-5. Shipper replaces `"ent-002-office"` with `"Q999888"` in tribal government before shipping
-6. Tribal government created with correct P1906 reference
-
-### Creation Path Breadcrumbs
-
-The `creation_path` field tracks entity provenance:
-
-| Creation Path | Meaning |
-|---------------|---------|
-| `primary` | Root entity; loaded directly by wizard or bulk operation |
-| `primary.office_held_by_head_of_state` | Created via statement on primary entity |
-| `primary.headquarters.location` | Nested entity (location of headquarters of primary) |
-
-**Uses:**
-
-- **Dependency ordering**: Ship entities depth-first (leaves before roots)
-- **Audit trails**: Understand how curator created complex entity graphs
-- **Rollback logic**: If primary creation fails, skip dependent entities
-
-### Packet Lifecycle States
-
-Tracked via `status` field on individual entities:
-
-| Status | Meaning | Next Action |
-|--------|---------|-------------|
-| `in_progress` | Curator actively editing | Continue curation |
-| `ready_to_resolve_refs` | All data entered; awaiting cross-entity QID resolution | Ship to Wikidata |
-| `waiting_for_qid` | Shipped to Wikidata; awaiting item creation response | Poll API or mark complete |
-
----
-
-## Profile Graph Integration
-
-Curation packets reflect the **profile graph** — the network of profiles connected via `entity_profile` statements.
-
-### Profile Graph Discovery
-
-When wizard loads `TribalGovernmentUS` profile, it:
-
-1. Scans statements for `entity_profile` type
-2. Finds `office_held_by_head_of_state` statement with `profile_name: OfficeHeldByHeadOfState`
-3. Recursively loads `OfficeHeldByHeadOfState` profile
-4. Creates packet with placeholders for both entities
-
-### Loading Strategy
-
-**Current implementation:** Depth = 1 (direct children only)
-
-- Primary profile → directly linked profiles
-- Does **not** recursively load links-of-links
-
-**Future:** Configurable depth or lazy loading:
-
-```yaml
-# In metadata.yaml
-profile_graph:
-  edges:
-    - target_profile: OfficeHeldByHeadOfState
-      loading_strategy: eager  # vs "lazy" (load on-demand)
-      max_depth: 2  # How many hops to traverse
-```
-
-### Multi-Entity Packet Example
-
-**Scenario:** User creates Cherokee Nation (tribal government) with its Principal Chief office
-
-**Profile linkage:**
-
-```
-TribalGovernmentUS (primary)
-  └─ office_held_by_head_of_state: OfficeHeldByHeadOfState (related)
-```
-
-**Resulting packet:**
-
-```json
-{
-  "packet_version": "1.0.0",
-  "created_at": "2026-03-03T10:00:00Z",
-  "entities": [
-    {
-      "packet_id": "ent-001-primary",
-      "profile_name": "TribalGovernmentUS",
-      "creation_path": "primary",
-      "labels": { "en": "Cherokee Nation" },
-      "statements": {
-        "office_held_by_head_of_state": [
-          { "value": "ent-002-office" }
-        ]
-      }
-    },
-    {
-      "packet_id": "ent-002-office",
-      "profile_name": "OfficeHeldByHeadOfState",
-      "creation_path": "primary.office_held_by_head_of_state",
-      "labels": { "en": "Principal Chief of the Cherokee Nation" },
-      "statements": {
-        "applies_to_jurisdiction": [
-          { "value": "ent-001-primary" }  // Bidirectional reference
-        ]
-      }
-    }
-  ]
-}
-```
-
-**Note:** Bidirectional references are allowed and encouraged for semantic clarity.
-
----
-
-## Bulk Operations
-
-Curation packets support bulk data operations where multiple existing entities are loaded, modified, and re-shipped together.
-
-### Bulk vs Single-Entity Packets
-
-| Aspect | Single-Entity | Bulk Operation |
-|--------|---------------|----------------|
-| **Packet size** | 1-3 entities (primary + related) | 10-1000+ entities |
-| **Entity source** | New entities from scratch | Existing Wikidata items |
-| **Modification scope** | All statements editable | Subset of statements (filtered) |
-| **Workflow** | Wizard step-by-step | Automated or semi-automated |
-
-### Statement Filtration
-
-Bulk operations often target **specific statements** rather than full entities.
-
-**Example:** "Update member_count and office leadership for all federally recognized tribes"
-
-**Packet structure:**
-
-```json
-{
-  "packet_version": "1.0.0",
-  "operation_mode": "bulk",  // Indicates bulk operation
-  "enabled_statements": [     // Whitelist of editable statements
-    "member_count",
-    "office_held_by_head_of_state"
-  ],
-  "entities": [
-    {
-      "packet_id": "bulk-001-Q5093",  // QID embedded for existing items
-      "profile_name": "TribalGovernmentUS",
-      "wikidata_qid": "Q5093",  // Original QID
-      "statements": {
-        "member_count": [
-          { "value": { "amount": 450000, "unit": null } }
-        ]
-        // Other statements NOT loaded or editable
-      }
-    },
-    // ... 99 more tribal governments
-  ]
-}
-```
-
-**Dot notation** for nested statements:
-
-```json
-"enabled_statements": [
-  "office_held_by_head_of_state.inception",  // Only edit inception date of office
-  "office_held_by_head_of_state.references"  // Only add references, not change office
-]
-```
-
-### Validation in Bulk Operations
-
-- **Schema validation**: Same as single-entity (all fields must conform)
-- **Completeness validation**: **Relaxed** (can ship partial entities with only modified statements)
-- **Cross-entity validation**: Can span multiple entities in packet (e.g., "all member counts must be > 0")
-
-**Future:** Bulk operation templates that define:
-
-- Which profiles to query
-- Which statements are modifiable
-- Validation rules specific to bulk context
-
----
-
-## Round-Trip Transformation
-
-Packets support **bidirectional transformation** between GKC Entity JSON and platform-specific formats (Wikidata JSON, Wikimedia Commons JSON, etc.).
-
-### Wikidata JSON → GKC Entity JSON
-
-**Use case:** Load existing Wikidata item into wizard for editing
-
-**Transformation steps:**
-
-1. Fetch Wikidata JSON via `wbgetentities` API
-2. Load profile for entity type (determined by P31 instance-of value)
-3. Transform Wikidata claims → GKC statements:
-   - Property IDs (P31) → statement IDs (instance_of)
-   - Wikidata datatypes → GKC value types
-   - Qualifiers and references preserved
-4. Generate `packet_id` and `creation_path` metadata
-5. Set `status: in_progress` for editing session
-
-**Example:**
-
-```json
-// Wikidata JSON (abbreviated)
-{
-  "entities": {
-    "Q5093": {
-      "labels": { "en": { "value": "Cherokee Nation" } },
-      "claims": {
-        "P31": [
-          {
-            "mainsnak": { "datavalue": { "value": { "id": "Q7840353" } } },
-            "references": [...]
-          }
-        ]
-      }
-    }
-  }
-}
-
-// GKC Entity JSON (transformed)
-{
-  "packet_id": "ent-001-primary",
-  "profile_name": "TribalGovernmentUS",
-  "wikidata_qid": "Q5093",  // Preserve original QID
-  "labels": { "en": "Cherokee Nation" },
-  "statements": {
-    "instance_of": [
-      { "value": "Q7840353", "references": [...] }
-    ]
-  }
-}
-```
-
-### GKC Entity JSON → Wikidata JSON
-
-**Use case:** Ship curation packet to Wikidata
-
-**Transformation steps:**
-
-1. Resolve `packet_id` references → QIDs (create secondary entities first)
-2. Transform GKC statements → Wikidata claims:
-   - Statement IDs (instance_of) → Property IDs (P31)
-   - GKC value types → Wikidata datatypes
-   - Validate all values conform to Wikidata constraints
-3. Generate Wikidata JSON structure
-4. Call `wbeditentity` API with bot credentials
-
-**Depth-first shipping:**
-
-```
-ent-002-office (no dependencies) → Ship first → Q999888
-ent-001-primary (depends on office) → Replace "ent-002-office" with "Q999888" → Ship second → Q999889
-```
-
-### Sitelinks: Wikidata Format ↔ URL Format
-
-**Current state:** Sitelinks stored in Wikidata format (`enwiki: "Article_Title"`)
-
-**Future enhancement:** URL-based curation format
-
-```json
-// GKC Entity JSON (curation format) - FUTURE
-{
-  "sitelinks": [
-    {
-      "url": "https://en.wikipedia.org/wiki/Cherokee_Nation",
-      "relationship": "primary",  // Article is exclusively about this entity
-      "verified": true  // URL existence validated
-    }
-  ]
-}
-
-// Transformed to Wikidata format for shipping
-{
-  "sitelinks": {
-    "enwiki": {
-      "site": "enwiki",
-      "title": "Cherokee_Nation"
+    "descriptions": {},
+    "aliases": {},
+    "statements": {
+      "https://datadistillery.wikibase.cloud/entity/Q16": [
+        {
+          "value": {"id": "Q7840353"},
+          "qualifiers": {},
+          "references": []
+        }
+      ]
     }
   }
 }
 ```
 
-**Bidirectional:** Existing Wikidata sitelinks reconstruct URL for editing; saved URLs parse to Wikidata format.
+### Nested Qualifier and Reference Shape
 
-### Profile-Driven Transformation
+Nested qualifiers and references may appear in statement-shaped map form keyed by nested statement URI.
 
-**Key principle:** All transformation logic derives from profile metadata
+Typical nested shape:
 
-- Profile declares Wikidata property mappings (`P31`, `P1906`, etc.)
-- Profile declares datatype conversions (quantity → Wikidata quantity format)
-- Profile declares sitelink rules (allowed languages, allowed projects)
+- `qualifiers`: object keyed by statement URI with list values.
+- `references`: object keyed by statement URI with list values, or an empty list where no references are provided.
 
-**No hardcoded entity-specific logic** — transformer reads profile and applies rules dynamically.
+Validation/coercion layers should normalize accepted nested forms and report shape violations as conformance notices.
 
----
+## Conformance and Blocking Policy
 
-## Complete Example
+Conformance is target-state oriented, not strict all-fields-must-be-present enforcement.
 
-```json
-{
-  "packet_version": "1.0.0",
-  "created_at": "2026-03-02T14:32:00Z",
-  "entities": [
-    {
-      "packet_id": "ent-001-primary",
-      "profile_name": "TribalGovernmentUS",
-      "username": "skybristol",
-      "status": "in_progress",
-      "created_at": "2026-03-02T14:32:00Z",
-      "creation_path": "primary",
-      
-      "labels": {
-        "en": "Cherokee Nation",
-        "chr": ""
-      },
-      "descriptions": {
-        "en": "Federally recognized Native American tribe based in Oklahoma",
-        "chr": ""
-      },
-      "aliases": {
-        "en": ["Cherokee", "Cherokee Tribe"],
-        "chr": []
-      },
-      
-      "statements": {
-        "instance_of": [
-          {
-            "value": "Q7840353",
-            "qualifiers": {},
-            "references": [
-              {
-                "stated_in": "Q4168174",
-                "retrieved": "+2026-03-02T00:00:00Z"
-              }
-            ]
-          }
-        ],
-        "member_count": [
-          {
-            "value": {
-              "amount": 380000,
-              "unit": null
-            },
-            "qualifiers": {
-              "point_in_time": [
-                {
-                  "value": {
-                    "value": "+2023-01-01T00:00:00Z",
-                    "precision": 9
-                  }
-                }
-              ]
-            },
-            "references": [
-              {
-                "stated_in": "Q123456"
-              }
-            ]
-          }
-        ]
-      },
-      
-      "sitelinks": {
-        "enwiki": "Cherokee_Nation",
-        "chrwiki": "ᎳᎫᎿ_ᎠᏰᎲ"
-      }
-    }
-  ]
-}
-```
+Current policy direction:
 
----
+- Type/shape conformance failures are hard blockers.
+- Missing expected statements, qualifiers, or references are usually notice-driven unless policy explicitly escalates.
+- `max_count` is an upper-bound target; effective lower bound is zero unless explicit minimum policy is introduced.
+- Derived-value and fixed/list constraints are enforced according to profile directives and resolver context.
 
-## Wizard Integration Contract
+## Packet Re-entry, Compatibility, and Migration
 
-### Input: Loading Existing Entity
+Long-lived packets may return after SpiritSafe/Wikibase state has changed.
 
-When wizard loads a saved packet (draft or for editing):
-1. Deserialize curation packet JSON
-2. Validate schema compliance (all fields present, correct types)
-3. Pass to step renderers as `draft_data`
-4. Steps read/write per multilingual structure
+To support deterministic handling, packets should carry `minted_from` metadata.
 
-### Output: Saving Curation Packet
+### Recommended `minted_from` Fields
 
-After each step or on explicit save:
-1. Serialize `draft_data` to curation packet format
-2. Write to disk (transient or permanent)
-3. On submission, validate completeness + pass to shipper
+| Field | Type | Meaning |
+|---|---|---|
+| `packet_contract_version` | string | Version of packet compatibility contract |
+| `spiritsafe_commit` | string | SpiritSafe git commit used at mint time |
+| `dd_revision` | string | Data Distillery revision watermark or snapshot ID |
+| `profiles` | array | Per-profile records used to mint packet |
+| `value_lists` | array | Value-list snapshot records used to mint packet |
+| `minted_at` | string | Mint timestamp (ISO 8601) |
 
-### Error Handling
+Per-profile metadata should include profile URI/QID and profile/statement digests.
 
-- **Schema violations**: Block load; display which fields are malformed
-- **Completeness warnings**: Display in Review step; allow save (non-blocking)
-- **Cross-entity validation failures**: Mark in `validation_issues` array per entity
+Per-value-list metadata should include value-list ID plus cache digest and refresh timestamp.
 
----
+### Compatibility Status Values
 
-## Future Extensions
+Suggested runtime values:
 
-1. **Annotation trails**: Add `audit_log` per entity tracking changes
-2. **Conflict resolution**: Support concurrent multi-curator editing with merge strategies
-3. **Version history**: Store historical snapshots for rollback
-4. **Automated filling**: Pre-populate from external sources (DBpedia, Wikidata, etc.)
-5. **Quality scoring**: Calculate confidence/completeness beyond binary checklist
+- `compatible`
+- `migration_available`
+- `manual_review_required`
+- `incompatible`
 
----
+### Change Classification
+
+Suggested drift classes:
+
+- `patch_compatible`
+- `minor_compatible`
+- `migration_required`
+- `breaking`
+
+### Re-entry Sequence
+
+1. Validate packet type and shape.
+2. Compare `minted_from` metadata to current SpiritSafe and DD state.
+3. Classify drift.
+4. Apply approved forward migrations when available.
+5. Re-run conformance validation/coercion.
+6. Emit compatibility and migration reporting.
+7. Proceed to shipping only when packet is structurally valid and required migrations succeeded.
+
+## Transition Notes
+
+Some legacy packet/documentation surfaces still reference older fields such as `profile_name`, profile-name keyed statement maps, or YAML-first assumptions.
+
+Current architecture direction is URI-first JSON profile and packet contracts, with compatibility shims preserved only where required during migration.
 
 ## Related Documentation
 
-- [GKC Architecture Overview](../architecture/index.md) — Core architectural components and data flow
-- [GKC Entity Profiles](./profiles.md) — Complete profile schema reference
-- [GKC Wizard Documentation](./wizard.md) — Multi-entity curation workflows
-- [Profile Graphs & Cross-References](./profiles.md#profile-graphs-cross-references) — How profiles link together
-- [Validation Architecture](../architecture/validation-architecture.md) — Real-time validation/coercion engine
-
+- [Data Distillery Wikibase Architecture](../architecture/DataDistillery-Wikibase.md)
+- [Cross-Module Contracts](../architecture/module-contracts.md)
+- [SpiritSafe Integration Architecture](../architecture/spirit_safe_models.md)
+- [Profiles and Graph Linkage](./profiles.md)
+- [Wizard Workflows](./wizard.md)

--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -2723,13 +2723,25 @@ def _handle_packet_create(args: argparse.Namespace) -> dict[str, Any]:
         else:
             message = f"Created packet {packet['packet_id']}"
 
+        entity_count = len(
+            packet.get("data", {}).get("entities", packet.get("entities", []))
+        )
+        graph_edge_count = len(
+            packet.get("metadata", {})
+            .get("graph", {})
+            .get("edges", packet.get("cross_references", []))
+        )
+        primary_profile = packet.get("metadata", {}).get("primary_profile", {})
+
         details = {
             "packet_id": packet["packet_id"],
             "operation_mode": packet["operation_mode"],
-            "primary_profile": packet["primary_profile"],
-            "primary_profile_entity": packet.get("primary_profile_entity"),
-            "entity_count": len(packet["entities"]),
-            "cross_reference_count": len(packet["cross_references"]),
+            "primary_profile": primary_profile.get("name_identifier")
+            or packet.get("primary_profile"),
+            "primary_profile_entity": primary_profile.get("id")
+            or packet.get("primary_profile_entity"),
+            "entity_count": entity_count,
+            "graph_edge_count": graph_edge_count,
             "output_file": args.output,
         }
 
@@ -2751,18 +2763,29 @@ def _handle_packet_info(args: argparse.Namespace) -> dict[str, Any]:
         with open(args.packet_file, "r") as f:
             packet = json.load(f)
 
+        entity_count = len(
+            packet.get("data", {}).get("entities", packet.get("entities", []))
+        )
+        graph_edge_count = len(
+            packet.get("metadata", {})
+            .get("graph", {})
+            .get("edges", packet.get("cross_references", []))
+        )
+        primary_profile = packet.get("metadata", {}).get("primary_profile", {})
+
         message = f"Packet {packet.get('packet_id', 'unknown')}"
         details = {
             "packet_id": packet.get("packet_id"),
             "operation_mode": packet.get("operation_mode"),
-            "created_at": packet.get("created_at"),
-            "primary_profile": packet.get("primary_profile"),
-            "primary_profile_entity": packet.get("primary_profile_entity"),
-            "entity_count": len(packet.get("entities", [])),
-            "cross_reference_count": len(packet.get("cross_references", [])),
-            "cardinality_constraint_count": len(
-                packet.get("cardinality_constraints", [])
-            ),
+            "minted_at": packet.get("metadata", {})
+            .get("mint", {})
+            .get("minted_at", packet.get("created_at")),
+            "primary_profile": primary_profile.get("name_identifier")
+            or packet.get("primary_profile"),
+            "primary_profile_entity": primary_profile.get("id")
+            or packet.get("primary_profile_entity"),
+            "entity_count": entity_count,
+            "graph_edge_count": graph_edge_count,
         }
 
         return {
@@ -2787,6 +2810,15 @@ def _handle_packet_validate(args: argparse.Namespace) -> dict[str, Any]:
 
         is_valid, errors = validate_packet_structure(packet)
 
+        entity_count = len(
+            packet.get("data", {}).get("entities", packet.get("entities", []))
+        )
+        graph_edge_count = len(
+            packet.get("metadata", {})
+            .get("graph", {})
+            .get("edges", packet.get("cross_references", []))
+        )
+
         message = (
             f"✓ Packet {packet.get('packet_id', 'unknown')} is valid"
             if is_valid
@@ -2797,8 +2829,8 @@ def _handle_packet_validate(args: argparse.Namespace) -> dict[str, Any]:
             "packet_id": packet.get("packet_id"),
             "is_valid": is_valid,
             "errors": errors,
-            "entity_count": len(packet.get("entities", [])),
-            "cross_reference_count": len(packet.get("cross_references", [])),
+            "entity_count": entity_count,
+            "graph_edge_count": graph_edge_count,
         }
 
         return {
@@ -2863,12 +2895,22 @@ def _handle_packet_build(args: argparse.Namespace) -> dict[str, Any]:
         else:
             message = f"Built packet {packet['packet_id']}"
 
+        entity_count = len(
+            packet.get("data", {}).get("entities", packet.get("entities", []))
+        )
+        graph_edge_count = len(
+            packet.get("metadata", {})
+            .get("graph", {})
+            .get("edges", packet.get("cross_references", []))
+        )
+        primary_profile = packet.get("metadata", {}).get("primary_profile", {})
+
         details = {
             "packet_id": packet["packet_id"],
-            "profile_entity": packet.get("profile_entity"),
-            "entity_count": len(packet.get("entities", [])),
-            "cross_reference_count": len(packet.get("cross_references", [])),
-            "value_list_routes_count": len(packet.get("value_list_routes", {})),
+            "profile_entity": primary_profile.get("id") or packet.get("profile_entity"),
+            "profile_name_identifier": primary_profile.get("name_identifier"),
+            "entity_count": entity_count,
+            "graph_edge_count": graph_edge_count,
             "output_file": args.output,
         }
 

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import uuid
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -1372,7 +1371,8 @@ class EntityProfileJsonBuilder:
     ALIAS_PROMPT = "P190"
     ALIAS_GUIDANCE = "P187"
 
-    SAME_AS = "P212"
+    NAME_IDENTIFIER = "P214"
+    SAME_AS = "P5"
     WIKIDATA_ENTITY_URL = "P5"
     GKC_ENTITY_PROFILE_CLASS = "Q3"
     GKC_VALUE_LIST_CLASS = "Q7"
@@ -1445,6 +1445,7 @@ class EntityProfileJsonBuilder:
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Build one JSON profile and enforce profile language completeness policy."""
         entity_uri = f"{self.entity_prefix}{wikibase_item.get('entity_id', '')}"
+        name_identifier = self._entity_name_identifier(wikibase_item)
 
         identification = {
             "labels": self._build_language_section(
@@ -1467,6 +1468,8 @@ class EntityProfileJsonBuilder:
         )
 
         profile_doc = {
+            "id": entity_uri,
+            "name_identifier": name_identifier,
             "entity": entity_uri,
             "identification": identification,
             "statements": statements,
@@ -1699,14 +1702,19 @@ class EntityProfileJsonBuilder:
                 if key in seen:
                     continue
                 seen.add(key)
-                graph.append(
-                    {
-                        "entity": f"{self.entity_prefix}{target_id}",
-                        "label": self._entity_label(target_id),
-                        "via_statement": f"{self.entity_prefix}{statement_id}",
-                        "linkage_type": self.HAS_VALUE,
-                    }
+                target_name_identifier = self._entity_name_identifier(
+                    self._cache_index.get(target_id)
                 )
+                entry: dict[str, Optional[str]] = {
+                    "id": f"{self.entity_prefix}{target_id}",
+                    "entity": f"{self.entity_prefix}{target_id}",
+                    "label": self._entity_label(target_id),
+                    "via_statement": f"{self.entity_prefix}{statement_id}",
+                    "linkage_type": self.HAS_VALUE,
+                }
+                if target_name_identifier:
+                    entry["name_identifier"] = target_name_identifier
+                graph.append(entry)
         return graph
 
     def _build_value_list_graph(
@@ -1744,14 +1752,20 @@ class EntityProfileJsonBuilder:
                 continue
             seen.add(key)
 
-            graph.append(
-                {
-                    "entity": f"{self.entity_prefix}{target_id}",
-                    "label": self._entity_label(target_id),
-                    "via_statement": statement_entity,
-                    "cache_path": cache_path,
-                }
+            target_name_identifier = self._entity_name_identifier(
+                self._cache_index.get(target_id)
             )
+            entry: dict[str, Optional[str]] = {
+                "id": f"{self.entity_prefix}{target_id}",
+                "entity": f"{self.entity_prefix}{target_id}",
+                "label": self._entity_label(target_id),
+                "via_statement": statement_entity,
+                "cache_path": cache_path,
+            }
+            if target_name_identifier:
+                entry["name_identifier"] = target_name_identifier
+
+            graph.append(entry)
         return graph
 
     def _iter_statement_nodes(
@@ -2134,6 +2148,8 @@ class EntityProfileJsonBuilder:
         )
 
         return {
+            "id": f"{self.entity_prefix}{entity_id}",
+            "name_identifier": self._entity_name_identifier(statement_item),
             "entity": f"{self.entity_prefix}{entity_id}",
             "label": label,
             "io_map": [{"to": target} for target in io_targets],
@@ -2615,6 +2631,17 @@ class EntityProfileJsonBuilder:
             required=False,
         )
 
+    def _entity_name_identifier(
+        self, entity_doc: Optional[dict[str, Any]]
+    ) -> Optional[str]:
+        if not entity_doc:
+            return None
+        claims = entity_doc.get("entity", {}).get("claims", {})
+        values = self._claim_string_values(claims.get(self.NAME_IDENTIFIER, []))
+        if values:
+            return values[0]
+        return None
+
 
 class EntityProfileLanguageCoverageError(ValueError):
     """Raised when a profile fails required language completeness coverage."""
@@ -2798,6 +2825,10 @@ def _label_from_cache_entity(document: dict[str, Any]) -> str:
 
 
 def _statement_id_from_definition(statement: dict[str, Any]) -> Optional[str]:
+    entity_id = _entity_id_from_reference(statement.get("id"))
+    if entity_id:
+        return entity_id
+
     entity_id = _entity_id_from_reference(statement.get("entity"))
     if entity_id:
         return entity_id
@@ -2822,7 +2853,7 @@ def _normalized_packet_statement(statement: dict[str, Any]) -> dict[str, Any]:
     normalized = deepcopy(statement)
     statement_id = _statement_id_from_definition(normalized)
     if statement_id and "id" not in normalized:
-        normalized["id"] = statement_id
+        normalized["id"] = f"{SPIRITSAFE_ENTITY_URI_PREFIX}{statement_id}"
     return normalized
 
 
@@ -3123,7 +3154,8 @@ def load_profile_package(
 
     return {
         "primary_profile": normalized_profile_id,
-        "primary_profile_entity": primary_profile.get("entity"),
+        "primary_profile_entity": primary_profile.get("id")
+        or primary_profile.get("entity"),
         "profiles": profiles_to_load,
         "graph": graph,
         "depth": depth,
@@ -3191,93 +3223,79 @@ def create_curation_packet(
     """
 
     del load_wikidata_qids
+    del depth
     del manifest
 
-    actual_depth = depth if operation_mode == "bulk" else 0
-    package = load_profile_package(profile_id, depth=actual_depth)
+    from gkc.still_charger import build_curation_packet_from_json_profile
 
-    entities: list[dict[str, Any]] = []
-    entity_id_map: dict[str, str] = {}
+    profile_doc = load_profile(profile_id)
+    profile_uri = _entity_uri_from_reference(profile_doc.get("id") or profile_id)
+    if not profile_uri:
+        raise ValueError(f"Invalid profile identifier: {profile_id}")
 
-    for idx, (profile_qid, profile_data) in enumerate(package["profiles"].items()):
-        entity_id = f"ent-{idx + 1:03d}"
-        entity_id_map[profile_qid] = entity_id
-        normalized_statements = [
-            _normalized_packet_statement(statement)
-            for statement in profile_data.get("statements", [])
-            if isinstance(statement, dict)
-        ]
-        entities.append(
-            {
-                "id": entity_id,
-                "profile": profile_qid,
-                "profile_entity": profile_data.get("entity"),
-                "data": {},
-                "profile_structure": {
-                    "identification": profile_data.get("identification", {}),
-                    "statements": normalized_statements,
-                },
-            }
-        )
+    if operation_mode == "single":
+        profile_doc = deepcopy(profile_doc)
+        profile_doc.setdefault("metadata", {})["profile_graph"] = []
 
-    cross_references: list[dict[str, Any]] = []
-    for source_profile_id, profile_data in package["profiles"].items():
-        source_entity_id = entity_id_map.get(source_profile_id)
-        if not source_entity_id:
-            continue
-        for edge in profile_data.get("metadata", {}).get("profile_graph", []):
-            target_profile = _entity_id_from_reference(edge.get("entity"))
-            if not target_profile or target_profile not in entity_id_map:
-                continue
-            cross_references.append(
-                {
-                    "from": source_entity_id,
-                    "from_profile": source_profile_id,
-                    "from_entity": profile_data.get("entity"),
-                    "to": entity_id_map[target_profile],
-                    "to_profile": target_profile,
-                    "to_entity": _entity_uri_from_reference(edge.get("entity")),
-                    "via_statement": _entity_uri_from_reference(
-                        edge.get("via_statement")
-                    ),
-                    "relationship_type": edge.get("linkage_type"),
-                    "cardinality": {},
-                    "workflow_policy": {},
-                }
-            )
-
-    cardinality_constraints = [
-        {
-            "from": cross_reference["from"],
-            "to": cross_reference["to"],
-            "min": 0,
-            "max": -1,
-        }
-        for cross_reference in cross_references
-    ]
-
-    primary_profile_id = package["primary_profile"]
-    return {
-        "packet_id": f"pkt-{uuid.uuid4().hex[:12]}",
-        "operation_mode": operation_mode,
-        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        "primary_profile": primary_profile_id,
-        "primary_profile_entity": package.get("primary_profile_entity"),
-        "entities": entities,
-        "cross_references": cross_references,
-        "cardinality_constraints": cardinality_constraints,
-        "profile_package": package,
-    }
+    packet = build_curation_packet_from_json_profile(
+        profile_entity=profile_uri,
+        json_profile_doc=profile_doc,
+        source_root=(
+            get_spirit_safe_source().local_root
+            if get_spirit_safe_source().mode == "local"
+            else None
+        ),
+    )
+    packet["operation_mode"] = operation_mode
+    return packet
 
 
 def validate_packet_structure(packet: dict[str, Any]) -> tuple[bool, list[str]]:
     """Validate packet structure and basic linkage consistency."""
 
     errors = []
-    required_fields = ["packet_id", "operation_mode", "entities", "cross_references"]
+    if "metadata" in packet and "data" in packet:
+        required_fields = ["packet_id", "operation_mode", "metadata", "data"]
+    else:
+        required_fields = [
+            "packet_id",
+            "operation_mode",
+            "entities",
+            "cross_references",
+        ]
+
     for required_field in required_fields:
         if required_field not in packet:
             errors.append(f"Missing required field: {required_field}")
+
+    if "metadata" in packet and "data" in packet:
+        data_entities = packet.get("data", {}).get("entities", [])
+        if not isinstance(data_entities, list):
+            errors.append("data.entities must be a list")
+            data_entities = []
+
+        for entity in data_entities:
+            if not isinstance(entity, dict):
+                errors.append("Each data.entities item must be an object")
+                continue
+            if not entity.get("profile"):
+                errors.append("Each data.entities item must include profile")
+            entity_id = entity.get("id")
+            if not isinstance(entity_id, str) or not entity_id.startswith("http"):
+                errors.append("Each data.entities item id must be an HTTP URI")
+
+        metadata = packet.get("metadata", {})
+        if not isinstance(metadata.get("profiles", []), list):
+            errors.append("metadata.profiles must be a list")
+
+        integrity = metadata.get("integrity", {})
+        if not isinstance(integrity, dict):
+            errors.append("metadata.integrity must be an object")
+        else:
+            if not integrity.get("metadata_digest"):
+                errors.append("metadata.integrity.metadata_digest is required")
+
+        return (len(errors) == 0, errors)
 
     entity_ids = {
         str(entity.get("id"))

--- a/gkc/still_charger.py
+++ b/gkc/still_charger.py
@@ -5,13 +5,17 @@ profile-generated curation packets are populated with real input values before
 barreling/transformation for shipping.
 """
 
+import hashlib
 import json
+import re
 import uuid
 from copy import deepcopy
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+import gkc
 from gkc.fermenter import ConformanceNotice
 
 
@@ -70,11 +74,166 @@ def _normalize_statement_scaffold(statement: dict[str, Any]) -> dict[str, Any]:
 
 def _target_profile_uri_from_edge(edge: dict[str, Any]) -> Optional[str]:
     """Extract target profile URI from a profile graph edge."""
-    target_ref = edge.get("entity") or edge.get("target")
+    target_ref = edge.get("id") or edge.get("entity") or edge.get("target")
     if not isinstance(target_ref, str) or not target_ref:
         return None
     target_uri, _ = _normalize_entity_uri(target_ref)
     return target_uri
+
+
+def _profile_uri_from_doc(profile_doc: dict[str, Any], fallback_uri: str) -> str:
+    candidate = profile_doc.get("id") or profile_doc.get("entity")
+    if isinstance(candidate, str) and candidate:
+        normalized, _ = _normalize_entity_uri(candidate)
+        return normalized
+    return fallback_uri
+
+
+def _profile_name_identifier(profile_doc: dict[str, Any], profile_uri: str) -> str:
+    name_identifier = profile_doc.get("name_identifier")
+    if isinstance(name_identifier, str) and name_identifier.strip():
+        return name_identifier.strip()
+    return profile_uri.rstrip("/").split("/")[-1]
+
+
+def _statement_identifier(statement: dict[str, Any]) -> Optional[str]:
+    candidate = statement.get("id") or statement.get("entity")
+    if not isinstance(candidate, str) or not candidate:
+        return None
+    normalized, _ = _normalize_entity_uri(candidate)
+    return normalized
+
+
+def _statement_name_identifier(statement: dict[str, Any]) -> str:
+    explicit = statement.get("name_identifier")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+
+    statement_id = _statement_identifier(statement)
+    if statement_id:
+        return statement_id.rstrip("/").split("/")[-1]
+
+    label = statement.get("label")
+    if isinstance(label, str) and label.strip():
+        normalized = re.sub(r"[^A-Za-z0-9_]+", "_", label.strip()).strip("_")
+        if normalized:
+            return normalized
+
+    return "statement"
+
+
+def _statement_data_slot(statement: dict[str, Any]) -> dict[str, Any]:
+    value_block = statement.get("value")
+    data_type = value_block.get("type") if isinstance(value_block, dict) else None
+    data_value: Any = None
+
+    if isinstance(value_block, dict):
+        value_list = value_block.get("value_list")
+        if isinstance(value_list, list) and len(value_list) == 1:
+            data_value = value_list[0]
+
+    return {
+        "id": _statement_identifier(statement),
+        "data-type": data_type,
+        "data-value": data_value,
+    }
+
+
+def _canonical_json_digest(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _build_unified_graph(
+    profile_docs: dict[str, dict[str, Any]],
+    name_by_uri: dict[str, str],
+    source_root: Optional[Path],
+) -> dict[str, list[dict[str, Any]]]:
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: list[dict[str, Any]] = []
+    value_list_routes = _build_value_list_routes(profile_docs, source_root)
+
+    for profile_uri, profile_doc in profile_docs.items():
+        profile_name = name_by_uri[profile_uri]
+        nodes[profile_name] = {
+            "kind": "profile",
+            "name_identifier": profile_name,
+            "id": profile_uri,
+            "label": profile_doc.get("metadata", {}).get("labels", {}).get("mul")
+            or profile_doc.get("metadata", {}).get("labels", {}).get("en"),
+        }
+
+        for edge in profile_doc.get("metadata", {}).get("profile_graph", []):
+            if not isinstance(edge, dict):
+                continue
+            target_uri = _target_profile_uri_from_edge(edge)
+            if not target_uri:
+                continue
+            target_name = name_by_uri.get(
+                target_uri, target_uri.rstrip("/").split("/")[-1]
+            )
+            edges.append(
+                {
+                    "from": profile_name,
+                    "to": target_name,
+                    "from_id": profile_uri,
+                    "to_id": target_uri,
+                    "via_statement": edge.get("via_statement"),
+                    "relationship_type": edge.get("linkage_type") or "profile_link",
+                }
+            )
+
+        for route in profile_doc.get("metadata", {}).get("value_list_graph", []):
+            if not isinstance(route, dict):
+                continue
+            value_list_id = route.get("id") or route.get("entity")
+            if not isinstance(value_list_id, str) or not value_list_id:
+                continue
+            value_list_uri, _ = _normalize_entity_uri(value_list_id)
+            value_list_name = route.get("name_identifier")
+            if not isinstance(value_list_name, str) or not value_list_name:
+                value_list_name = value_list_uri.rstrip("/").split("/")[-1]
+
+            nodes.setdefault(
+                value_list_name,
+                {
+                    "kind": "value_list",
+                    "name_identifier": value_list_name,
+                    "id": value_list_uri,
+                    "label": route.get("label"),
+                },
+            )
+
+            statement_uri = route.get("via_statement")
+            route_info = (
+                value_list_routes.get(statement_uri, {})
+                if isinstance(statement_uri, str)
+                else {}
+            )
+
+            edges.append(
+                {
+                    "from": profile_name,
+                    "to": value_list_name,
+                    "from_id": profile_uri,
+                    "to_id": value_list_uri,
+                    "via_statement": statement_uri,
+                    "relationship_type": "value_list_link",
+                    "cache_path": route.get("cache_path")
+                    or route_info.get("cache_path"),
+                    "item_count": route_info.get("item_count"),
+                }
+            )
+
+    edges.sort(
+        key=lambda edge: (
+            str(edge.get("from", "")),
+            str(edge.get("to", "")),
+            str(edge.get("via_statement", "")),
+        )
+    )
+    ordered_nodes = [nodes[key] for key in sorted(nodes.keys())]
+    return {"nodes": ordered_nodes, "edges": edges}
 
 
 def _load_related_profile_documents(
@@ -110,9 +269,13 @@ def _load_related_profile_documents(
                 except Exception:
                     continue
                 loaded_uri = (
-                    loaded.get("entity")
-                    if isinstance(loaded.get("entity"), str)
-                    else target_uri
+                    loaded.get("id")
+                    if isinstance(loaded.get("id"), str)
+                    else (
+                        loaded.get("entity")
+                        if isinstance(loaded.get("entity"), str)
+                        else target_uri
+                    )
                 )
                 profile_docs[loaded_uri] = loaded
                 _visit(loaded_uri, loaded)
@@ -270,22 +433,27 @@ def build_curation_packet_from_json_profile(
             "value_list_routes": {...}
         }
     """
-    # Step 1: Normalize profile_entity to full URI and extract QID
-    full_profile_uri, profile_qid = _normalize_entity_uri(profile_entity)
+    # Step 1: Normalize profile_entity to full URI
+    full_profile_uri, _ = _normalize_entity_uri(profile_entity)
 
     # Step 2: Load primary + linked profile documents from metadata.profile_graph
     profile_docs = _load_related_profile_documents(full_profile_uri, json_profile_doc)
 
-    # Step 3: Build entities list (primary first, then deterministic linked order)
+    # Step 3: Build ordered profiles (primary first, then deterministic linked order)
     ordered_profile_uris = [full_profile_uri] + sorted(
         uri for uri in profile_docs.keys() if uri != full_profile_uri
     )
 
-    entity_id_by_uri: dict[str, str] = {}
-    entities: list[dict[str, Any]] = []
+    data_entities: list[dict[str, Any]] = []
+    metadata_profiles: list[dict[str, Any]] = []
+    profile_name_by_uri: dict[str, str] = {}
 
-    for index, profile_uri in enumerate(ordered_profile_uris, start=1):
+    for profile_uri in ordered_profile_uris:
         profile_doc = profile_docs[profile_uri]
+        profile_uri = _profile_uri_from_doc(profile_doc, profile_uri)
+        profile_name = _profile_name_identifier(profile_doc, profile_uri)
+        profile_name_by_uri[profile_uri] = profile_name
+
         statements = profile_doc.get("statements", [])
         if not isinstance(statements, list):
             statements = []
@@ -296,32 +464,76 @@ def build_curation_packet_from_json_profile(
             if isinstance(statement, dict)
         ]
 
-        entity_id = f"ent-{index:03d}"
-        entity_id_by_uri[profile_uri] = entity_id
-        entities.append(
+        statement_slots: dict[str, dict[str, Any]] = {}
+        for statement in normalized_statements:
+            key_base = _statement_name_identifier(statement)
+            key = key_base
+            suffix = 2
+            while key in statement_slots:
+                key = f"{key_base}_{suffix}"
+                suffix += 1
+            statement_slots[key] = _statement_data_slot(statement)
+
+        metadata_profiles.append(
             {
-                "id": entity_id,
-                "profile_entity": profile_uri,
-                "data": {},
+                "id": profile_uri,
+                "name_identifier": profile_name,
+                "identification": deepcopy(profile_doc.get("identification", {})),
                 "statements": normalized_statements,
+                "metadata": deepcopy(profile_doc.get("metadata", {})),
             }
         )
 
-    # Step 4: Build cross references and value-list routes from metadata graphs
-    cross_references = _build_cross_references(profile_docs, entity_id_by_uri)
-    value_list_routes = _build_value_list_routes(profile_docs, source_root)
+        data_entities.append(
+            {
+                "profile": profile_name,
+                "id": profile_uri,
+                "labels": {},
+                "descriptions": {},
+                "aliases": {},
+                "statements": statement_slots,
+            }
+        )
+
+    primary_profile_name = profile_name_by_uri.get(
+        full_profile_uri, full_profile_uri.rstrip("/").split("/")[-1]
+    )
+
+    # Step 4: Build packet metadata graph and mint metadata
+    unified_graph = _build_unified_graph(profile_docs, profile_name_by_uri, source_root)
+    minted_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
     # Step 5: Generate packet_id
     packet_id = f"pkt-{uuid.uuid4()}"
 
-    # Assemble the final packet
+    metadata = {
+        "primary_profile": {
+            "name_identifier": primary_profile_name,
+            "id": full_profile_uri,
+        },
+        "profiles": metadata_profiles,
+        "graph": unified_graph,
+        "mint": {
+            "minted_at": minted_at,
+            "generator": "gkc.still_charger.build_curation_packet_from_json_profile",
+            "gkc_version": gkc.__version__,
+        },
+    }
+
+    metadata_digest = _canonical_json_digest(metadata)
+    metadata["integrity"] = {
+        "metadata_canonicalization": "json-sort-keys-v1",
+        "metadata_digest_algorithm": "sha256",
+        "metadata_digest": metadata_digest,
+    }
+
     packet = {
         "packet_id": packet_id,
         "operation_mode": "new",
-        "profile_entity": full_profile_uri,
-        "entities": entities,
-        "cross_references": cross_references,
-        "value_list_routes": value_list_routes,
+        "metadata": metadata,
+        "data": {
+            "entities": data_entities,
+        },
     }
 
     return packet

--- a/tests/test_spirit_safe_entity_profile_json.py
+++ b/tests/test_spirit_safe_entity_profile_json.py
@@ -267,12 +267,14 @@ def test_value_list_graph_includes_reference_and_qualifier_routes(tmp_path):
     value_list_graph = docs[0]["metadata"]["value_list_graph"]
     assert value_list_graph == [
         {
+            "id": "https://datadistillery.wikibase.cloud/entity/Q43",
             "entity": "https://datadistillery.wikibase.cloud/entity/Q43",
             "label": "List of Tribal Jurisdictions",
             "via_statement": "https://datadistillery.wikibase.cloud/entity/Q41",
             "cache_path": "cache/queries/Q43.json",
         },
         {
+            "id": "https://datadistillery.wikibase.cloud/entity/Q28",
             "entity": "https://datadistillery.wikibase.cloud/entity/Q28",
             "label": "List of Federal Register Sources",
             "via_statement": "https://datadistillery.wikibase.cloud/entity/Q30",

--- a/tests/test_spirit_safe_phase3.py
+++ b/tests/test_spirit_safe_phase3.py
@@ -140,18 +140,22 @@ def test_create_curation_packet_single_mode():
 
     packet = create_curation_packet("Q4", operation_mode="single")
 
-    assert packet["primary_profile"] == "Q4"
-    assert packet["primary_profile_entity"] == (
+    assert packet["metadata"]["primary_profile"]["name_identifier"] == "Q4"
+    assert packet["metadata"]["primary_profile"]["id"] == (
         "https://datadistillery.wikibase.cloud/entity/Q4"
     )
-    assert len(packet["entities"]) == 1
-    assert packet["cross_references"] == []
+    assert len(packet["data"]["entities"]) == 1
+    graph_edges = packet["metadata"]["graph"]["edges"]
+    assert all(edge.get("relationship_type") != "P161" for edge in graph_edges)
 
     statement_ids = [
-        statement.get("id")
-        for statement in packet["entities"][0]["profile_structure"]["statements"]
+        statement.get("id") or statement.get("entity")
+        for statement in packet["metadata"]["profiles"][0]["statements"]
     ]
-    assert statement_ids == ["Q16", "Q40"]
+    assert statement_ids == [
+        "https://datadistillery.wikibase.cloud/entity/Q16",
+        "https://datadistillery.wikibase.cloud/entity/Q40",
+    ]
 
 
 def test_create_curation_packet_bulk_mode():
@@ -159,21 +163,18 @@ def test_create_curation_packet_bulk_mode():
 
     packet = create_curation_packet("Q4", operation_mode="bulk", depth=1)
 
-    assert len(packet["entities"]) == 2
-    assert len(packet["cross_references"]) == 2
-    assert packet["cardinality_constraints"] == [
-        {"from": "ent-001", "to": "ent-002", "min": 0, "max": -1},
-        {"from": "ent-002", "to": "ent-001", "min": 0, "max": -1},
-    ]
+    assert len(packet["data"]["entities"]) == 2
+    assert len(packet["metadata"]["graph"]["edges"]) == 4
+    assert "integrity" in packet["metadata"]
 
 
-def test_validate_packet_structure_reports_invalid_cross_reference():
-    """Packet validation should catch broken entity references."""
+def test_validate_packet_structure_reports_invalid_data_entity_id():
+    """Packet validation should catch invalid entity identifiers in new schema."""
 
     packet = create_curation_packet("Q4", operation_mode="bulk", depth=1)
-    packet["cross_references"][0]["to"] = "ent-999"
+    packet["data"]["entities"][0]["id"] = "Q4"
 
     is_valid, errors = validate_packet_structure(packet)
 
     assert is_valid is False
-    assert "Cross-reference to ent-999 points to unknown entity" in errors
+    assert "Each data.entities item id must be an HTTP URI" in errors

--- a/tests/test_still_charger.py
+++ b/tests/test_still_charger.py
@@ -53,13 +53,18 @@ def test_build_packet_expands_linked_profiles_from_graph():
         source_root=fixture_root,
     )
 
-    assert packet["profile_entity"] == "https://datadistillery.wikibase.cloud/entity/Q4"
-    assert len(packet["entities"]) == 2
-    assert {entity["profile_entity"] for entity in packet["entities"]} == {
+    assert packet["metadata"]["primary_profile"]["id"] == (
+        "https://datadistillery.wikibase.cloud/entity/Q4"
+    )
+    assert len(packet["data"]["entities"]) == 2
+    assert {entity["id"] for entity in packet["data"]["entities"]} == {
         "https://datadistillery.wikibase.cloud/entity/Q4",
         "https://datadistillery.wikibase.cloud/entity/Q39",
     }
-    assert len(packet["cross_references"]) == 2
+    edge_types = {
+        edge["relationship_type"] for edge in packet["metadata"]["graph"]["edges"]
+    }
+    assert "P161" in edge_types
 
 
 def test_build_packet_value_list_routes_use_statement_uris_and_item_counts():
@@ -72,12 +77,17 @@ def test_build_packet_value_list_routes_use_statement_uris_and_item_counts():
         source_root=fixture_root,
     )
 
-    routes = packet["value_list_routes"]
-    assert "https://datadistillery.wikibase.cloud/entity/Q16" in routes
-    assert routes["https://datadistillery.wikibase.cloud/entity/Q16"]["cache_path"] == (
-        "cache/queries/Q28.json"
+    value_list_edges = [
+        edge
+        for edge in packet["metadata"]["graph"]["edges"]
+        if edge.get("relationship_type") == "value_list_link"
+    ]
+    assert any(
+        edge.get("via_statement") == "https://datadistillery.wikibase.cloud/entity/Q16"
+        and edge.get("cache_path") == "cache/queries/Q28.json"
+        and edge.get("item_count") == 2
+        for edge in value_list_edges
     )
-    assert routes["https://datadistillery.wikibase.cloud/entity/Q16"]["item_count"] == 2
 
 
 def test_charge_packet_by_profile_id():


### PR DESCRIPTION
## Summary
- implement Curation Packet Phase A contract with strict metadata/data split
- mint packet metadata for integrity and downstream fermenter gating
- enrich profile and graph surfaces with resolvable `id` and `name_identifier` (P214)
- adapt CLI packet commands and structure validation for the new contract
- update tests and docs fixture expectations to match new packet/profile shape

## Validation
- poetry run pre-merge-check
- targeted packet/profile test suites pass

## Notes
- includes legacy fallback path in packet structure validation during migration window
