### PR TITLE
StillChargerFirmUp: packet schema consistency, ownership, and charging improvements

### DIFF
--- a/docs/architecture/SpiritSafe.md
+++ b/docs/architecture/SpiritSafe.md
@@ -46,7 +46,7 @@ Both artifacts are generated in a single operation and are kept in sync.
 
 See [SpiritSafe Entity Index Architecture](spiritsafe-entity-index.md) for detailed schema and consumption patterns.
 
-Packet assembly routes (`create_curation_packet`) do not require manifest or entity index lookups; they consume profiles directly.
+Packet assembly routes in `still_charger.create_curation_packet` do not require manifest or entity index lookups; they consume profile JSON directly.
 
 ## Manifest Sections
 

--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -56,7 +56,6 @@ Current anchor surface:
 
 Transition-only legacy surface (deferred removal):
 
-- `create_curation_packet`
 - `validate_packet_structure`
 
 ### Still Charger (`gkc.still_charger`)
@@ -75,6 +74,7 @@ Out of scope:
 
 Current anchor surface:
 
+- `create_curation_packet`
 - `build_curation_packet_from_json_profile`
 - `charge_curation_packet`
 - `charge_packet_from_wikidata_items`

--- a/docs/architecture/spirit_safe_models.md
+++ b/docs/architecture/spirit_safe_models.md
@@ -32,7 +32,7 @@ Implemented and committed:
 - `load_profile()` resolves QID/URI and loads JSON profile documents.
 - `load_profile_package()` loads primary plus related profiles by traversing embedded `metadata.profile_graph` edges.
 - `get_profile_graph()` loads manifest and builds a graph for registry tooling.
-- `create_curation_packet()` builds packet scaffolds from profile documents directly.
+- `still_charger.create_curation_packet()` builds packet scaffolds from profile documents loaded via SpiritSafe.
 
 ## Identity Model
 
@@ -74,7 +74,7 @@ Normalization rules:
 
 ## Packet Scaffolding Model
 
-`create_curation_packet()` outputs:
+`still_charger.create_curation_packet()` outputs:
 
 - `packet_id`
 - `operation_mode`

--- a/docs/gkc/api/spirit_safe.md
+++ b/docs/gkc/api/spirit_safe.md
@@ -22,29 +22,29 @@ The typical workflow for curation involves three stages:
 
 ```python
 from pathlib import Path
-from gkc.spirit_safe import create_curation_packet, set_spirit_safe_source
-from gkc.still_charger import charge_packet_from_wikidata_items
+from gkc.spirit_safe import set_spirit_safe_source
+from gkc.still_charger import create_curation_packet, charge_packet_from_wikidata_items
 
 # 1. Configure source
 set_spirit_safe_source(mode="local", local_root="/path/to/SpiritSafe")
 
 # 2. Create empty scaffold from profile Q4 (TribalGovernmentUS)
 packet = create_curation_packet("Q4", operation_mode="single", depth=1)
-print(f"Created packet {packet['packet_id']} with {len(packet['entities'])} entities")
+print(f"Created packet {packet['packet_id']} with {len(packet['data']['entities'])} entities")
 
 # 3. Map entities to Wikidata QIDs and charge
-qid_map = {entity["id"]: "Q195562" for entity in packet["entities"]}  # Cherokee Nation
+qid_map = {entity["id"]: "Q195562" for entity in packet["data"]["entities"]}  # Cherokee Nation
 charged_packet, notices = charge_packet_from_wikidata_items(packet, qid_map)
 
 # 4. Check for issues
 errors = [n for n in notices if n.severity == "error"]
 warnings = [n for n in notices if n.severity == "warning"]
-print(f"Charged: {len(charged_packet['entities'])} entities, {len(errors)} errors, {len(warnings)} warnings")
+print(f"Charged: {len(charged_packet['data']['entities'])} entities, {len(errors)} errors, {len(warnings)} warnings")
 
 # Now packet is ready for validation or review
 ```
 
