### PR TITLE
Build SpiritSafe normalized entity index in gkc

### DIFF
--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -33,6 +33,7 @@ from gkc.spirit_safe import (
     build_entity_profile_json_documents,
     create_curation_packet,
     export_entity_profile_json_documents,
+    export_spiritsafe_entity_index,
     export_spiritsafe_manifest,
     get_spirit_safe_source,
     load_manifest,
@@ -2557,7 +2558,7 @@ def _handle_registry_validate(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _handle_spiritsafe_manifest_build(args: argparse.Namespace) -> dict[str, Any]:
-    """Build cache/manifest.json from local SpiritSafe artifacts."""
+    """Build cache/manifest.json and cache/entity_index.json from local artifacts."""
 
     if args.source != "local" or not args.local_root:
         raise CLIError(
@@ -2571,18 +2572,26 @@ def _handle_spiritsafe_manifest_build(args: argparse.Namespace) -> dict[str, Any
             if args.output
             else local_root / "cache" / "manifest.json"
         )
+        index_output_path = local_root / "cache" / "entity_index.json"
         manifest_document = export_spiritsafe_manifest(local_root, output_path)
+        index_document = export_spiritsafe_entity_index(local_root, index_output_path)
         details = {
             "output_path": str(output_path),
+            "entity_index_output_path": str(index_output_path),
             "profile_count": len(manifest_document.get("profiles", [])),
             "entity_count": manifest_document.get("entities", {}).get("count", 0),
             "query_count": len(manifest_document.get("queries", [])),
             "value_list_count": len(manifest_document.get("value_lists", [])),
+            "indexed_entity_count": index_document.get("entity_count", 0),
+            "indexed_class_count": index_document.get("class_count", 0),
         }
         return {
             "command": args.command_path,
             "ok": True,
-            "message": f"Built SpiritSafe manifest at {output_path}",
+            "message": (
+                f"Built SpiritSafe manifest at {output_path} "
+                f"and entity index at {index_output_path}"
+            ),
             "details": details,
         }
     except Exception as exc:

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -2826,6 +2826,256 @@ def _label_from_cache_entity(document: dict[str, Any]) -> str:
     return ""
 
 
+def _claim_entity_id_value(claim: dict[str, Any]) -> Optional[str]:
+    value = claim.get("mainsnak", {}).get("datavalue", {}).get("value", {})
+    return value.get("id") if isinstance(value, dict) else None
+
+
+def _claim_string_value(claim: dict[str, Any]) -> Optional[str]:
+    value = claim.get("mainsnak", {}).get("datavalue", {}).get("value")
+    return value if isinstance(value, str) and value else None
+
+
+def _claim_quantity_int_value(claim: dict[str, Any]) -> Optional[int]:
+    value = claim.get("mainsnak", {}).get("datavalue", {}).get("value", {})
+    if not isinstance(value, dict):
+        return None
+    amount = value.get("amount")
+    if not isinstance(amount, str) or not amount:
+        return None
+    try:
+        return int(float(amount))
+    except ValueError:
+        return None
+
+
+def _qualifier_entity_ids(
+    qualifiers: Any,
+    prop_id: str,
+) -> list[str]:
+    if not isinstance(qualifiers, dict):
+        return []
+
+    values: list[str] = []
+    for snak in qualifiers.get(prop_id, []):
+        value = snak.get("datavalue", {}).get("value", {})
+        entity_id = value.get("id") if isinstance(value, dict) else None
+        if isinstance(entity_id, str) and entity_id:
+            values.append(entity_id)
+    return values
+
+
+def _claim_monolingual_by_language(claims: list[dict[str, Any]]) -> dict[str, str]:
+    by_language: dict[str, str] = {}
+    for claim in claims:
+        value = claim.get("mainsnak", {}).get("datavalue", {}).get("value", {})
+        if not isinstance(value, dict):
+            continue
+        language = value.get("language")
+        text = value.get("text")
+        if (
+            isinstance(language, str)
+            and language
+            and isinstance(text, str)
+            and text
+            and language not in by_language
+        ):
+            by_language[language] = text
+    return by_language
+
+
+def _sorted_unique(values: list[str]) -> list[str]:
+    return sorted({value for value in values if isinstance(value, str) and value})
+
+
+def _build_link_entries(
+    claims: list[dict[str, Any]],
+    *,
+    applies_to_profile_prop: str,
+    applies_to_statement_prop: str,
+) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for claim in claims:
+        target_id = _claim_entity_id_value(claim)
+        if not target_id:
+            continue
+
+        entry: dict[str, Any] = {"target": target_id}
+        scope_profiles = _sorted_unique(
+            _qualifier_entity_ids(claim.get("qualifiers", {}), applies_to_profile_prop)
+        )
+        scope_statements = _sorted_unique(
+            _qualifier_entity_ids(
+                claim.get("qualifiers", {}),
+                applies_to_statement_prop,
+            )
+        )
+        if scope_profiles or scope_statements:
+            entry["scope"] = {
+                "profiles": scope_profiles,
+                "statements": scope_statements,
+            }
+        entries.append(entry)
+
+    return sorted(entries, key=lambda entry: (entry["target"], json.dumps(entry)))
+
+
+def _build_entity_index_entry(entity_doc: dict[str, Any]) -> dict[str, Any]:
+    entity_id = str(entity_doc.get("entity_id") or "")
+    claims = entity_doc.get("entity", {}).get("claims", {})
+    classes = _sorted_unique(
+        [
+            entity_id_value
+            for entity_id_value in (
+                _claim_entity_id_value(claim) for claim in claims.get("P1", [])
+            )
+            if entity_id_value
+        ]
+    )
+
+    value_type = next(
+        (
+            value
+            for value in (
+                _claim_entity_id_value(claim) for claim in claims.get("P194", [])
+            )
+            if value
+        ),
+        None,
+    )
+    max_count = next(
+        (
+            value
+            for value in (
+                _claim_quantity_int_value(claim) for claim in claims.get("P182", [])
+            )
+            if value is not None
+        ),
+        None,
+    )
+    name_identifier = next(
+        (
+            value
+            for value in (
+                _claim_string_value(claim) for claim in claims.get("P214", [])
+            )
+            if value
+        ),
+        None,
+    )
+
+    messages: dict[str, dict[str, str]] = {}
+    for prop_id, field_name in {
+        "P171": "prompt",
+        "P169": "guidance",
+        "P170": "consequences_message",
+        "P168": "error_message",
+    }.items():
+        for language, text in _claim_monolingual_by_language(
+            claims.get(prop_id, [])
+        ).items():
+            messages.setdefault(language, {})[field_name] = text
+
+    return {
+        "id": entity_id,
+        "entity": f"{SPIRITSAFE_ENTITY_URI_PREFIX}{entity_id}",
+        "label": _label_from_cache_entity(entity_doc),
+        "name_identifier": name_identifier,
+        "classes": classes,
+        "value_type": value_type,
+        "io_map": _sorted_unique(
+            [
+                value
+                for value in (
+                    _claim_string_value(claim) for claim in claims.get("P5", [])
+                )
+                if value
+            ]
+        ),
+        "max_count": max_count,
+        "messages": messages,
+        "links": {
+            "statements": _build_link_entries(
+                claims.get("P157", []),
+                applies_to_profile_prop="P205",
+                applies_to_statement_prop="P163",
+            ),
+            "qualifiers": _build_link_entries(
+                claims.get("P158", []),
+                applies_to_profile_prop="P205",
+                applies_to_statement_prop="P163",
+            ),
+            "references": _build_link_entries(
+                claims.get("P211", []),
+                applies_to_profile_prop="P205",
+                applies_to_statement_prop="P163",
+            ),
+            "values": _build_link_entries(
+                claims.get("P161", []),
+                applies_to_profile_prop="P205",
+                applies_to_statement_prop="P163",
+            ),
+            "derives_default_value_from": _build_link_entries(
+                claims.get("P213", []),
+                applies_to_profile_prop="P205",
+                applies_to_statement_prop="P163",
+            ),
+        },
+    }
+
+
+def build_spiritsafe_entity_index_document(
+    spiritsafe_root: Union[str, Path],
+) -> dict[str, Any]:
+    """Build a normalized entity index from cached SpiritSafe entity JSON docs."""
+
+    root = Path(spiritsafe_root).expanduser().resolve()
+    cache_entities_dir = root / "cache" / "entities"
+
+    entities: dict[str, dict[str, Any]] = {}
+    by_class: dict[str, list[str]] = {}
+
+    for entity_path in sorted(cache_entities_dir.glob("*.json")):
+        entity_doc = json.loads(entity_path.read_text(encoding="utf-8"))
+        entry = _build_entity_index_entry(entity_doc)
+        entity_id = str(entry.get("id") or entity_path.stem)
+        entities[entity_id] = entry
+
+        for class_id in entry.get("classes", []):
+            by_class.setdefault(class_id, []).append(entity_id)
+
+    for class_id, members in by_class.items():
+        by_class[class_id] = sorted(set(members))
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "source": _manifest_source_url(),
+        "entity_count": len(entities),
+        "class_count": len(by_class),
+        "entities": entities,
+        "class_index": by_class,
+    }
+
+
+def export_spiritsafe_entity_index(
+    spiritsafe_root: Union[str, Path],
+    output_path: Optional[Union[str, Path]] = None,
+) -> dict[str, Any]:
+    """Build and write the SpiritSafe normalized entity index document."""
+
+    root = Path(spiritsafe_root).expanduser().resolve()
+    destination = (
+        Path(output_path).expanduser().resolve()
+        if output_path is not None
+        else (root / "cache" / "entity_index.json")
+    )
+
+    index_document = build_spiritsafe_entity_index_document(root)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(index_document, indent=2), encoding="utf-8")
+    return index_document
+
+
 def _statement_id_from_definition(statement: dict[str, Any]) -> Optional[str]:
     entity_id = _entity_id_from_reference(statement.get("id"))
     if entity_id:

--- a/tests/test_spirit_safe_phase3.py
+++ b/tests/test_spirit_safe_phase3.py
@@ -5,8 +5,10 @@ from pathlib import Path
 import pytest
 
 from gkc.spirit_safe import (
+    build_spiritsafe_entity_index_document,
     build_spiritsafe_manifest_document,
     create_curation_packet,
+    export_spiritsafe_entity_index,
     export_spiritsafe_manifest,
     get_profile_graph,
     load_manifest,
@@ -72,6 +74,33 @@ def test_export_spiritsafe_manifest(fixture_root: Path, tmp_path: Path):
 
     assert output_path.exists()
     assert {profile["qid"] for profile in manifest["profiles"]} == {"Q4", "Q39"}
+
+
+def test_build_spiritsafe_entity_index_document(fixture_root: Path):
+    """Entity index builder should normalize cached entity artifacts."""
+
+    index = build_spiritsafe_entity_index_document(fixture_root)
+
+    assert index["source"] == "https://github.com/skybristol/SpiritSafe"
+    assert index["entity_count"] == 1
+    assert "Q4" in index["entities"]
+    q4 = index["entities"]["Q4"]
+    assert q4["id"] == "Q4"
+    assert q4["entity"] == "https://datadistillery.wikibase.cloud/entity/Q4"
+    assert q4["label"] == "Tribal Government in the United States"
+    assert q4["classes"] == []
+    assert q4["links"]["statements"] == []
+
+
+def test_export_spiritsafe_entity_index(fixture_root: Path, tmp_path: Path):
+    """Entity index export should write JSON to the requested path."""
+
+    output_path = tmp_path / "entity_index.json"
+    index = export_spiritsafe_entity_index(fixture_root, output_path)
+
+    assert output_path.exists()
+    assert index["entity_count"] == 1
+    assert index["class_index"] == {}
 
 
 def test_load_manifest_reads_new_shape():


### PR DESCRIPTION
## Summary
- add gkc-native SpiritSafe entity index builder/exporter producing cache/entity_index.json
- normalize cached entity semantics (classes, value/link semantics, language messages, scoped link metadata)
- extend spiritsafe manifest build CLI path to build both manifest and entity index
- add phase3 regression tests for index build/export

## Validation
- poetry run pytest tests/test_spirit_safe_phase3.py -q
- bash scripts/pre-merge-check.sh