-See [Still Charger API](still_charger.md) for detailed charging documentation.
+See [Still Charger API](still_charger.md) for packet-assembly and charging documentation.
 
 ### Configure SpiritSafe Source
 
@@ -115,7 +115,8 @@ print(link)
 ### Create and Validate Curation Packets
 
 ```python
-from gkc.spirit_safe import create_curation_packet, validate_packet_structure
+from gkc.spirit_safe import validate_packet_structure
+from gkc.still_charger import create_curation_packet
 
 # Creates an EMPTY scaffold with entity slots defined by the profile
 packet = create_curation_packet("Q4", operation_mode="bulk", depth=1)
@@ -124,8 +125,8 @@ print(packet["packet_id"], is_valid, errors)
 
 # Packets are empty at this point - no data values populated
 # To populate with Wikidata or other source data, see still_charger.charge_packet_from_wikidata_items()
-for entity in packet["entities"]:
-    print(entity["id"], "data:" if entity["data"] else "empty")
+for entity in packet["data"]["entities"]:
+    print(entity["id"], "data:" if entity.get("data") else "empty")
 ```
 
 **Important:** `create_curation_packet()` returns an **empty scaffold**. To populate it with data from Wikidata or other sources, use the **Still Charger** module:
@@ -133,7 +134,7 @@ for entity in packet["entities"]:
 ```python
 from gkc.still_charger import charge_packet_from_wikidata_items
 
-qid_map = {entity["id"]: "Q195562" for entity in packet["entities"]}
+qid_map = {entity["id"]: "Q195562" for entity in packet["data"]["entities"]}
 charged_packet, notices = charge_packet_from_wikidata_items(packet, qid_map)
 ```
 
@@ -231,8 +232,6 @@ print(result.hydrated_ids)
 ::: gkc.spirit_safe.get_profile_graph
 
 ::: gkc.spirit_safe.resolve_profile_link
-
-::: gkc.spirit_safe.create_curation_packet
 
 ::: gkc.spirit_safe.validate_packet_structure
 

--- a/docs/gkc/api/still_charger.md
+++ b/docs/gkc/api/still_charger.md
@@ -12,9 +12,17 @@ Validation and coercion notices are emitted as `ConformanceNotice` objects (see 
 ```python
 from pathlib import Path
 from gkc.still_charger import (
+  create_curation_packet,
     build_curation_packet_from_json_profile,
     charge_packet_from_wikidata_items,
 )
+
+from gkc.spirit_safe import set_spirit_safe_source
+
+set_spirit_safe_source(mode="local", local_root="/path/to/SpiritSafe")
+
+# 0. Create scaffold directly from profile id (canonical entrypoint)
+packet = create_curation_packet("Q4", operation_mode="bulk")
 
 # 1. Load a JSON profile from local SpiritSafe
 import json
@@ -31,10 +39,10 @@ packet = build_curation_packet_from_json_profile(
 )
 
 print(packet["packet_id"])
-print(len(packet["entities"]))
+print(len(packet["data"]["entities"]))
 
 # 3. Charge from Wikidata (e.g., Cherokee Nation Q195562)
-qid_map = {entity["id"]: "Q195562" for entity in packet["entities"]}
+qid_map = {entity["id"]: "Q195562" for entity in packet["data"]["entities"]}
 charged_packet, notices = charge_packet_from_wikidata_items(packet, qid_map)
 
 for notice in notices:
@@ -42,6 +50,27 @@ for notice in notices:
 ```
 
 ## Public API
+
+### `create_curation_packet()`
+
+Create a packet scaffold from SpiritSafe by profile identifier.
+
+```python
+from gkc.still_charger import create_curation_packet
+
+packet = create_curation_packet("Q4", operation_mode="single")
+```
+
+**Arguments:**
+
+| Argument | Type | Description |
+|---|---|---|
+| `profile_id` | `str` | Profile QID or full profile URI |
+| `operation_mode` | `str` | `single` for primary-only scaffold or `bulk` for profile-graph expansion |
+
+**Returns:** `dict` — Packet scaffold in the URI-keyed contract.
+
+---
 
 ### `build_curation_packet_from_json_profile()`
 
@@ -70,21 +99,27 @@ packet = build_curation_packet_from_json_profile(
 
 ```json
 {
-  "packet_id": "uuid-...",
-  "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
-  "entities": [
-    {
-      "id": "uuid-...",
-      "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
-      "statements": [
-        {"entity": "https://datadistillery.wikibase.cloud/entity/P5", "data": {}}
-      ],
-      "data": {}
-    }
-  ],
-  "cross_references": [],
-  "value_list_routes": {
-    "https://datadistillery.wikibase.cloud/entity/P5": "/path/to/cache/queries/Q28.json"
+  "packet_id": "pkt-...",
+  "operation_mode": "new",
+  "metadata": {
+    "primary_profile": {
+      "name_identifier": "Q4",
+      "id": "https://datadistillery.wikibase.cloud/entity/Q4"
+    },
+    "profiles": [],
+    "graph": {"nodes": [], "edges": []}
+  },
+  "data": {
+    "entities": [
+      {
+        "profile": "Q4",
+        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "labels": {},
+        "descriptions": {},
+        "aliases": {},
+        "statements": {}
+      }
+    ]
   }
 }
 ```
@@ -99,7 +134,7 @@ Charge a packet scaffold with live data fetched from Wikidata.
 from gkc.still_charger import charge_packet_from_wikidata_items
 
 # Map all packet entities to a single QID
-qid_map = {entity["id"]: "Q195562" for entity in packet["entities"]}
+qid_map = {entity["id"]: "Q195562" for entity in packet["data"]["entities"]}
 
 charged_packet, notices = charge_packet_from_wikidata_items(packet, qid_map)
 
@@ -124,8 +159,7 @@ warnings = [n for n in notices if n.severity == "warning"]
 
 1. Intra-packet UUID → exact key match in `qid_map`
 2. Full entity URI → key match in `qid_map`
-3. QID string → direct Wikidata lookup
-4. Profile name (legacy) → backward-compatible fallback
+3. Profile entity URI tail QID → direct Wikidata lookup
 
 ---
 
@@ -187,6 +221,20 @@ print(report.entities_charged, report.issues[0].severity)
 ### `ChargeReport`
 
 ::: gkc.still_charger.ChargeReport
+    options:
+      show_root_heading: false
+      heading_level: 4
+
+### `create_curation_packet()`
+
+::: gkc.still_charger.create_curation_packet
+    options:
+      show_root_heading: false
+      heading_level: 4
+
+### `build_curation_packet_from_json_profile()`
+
+::: gkc.still_charger.build_curation_packet_from_json_profile
     options:
       show_root_heading: false
       heading_level: 4

--- a/docs/gkc/cli/profiles.md
+++ b/docs/gkc/cli/profiles.md
@@ -134,10 +134,10 @@ gkc packet build --profile Q4 --source github --repo skybristol/SpiritSafe --ref
 The output packet includes:
 
 - `packet_id` — UUID for this packet
-- `profile_entity` — Full URI of the source profile
-- `entities[]` — Entity slots with statement slots pre-scaffolded
-- `cross_references[]` — Cross-reference slots for linked profiles
-- `value_list_routes{}` — Cached value-list file paths keyed by statement entity URI
+- `operation_mode` — Scaffold mode indicator
+- `metadata.primary_profile` — Full URI and identifier for the source profile
+- `metadata.graph.edges[]` — Linked-profile graph edges for packet traversal
+- `data.entities[]` — Entity slots with statement slots pre-scaffolded
 
 ### `gkc packet charge`
 

--- a/docs/gkc/cli/wikibase.md
+++ b/docs/gkc/cli/wikibase.md
@@ -111,7 +111,7 @@ When `--output` is used, command output includes:
 
 `plan-write` runs the shared pipeline:
 
-- `spirit_safe.create_curation_packet`
+- `still_charger.create_curation_packet`
 - `still_charger.charge_curation_packet`
 - `wikibase.orchestration.barrel_curation_packet_to_wikibase_plan`
 - optional `shipper.plan_batch`
@@ -175,7 +175,7 @@ With `--with-shipper-plan`, output also includes:
 
 Execution path:
 
-- `spirit_safe.create_curation_packet`
+- `still_charger.create_curation_packet`
 - `still_charger.charge_curation_packet`
 - `wikibase.orchestration.barrel_curation_packet_to_wikibase_plan`
 - `shipper.write_item` / `shipper.write_property`

--- a/docs/gkc/entity-json-schema.md
+++ b/docs/gkc/entity-json-schema.md
@@ -75,10 +75,20 @@ The active scaffold contract produced by `build_curation_packet_from_json_profil
 {
   "packet_id": "pkt-<uuid>",
   "operation_mode": "new",
-  "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
-  "entities": [],
-  "cross_references": [],
-  "value_list_routes": {}
+  "metadata": {
+    "primary_profile": {
+      "name_identifier": "Q4",
+      "id": "https://datadistillery.wikibase.cloud/entity/Q4"
+    },
+    "profiles": [],
+    "graph": {
+      "nodes": [],
+      "edges": []
+    }
+  },
+  "data": {
+    "entities": []
+  }
 }
 ```
 
@@ -88,40 +98,41 @@ The active scaffold contract produced by `build_curation_packet_from_json_profil
 |---|---|---|---|
 | `packet_id` | string | Yes | Packet-local identifier |
 | `operation_mode` | string | Yes | Current mode (`new` in scaffold builder) |
-| `profile_entity` | string | Yes | Primary profile URI used to mint packet |
-| `entities` | array | Yes | Entity slots in this packet |
-| `cross_references` | array | Yes | URI-aware profile graph edges mapped to entity IDs |
-| `value_list_routes` | object | Yes | Statement URI keyed value-list route metadata |
+| `metadata.primary_profile.id` | string | Yes | Primary profile URI used to mint packet |
+| `metadata.profiles` | array | Yes | Profile metadata and statement definitions in packet scope |
+| `metadata.graph.edges` | array | Yes | URI-aware profile graph edges |
+| `data.entities` | array | Yes | Entity slots in this packet |
 | `minted_from` | object | No (recommended) | Provenance and compatibility metadata |
 | `compatibility_status` | string | No | Re-entry compatibility outcome |
 | `migration_report` | object | No | Migration actions and warnings |
 
 ### Entity Slot Scaffold Shape
 
-Each entry in `entities[]` includes:
+Each entry in `data.entities[]` includes:
 
 ```json
 {
-  "id": "ent-001",
-  "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
-  "data": {},
-  "statements": [
-    {
-      "entity": "https://datadistillery.wikibase.cloud/entity/Q16",
-      "value": {"type": "wikibase-item"},
-      "qualifiers": [],
-      "references": []
+  "profile": "Q4",
+  "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+  "labels": {"mul": {"data-value": ""}},
+  "descriptions": {"mul": {"data-value": ""}},
+  "aliases": {"mul": {"data-value": ""}},
+  "statements": {
+    "Q16": {
+      "id": "https://datadistillery.wikibase.cloud/entity/Q16",
+      "data-type": "item",
+      "data-value": ""
     }
-  ]
+  }
 }
 ```
 
 | Field | Type | Required | Meaning |
 |---|---|---|---|
-| `id` | string | Yes | Packet-local entity slot ID (`ent-###`) |
-| `profile_entity` | string | Yes | Profile URI for this slot |
-| `data` | object | Yes | Charged curator/source data payload |
-| `statements` | array | Yes | Statement scaffold copied from profile JSON |
+| `profile` | string | Yes | Profile name identifier for this entity slot |
+| `id` | string | Yes | Entity URI for this slot |
+| `labels/descriptions/aliases` | object | Yes | Identification field slots |
+| `statements` | object | Yes | Statement slot map keyed by statement identifier |
 
 ## Charged Entity Data Contract
 

--- a/gkc/__init__.py
+++ b/gkc/__init__.py
@@ -120,7 +120,6 @@ from gkc.spirit_safe import (
     ValueListHydrationResult,
     build_entity_profile_json_documents,
     build_spiritsafe_manifest_document,
-    create_curation_packet,
     discover_value_list_ids,
     export_entity_profile_json_documents,
     export_spiritsafe_manifest,
@@ -148,6 +147,7 @@ from gkc.still_charger import (
     build_curation_packet_from_json_profile,
     charge_curation_packet,
     charge_packet_from_wikidata_items,
+    create_curation_packet,
 )
 
 # Utilities (common helpers)

--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -31,7 +31,6 @@ from gkc.shipper import WikibaseShipper
 from gkc.sparql import fetch_entity_labels
 from gkc.spirit_safe import (
     build_entity_profile_json_documents,
-    create_curation_packet,
     export_entity_profile_json_documents,
     export_spiritsafe_entity_index,
     export_spiritsafe_manifest,
@@ -41,6 +40,7 @@ from gkc.spirit_safe import (
     load_profile_package,
     validate_packet_structure,
 )
+from gkc.still_charger import create_curation_packet
 from gkc.wikibase import (
     build_wikibase_cache,
     build_wikibase_write_plan,
@@ -3104,7 +3104,7 @@ def _handle_wikibase_plan_write(args: argparse.Namespace) -> dict[str, Any]:
         )
 
         logical_path = [
-            "spirit_safe.create_curation_packet",
+            "still_charger.create_curation_packet",
             (
                 "still_charger.charge_curation_packet"
                 + (" [specificationless]" if not args.strict_charging else " [strict]")
@@ -3312,7 +3312,7 @@ def _handle_wikibase_execute_write(args: argparse.Namespace) -> dict[str, Any]:
         )
 
         logical_path = [
-            "spirit_safe.create_curation_packet",
+            "still_charger.create_curation_packet",
             (
                 "still_charger.charge_curation_packet"
                 + (" [specificationless]" if not args.strict_charging else " [strict]")

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -3461,47 +3461,6 @@ def resolve_profile_link(
     return None
 
 
-def create_curation_packet(
-    profile_id: str,
-    operation_mode: str = "single",
-    load_wikidata_qids: bool = False,
-    depth: int = 1,
-    manifest: Optional[Manifest] = None,
-) -> dict[str, Any]:
-    """Create a curation packet from JSON Entity Profiles.
-
-    Packet assembly reads `profiles/<QID>.json` directly. The SpiritSafe
-    manifest remains a tooling/index artifact and is not required here.
-    """
-
-    del load_wikidata_qids
-    del depth
-    del manifest
-
-    from gkc.still_charger import build_curation_packet_from_json_profile
-
-    profile_doc = load_profile(profile_id)
-    profile_uri = _entity_uri_from_reference(profile_doc.get("id") or profile_id)
-    if not profile_uri:
-        raise ValueError(f"Invalid profile identifier: {profile_id}")
-
-    if operation_mode == "single":
-        profile_doc = deepcopy(profile_doc)
-        profile_doc.setdefault("metadata", {})["profile_graph"] = []
-
-    packet = build_curation_packet_from_json_profile(
-        profile_entity=profile_uri,
-        json_profile_doc=profile_doc,
-        source_root=(
-            get_spirit_safe_source().local_root
-            if get_spirit_safe_source().mode == "local"
-            else None
-        ),
-    )
-    packet["operation_mode"] = operation_mode
-    return packet
-
-
 def validate_packet_structure(packet: dict[str, Any]) -> tuple[bool, list[str]]:
     """Validate packet structure and basic linkage consistency."""
 

--- a/gkc/still_charger.py
+++ b/gkc/still_charger.py
@@ -592,6 +592,48 @@ def build_curation_packet_from_json_profile(
     return packet
 
 
+def create_curation_packet(
+    profile_id: str,
+    operation_mode: str = "single",
+    load_wikidata_qids: bool = False,
+    depth: int = 1,
+    manifest: Optional[Any] = None,
+) -> dict[str, Any]:
+    """Create a curation packet scaffold from SpiritSafe JSON profiles.
+
+    This is the canonical packet-assembly entrypoint. It loads the primary
+    profile from SpiritSafe, applies operation-mode expansion policy, and
+    delegates scaffold construction to ``build_curation_packet_from_json_profile``.
+    """
+
+    del load_wikidata_qids
+    del depth
+    del manifest
+
+    if operation_mode not in {"single", "bulk"}:
+        raise ValueError(
+            f"Unsupported operation_mode '{operation_mode}'. Expected 'single' or 'bulk'."
+        )
+
+    from gkc.spirit_safe import get_spirit_safe_source, load_profile
+
+    profile_doc = load_profile(profile_id)
+    profile_uri, _ = _normalize_entity_uri(str(profile_doc.get("id") or profile_id))
+
+    if operation_mode == "single":
+        profile_doc = deepcopy(profile_doc)
+        profile_doc.setdefault("metadata", {})["profile_graph"] = []
+
+    source = get_spirit_safe_source()
+    packet = build_curation_packet_from_json_profile(
+        profile_entity=profile_uri,
+        json_profile_doc=profile_doc,
+        source_root=source.local_root if source.mode == "local" else None,
+    )
+    packet["operation_mode"] = operation_mode
+    return packet
+
+
 def charge_packet_from_wikidata_items(
     packet: dict[str, Any],
     qid_map: dict[str, str],
@@ -631,10 +673,38 @@ def charge_packet_from_wikidata_items(
     if mash_client is None:
         mash_client = WikibaseLoader()
 
-    entities = charged.get("entities", [])
+    entities = charged.get("data", {}).get("entities")
+    if not isinstance(entities, list):
+        entities = charged.get("entities", [])
+
+    metadata_profiles = charged.get("metadata", {}).get("profiles", [])
+    if not isinstance(metadata_profiles, list):
+        metadata_profiles = []
+
+    profile_statements_by_key: dict[str, list[dict[str, Any]]] = {}
+    for profile_meta in metadata_profiles:
+        if not isinstance(profile_meta, dict):
+            continue
+        statements = profile_meta.get("statements", [])
+        if not isinstance(statements, list):
+            continue
+        profile_id = profile_meta.get("id")
+        name_identifier = profile_meta.get("name_identifier")
+        if isinstance(profile_id, str) and profile_id:
+            profile_statements_by_key[profile_id] = statements
+        if isinstance(name_identifier, str) and name_identifier:
+            profile_statements_by_key[name_identifier] = statements
+
     for entity in entities:
         entity_id = entity.get("id")
         profile_entity = entity.get("profile_entity")
+        if not isinstance(profile_entity, str) or not profile_entity:
+            if isinstance(entity_id, str) and (
+                entity_id.startswith("http://") or entity_id.startswith("https://")
+            ):
+                profile_entity = entity_id
+
+        entity_profile_name = entity.get("profile")
 
         # Resolve the QID for this entity
         target_qid = (
@@ -686,6 +756,23 @@ def charge_packet_from_wikidata_items(
 
         # Build a mapping from Wikidata property ID to packet statements
         statements = entity.get("statements", [])
+        if isinstance(statements, dict):
+            if (
+                isinstance(profile_entity, str)
+                and profile_entity in profile_statements_by_key
+            ):
+                statements = profile_statements_by_key[profile_entity]
+            elif (
+                isinstance(entity_profile_name, str)
+                and entity_profile_name in profile_statements_by_key
+            ):
+                statements = profile_statements_by_key[entity_profile_name]
+            else:
+                statements = []
+
+        if not isinstance(statements, list):
+            statements = []
+
         io_map_by_property_id = {}
         for stmt in statements:
             if isinstance(stmt, dict):

--- a/gkc/wikibase/__init__.py
+++ b/gkc/wikibase/__init__.py
@@ -1,7 +1,7 @@
 """Wikibase integration utilities for GKC.
 
 Scope: Wikibase-first ProfilesV2 support, including live ontology snapshots
-for semantic resolution, write plan orchestration, and legacy foundation workflows.
+for semantic resolution, write plan orchestration, and foundation workflows.
 """
 
 from gkc.wikibase.cache import (

--- a/gkc/wikibase/orchestration.py
+++ b/gkc/wikibase/orchestration.py
@@ -5,11 +5,12 @@ from pathlib import Path
 from typing import Any, Optional
 
 from gkc.shipper import WriteResult
-from gkc.spirit_safe import Manifest, create_curation_packet
+from gkc.spirit_safe import Manifest
 from gkc.still_charger import (
     ChargeReport,
     build_curation_packet_from_json_profile,
     charge_curation_packet,
+    create_curation_packet,
 )
 from gkc.utilities import validate_entity_reference
 
@@ -340,33 +341,33 @@ def build_wikibase_write_plan(
     """Build a Wikibase write plan from profile and source values.
 
     Pipeline:
-    1) Create curation packet from profile scaffolds (old or new method)
+    1) Create curation packet from profile scaffolds (still_charger)
     2) Charge packet with concrete values
     3) Barrel charged packet into shipper-compatible operations
     4) Optionally compute diff plan using WikibaseShipper.plan_batch
 
     Args:
-        profile_id: (deprecated) Profile name string for old create_curation_packet path
+        profile_id: Profile identifier used by still_charger.create_curation_packet.
         source_values: Source values mapping for charging
-        profile_entity: Full profile entity URI for new path
-        json_profile_doc: Pre-loaded JSON profile document for new path
+        profile_entity: Full profile entity URI for direct JSON-doc assembly mode.
+        json_profile_doc: Pre-loaded JSON profile document for direct assembly mode.
         source_root: Optional path root for value list cache hydration
         operation_mode: Mode for packet assembly
-        manifest: Old manifest (for transitional create_curation_packet)
+        manifest: Optional compatibility argument passed through to packet creation.
         Other args: same as before
     """
 
     if source_values is None:
         source_values = {}
 
-    # New path: build packet from JSON profile
+    # Direct path: build packet from explicit JSON profile document.
     if json_profile_doc is not None and profile_entity is not None:
         packet = build_curation_packet_from_json_profile(
             profile_entity=profile_entity,
             json_profile_doc=json_profile_doc,
             source_root=source_root,
         )
-    # Old path: build packet from profile_id + manifest (transitional)
+    # Canonical path: build packet from profile identifier.
     elif profile_id is not None:
         packet = create_curation_packet(
             profile_id=profile_id,

--- a/tests/test_spirit_safe_phase3.py
+++ b/tests/test_spirit_safe_phase3.py
@@ -7,7 +7,6 @@ import pytest
 from gkc.spirit_safe import (
     build_spiritsafe_entity_index_document,
     build_spiritsafe_manifest_document,
-    create_curation_packet,
     export_spiritsafe_entity_index,
     export_spiritsafe_manifest,
     get_profile_graph,
@@ -18,6 +17,7 @@ from gkc.spirit_safe import (
     set_spirit_safe_source,
     validate_packet_structure,
 )
+from gkc.still_charger import create_curation_packet
 
 
 @pytest.fixture

--- a/tests/test_still_charger.py
+++ b/tests/test_still_charger.py
@@ -6,6 +6,8 @@ from gkc.spirit_safe import load_profile, set_spirit_safe_source
 from gkc.still_charger import (
     build_curation_packet_from_json_profile,
     charge_curation_packet,
+    charge_packet_from_wikidata_items,
+    create_curation_packet,
 )
 
 
@@ -65,6 +67,23 @@ def test_build_packet_expands_linked_profiles_from_graph():
         edge["relationship_type"] for edge in packet["metadata"]["graph"]["edges"]
     }
     assert "P161" in edge_types
+
+
+def test_create_curation_packet_single_mode_is_primary_only():
+    packet = create_curation_packet("Q4", operation_mode="single")
+
+    assert packet["operation_mode"] == "single"
+    assert len(packet["data"]["entities"]) == 1
+    graph_edges = packet["metadata"]["graph"]["edges"]
+    assert all(edge.get("relationship_type") != "P161" for edge in graph_edges)
+
+
+def test_create_curation_packet_bulk_mode_expands_profile_graph():
+    packet = create_curation_packet("Q4", operation_mode="bulk")
+
+    assert packet["operation_mode"] == "bulk"
+    assert len(packet["data"]["entities"]) == 2
+    assert len(packet["metadata"]["graph"]["edges"]) == 2
 
 
 def test_build_packet_materializes_value_list_path_on_statement_slots():
@@ -326,3 +345,38 @@ def test_build_packet_includes_nested_children_for_q58_modifier_qualifier():
     unit_value_slot = units_slot["qualifiers"]["unit_value"][0]
     assert unit_value_slot["id"] == "https://datadistillery.wikibase.cloud/entity/Q56"
     assert unit_value_slot["value-list"] == "cache/queries/Q56.json"
+
+
+def test_charge_wikidata_supports_data_entities_packet_schema():
+    packet = create_curation_packet("Q4", operation_mode="single")
+
+    class _FakeTemplate:
+        def to_dict(self):
+            return {
+                "labels": {"en": {"language": "en", "value": "Cherokee Nation"}},
+                "descriptions": {
+                    "en": {
+                        "language": "en",
+                        "value": "federally recognized Native American tribe",
+                    }
+                },
+                "aliases": {"en": [{"language": "en", "value": "Cherokee"}]},
+                "claims": {},
+            }
+
+    class _FakeMashClient:
+        def load_item(self, qid: str):
+            _ = qid
+            return _FakeTemplate()
+
+    qid_map = {entity["id"]: "Q195562" for entity in packet["data"]["entities"]}
+    charged, notices = charge_packet_from_wikidata_items(
+        packet,
+        qid_map,
+        mash_client=_FakeMashClient(),
+    )
+
+    entity_data = charged["data"]["entities"][0]["data"]
+    assert "labels" in entity_data
+    assert entity_data["labels"]["en"]["value"] == "Cherokee Nation"
+    assert any(n.code == "statement_missing" for n in notices)


### PR DESCRIPTION
## Summary

Firms up packet schema consistency, ownership, and charging logic across still_charger, docs, CLI, and tests.

### What changed

**Packet schema consistency**
- All docs and runtime code now use canonical packet shape with data.entities
- Removed all references to old top-level entities, cross_references, value_list_routes, profile_entity fields

**Ownership**
- create_curation_packet moved from spirit_safe to still_charger as canonical owner
- Removed implementation from spirit_safe.py; __init__.py re-exports from still_charger

**Charging**
- charge_packet_from_wikidata_items updated to read data.entities (with legacy fallback)
- _handle_packet_charge CLI updated to build qid_map from data.entities

**Cleanup**
- Removed old-path/deprecated/legacy wording from orchestration.py, wikibase/__init__.py

**Documentation**
- still_charger.md, spirit_safe.md, cli/profiles.md, entity-json-schema.md all updated to current packet schema
- Architecture docs updated for current module contracts

**Tests**
- Added regression test test_charge_wikidata_supports_data_entities_packet_schema

### Validation
- bash scripts/pre-merge-check.sh: full pass (ruff, black, 408 tests, mkdocs build, package build)

### Related
- Phase B tracking: skybristol/gkc#164
