### PR TITLE
Fermenter atomic validator suite and evaluator scaffolding

### DIFF
--- a/docs/architecture/DataDistillery-Wikibase.md
+++ b/docs/architecture/DataDistillery-Wikibase.md
@@ -29,6 +29,13 @@ The Data Distillery Wikibase architecture is organized around three primary item
 
 These components are designed to work together as a layered model where profiles compose reusable statements and statements can bind to curated value lists.
 
+Profiles and statements are equal-priority architectural components:
+
+- Profiles provide context, composition, and modulation.
+- Statements provide reusable semantic units that can span many profiles.
+
+Validation and packet design should treat both as first-class runtime entities.
+
 ### Component: GKC Entity Profile
 
 Purpose:
@@ -165,6 +172,20 @@ Architectural role:
 - Carries statement-level directives such as value, qualifier, and reference expectations.
 - Supports scoping qualifiers for profile-specific or parent-statement-specific behavior.
 
+#### Statement Minimum Shape
+
+For curation and validation architecture, a statement is treated as a compound data object with a minimum shape of:
+
+- value
+- reference
+- provenance
+
+Reference is itself statement-like and follows statement semantics.
+
+Provenance must capture presentation circumstances at minimum, including how, when, and by whom the statement was stated.
+
+Additional provenance depth may be included by profile context, but packet and fermenter workflows should assume this minimum shape as the baseline contract.
+
 ### Statement-Level Directive Semantics
 
 The following properties are used as directives on GKC Entity Statement items:
@@ -263,6 +284,17 @@ Core principles:
 - Statement-level defaults should remain reusable and broadly applicable.
 - Profile-level directives should capture entity-context specialization.
 - Resolution behavior must be deterministic and auditable.
+
+### Curation Packet as Composition Vehicle
+
+The Curation Packet is where profile rules, statement rules, source data capabilities, and evaluation artifacts are assembled into one runtime structure.
+
+This model must support both broad and thin packet shapes:
+
+- profile-broad packets that include full profile-composed statement sets
+- statement-thin packets that slice a single statement across all applicable entities or all occurrences in scope
+
+Both packet modes should use the same statement and profile contracts so validation, coercion, and notice semantics remain consistent.
 
 ### Conformance Semantics
 
@@ -372,6 +404,7 @@ The following items reflect active architectural exploration and are not yet fin
 - Profile-local statement-instance directives may become the primary effective configuration surface, with statement-level rules serving as reusable defaults.
 - A dedicated suppression/removal semantic may be introduced for qualifier/reference collisions instead of relying on absence semantics.
 - Additional explicit conflict-reporting structures may be emitted in profile generation reports to improve curation diagnostics at scale.
+- URL interpretation and domain-rule semantics are expected to be modeled in Data Distillery so wizard and fermenter URL handling can use a shared ontology-backed rule registry.
 
 ## Environment Variables
 

--- a/docs/architecture/validation-architecture.md
+++ b/docs/architecture/validation-architecture.md
@@ -2,15 +2,42 @@
 
 ## Implementation Status
 
-This page documents the currently implemented validation model and committed architectural direction.
+This page documents the currently implemented validation model and the committed architectural direction for upcoming validation and coercion work.
+
+The immediate direction is to make the fermenter module the canonical runtime evaluation layer for profile-aware validation, data coercion, and conformance classification.
+
+## Architectural Core
+
+Validation is built around two equally important semantic components:
+
+- GKC Entity Profile
+- GKC Entity Statement
+
+Profiles organize statement instances and apply profile-specific context.
+
+Statements are reusable compound data objects that can participate across many profiles and can stand on their own as semantic units.
+
+For validation architecture, the minimum statement shape is:
+
+- value
+- reference
+- provenance
+
+At minimum, provenance must capture presentation circumstances: how, when, and by whom a statement was stated.
 
 ## Validation Layers
 
 Validation in GKC is layered around profile-defined constraints:
 
-- **Profile definition validation**: YAML is parsed into typed profile models.
-- **Entity data validation**: Item/statement content is checked against profile requirements.
-- **Hydration input validation**: Query references and templates are resolved before execution.
+- Profile definition validation: YAML is parsed into typed profile models.
+- Entity data validation: item and statement content is checked against profile requirements.
+- Hydration input validation: query references and templates are resolved before execution.
+- Packet evaluation validation: packet metadata integrity is verified before data evaluation runs.
+
+Runtime entity validation now also distinguishes:
+
+- offline validation (shape, coercion, and rule checks without network retrieval)
+- policy-driven online validation (resolvability and retrieval checks for referenced assets)
 
 ## Profile-Driven Rules
 
@@ -21,6 +48,13 @@ Entity profiles remain the source of truth for validation behavior, including:
 - Qualifier and reference rules.
 - Allowed-items constraints and fallback behavior.
 
+As packet evaluation evolves, profiles define the rule set while fermenter owns runtime interpretation and enforcement.
+
+This separation is intentional:
+
+- Profiles define what is valid.
+- Fermenter determines whether concrete input conforms, can be coerced, must be flagged, or remains outside current profile coverage.
+
 ## Runtime Validation Policy
 
 Current policy behavior includes both permissive and strict paths depending on context:
@@ -28,12 +62,150 @@ Current policy behavior includes both permissive and strict paths depending on c
 - Existing non-conforming data can be tolerated where policy allows.
 - New curation inputs are expected to follow profile-defined constraints.
 
+The next runtime model will make this policy explicit through statement-level and profile-level outcome classification.
+
+## Multi-Tier Validation Policy
+
+For reference-bearing datatypes (for example, Wikibase items and URLs), validation supports a staged policy model:
+
+- `STRUCTURE`: local structural checks only
+- `HEARTBEAT`: quick online "are you alive" checks
+- `ACTIONABLE`: richer online retrieval for intended interactions
+
+The goal is to preserve deterministic offline behavior while enabling optional ACTIONABLE checks when network and policy context allow.
+
+Validation policy must remain configurable per operation context so bulk ingestion, notebook review, and interactive curation can choose appropriate depth.
+
+## Uncertainty Model
+
+Coercion and online validation can produce valid outputs that still carry uncertainty.
+
+Validation results therefore include uncertainty metadata used for curator-facing feedback and policy decisions:
+
+- uncertainty score (`0.0` to `1.0`)
+- uncertainty reasons (machine-readable cause tags)
+
+This supports robust automation while preserving explicit review pathways for ambiguous inputs.
+
+## Conformance Outcomes
+
+The fermenter direction is to classify inbound or edited data using four standard outcomes.
+
+### `CONFORMANT`
+
+At the statement level, `CONFORMANT` means the profile defines the statement, the input can be normalized into the expected data shape, and it passes the relevant profile rules.
+
+This includes rules such as datatype checks, allowed-items constraints, fixed-value requirements, count limits, and other custom validation logic derived from the profile.
+
+At the profile level, `CONFORMANT` means the evaluated statement content satisfies the profile contract for that part of the entity.
+
+### `NON_CONFORMANT_MAPPABLE`
+
+At the statement level, `NON_CONFORMANT_MAPPABLE` means the profile clearly recognizes the statement, but the current value does not satisfy one or more profile rules.
+
+This is the retained-but-flagged case. The value still belongs to a known statement slot, so it should not be discarded. Instead, it should be preserved with actionable feedback and, where possible, normalized or coerced for curator review.
+
+Typical causes include datatype mismatch, value-list miss, fixed-value conflict, or cardinality overrun.
+
+At the profile level, `NON_CONFORMANT_MAPPABLE` means the profile covers the statement semantically, but the concrete data does not yet conform.
+
+### `TO_BE_DEFINED`
+
+At the statement level, `TO_BE_DEFINED` means inbound data contains a statement that the active profile does not currently define.
+
+This does not mean the statement is wrong. It means the profile does not yet provide a rule set or packet slot for handling it. These statements should be preserved separately so they can inform profile expansion, curation review, or future modeling decisions.
+
+At the profile level, `TO_BE_DEFINED` indicates a profile-coverage gap rather than a validation failure. The profile has not yet defined how to interpret that part of the source data.
+
+### `MISSING`
+
+At the statement level, `MISSING` means the profile expects a statement, but no usable value is present in the evaluated data.
+
+This is an absence case, not an invalid-value case. It is distinct from `NON_CONFORMANT_MAPPABLE`, where a candidate value exists but fails validation.
+
+At the profile level, `MISSING` indicates that the profile contract is incomplete for the entity being evaluated because one or more expected statements are absent.
+
+## Curation Packet Role
+
+The Curation Packet is the integration vehicle where profile rules, statement rules, source-data capabilities, and evaluation outputs are materialized together.
+
+A packet can be broad (full entity profile composition) or intentionally thin.
+
+Thin packet operation is an explicit architectural target:
+
+- a packet may represent a single statement sliced across all relevant entities
+- the same conformance model must apply regardless of packet breadth
+- packet shape must support both profile-centric and statement-centric workflows
+
+## Fermenter Responsibilities
+
+The fermenter module is the canonical home for runtime validation and coercion behavior.
+
+Its responsibilities are:
+
+- datatype-aware normalization of inbound values
+- profile-aware statement evaluation
+- reusable conformance notice generation
+- packet integrity checks before data validation
+- file-based and inline-object validation entry points
+
+Its responsibilities do not include:
+
+- assembling curation packet scaffolds
+- traversing profile graphs for packet construction
+- owning UI-specific rendering or workflow logic
+
+That boundary matters because it keeps the still charger responsible for packet assembly and source-item retrieval while making the fermenter responsible for the actual validation and classification work.
+
+## Planned Evaluation Scaffolding
+
+The next major step is to formalize a reusable evaluator structure inside the fermenter.
+
+The intended progression is:
+
+1. Add shared conformance outcome types and result envelopes for statements and entities.
+2. Add atomic claim normalization and statement evaluation functions.
+3. Add entity-level aggregation that groups evaluated statements into the four conformance outcomes.
+4. Add packet validation entry points for both inline objects and file-based workflows.
+5. Integrate still_charger with fermenter evaluators so charged packets are populated from evaluated results rather than direct raw-claim copying.
+
+This scaffolding is meant to support both interactive curation and bulk evaluation without duplicating logic across CLI, notebook, and wizard interfaces.
+
+Evaluator outputs should remain statement-instance anchored so profile context and statement context are both preserved for notices, coercion traces, and downstream policy.
+
+## Packet Validation Direction
+
+Packet validation is moving toward a strict metadata/data separation.
+
+The metadata section will carry:
+
+- profile definitions and packet graph metadata
+- mint provenance
+- integrity digest information
+- packet-level conformance summaries
+
+The data section will carry:
+
+- entity data prepared from the profile scaffold
+- conformant values placed directly in their profile-defined slots
+- retained non-conformant values and notices where policy allows
+- statements that remain `TO_BE_DEFINED`
+- empty but expected fields represented as `MISSING`
+
+Validation must first verify that packet metadata has not been altered in ways that break its binding to the profile ruleset. If the packet integrity digest fails, data validation must stop immediately.
+
 ## Serialization Alignment
 
 Validation and profile models are designed to support downstream serialization workflows without inventing ad hoc Wikidata JSON structures.
+
+The fermenter will therefore work with profile-defined packet shapes and normalized GKC runtime structures, while preserving enough provenance to support later bottling and shipping decisions.
 
 ## Theoretical Design Notes
 
 - Expanded cross-statement semantic validation is still evolving.
 - Additional wizard-step-specific validation orchestration remains future work.
 - A centralized, reusable constraint message library for all interfaces is not yet fully formalized.
+- Linked-profile charging and evaluation should be added only after single-profile evaluator contracts are stable.
+- `TO_BE_DEFINED` is an intentional profile-coverage classification, not a data-quality judgment.
+- `MISSING` should remain distinct from invalid-value cases so downstream tools can separate absence from non-conformance.
+- Statement-level provenance enforcement may evolve from advisory to policy-driven required checks in specific operation modes.

--- a/docs/gkc/api/fermenter.md
+++ b/docs/gkc/api/fermenter.md
@@ -62,6 +62,36 @@ Supported datatypes: `wikibase-item`, `string`, `monolingualtext`, `url`, `time`
 
 Returns a `ValidationResult(valid=False, ...)` with an error message for unrecognized datatypes.
 
+### Validation Policy (Structure + Online Tiers)
+
+`validate_wikibase_item()`, `validate_url()`, and `validate_commons_media()` support staged validation through `ValidationPolicy`.
+
+```python
+from gkc.fermenter import ValidationPolicy, ValidationPolicyConfig
+
+policy = ValidationPolicy.HEARTBEAT
+config = ValidationPolicyConfig(
+    wikibase_api_url="https://www.wikidata.org/w/api.php",
+    commons_api_url="https://commons.wikimedia.org/w/api.php",
+    timeout_seconds=10,
+)
+```
+
+Tiers:
+
+- `STRUCTURE`: shape and coercion checks only (default, offline)
+- `HEARTBEAT`: online resource responds to a basic alive check
+- `ACTIONABLE`: online resource can be retrieved for intended interaction context
+
+`ValidationPolicyConfig` accepts `commons_api_url` to redirect Commons checks to an alternate MediaWiki API (useful for testing or alternative Commons deployments).
+
+`ValidationResult` now includes uncertainty metadata:
+
+- `uncertainty`: float in `[0.0, 1.0]`
+- `uncertainty_reasons`: list of machine-readable uncertainty causes
+
+This supports curator-facing decision paths where coercion and online checks are successful but confidence is not maximal.
+
 ---
 
 ### `validate_wikibase_item(value)`
@@ -78,7 +108,26 @@ result = validate_wikibase_item("Q195562")
 # From existing Wikibase dict
 result = validate_wikibase_item({"entity-type": "item", "id": "Q195562"})
 # result.valid → True
+
+# From full entity URI (coerced to QID)
+result = validate_wikibase_item("https://www.wikidata.org/entity/Q195562")
+# result.valid → True, result.value["id"] → "Q195562"
+
+# Online validation against custom Wikibase instance
+config = ValidationPolicyConfig(
+    wikibase_api_url="https://datadistillery.wikibase.cloud/w/api.php",
+)
+result = validate_wikibase_item(
+    "Q195562",
+    validation_policy=ValidationPolicy.HEARTBEAT,
+    policy_config=config,
+)
 ```
+
+Notes:
+
+- Coercion accepts QIDs, full entity URIs, and dict references with `id` or `item` fields.
+- Normalized output includes `wikibase-api-url` so downstream logic can preserve instance context.
 
 ---
 
@@ -94,6 +143,38 @@ result = validate_string("Cherokee Nation")
 
 result = validate_string(12345)
 # result.valid → True, result.value → "12345", result.warnings → ["Coerced int to string"]
+```
+
+---
+
+### `validate_with_pattern(value, pattern, *, flags=0)`
+
+Validates a string-like value against a regex pattern sourced from profile or statement constraints.
+
+This validator first applies `validate_string()` and then checks the normalized value with
+`re.search`, so profile-authored patterns can control whether matching is anchored or partial.
+
+```python
+import re
+from gkc.fermenter import validate_with_pattern
+
+result = validate_with_pattern("AB-1234", r"^[A-Z]{2}-\d{4}$")
+# result.valid -> True
+
+result = validate_with_pattern(2024, r"^2024$")
+# result.valid -> True
+# result.value -> "2024"
+
+result = validate_with_pattern(
+    "cherokee nation",
+    r"CHEROKEE",
+    flags=re.IGNORECASE,
+)
+# result.valid -> True
+
+result = validate_with_pattern("invalid", r"^[A-Z]{2}-\d{4}$")
+# result.valid -> False
+# result.errors -> ["String does not match required pattern: ^[A-Z]{2}-\\d{4}$"]
 ```
 
 ---
@@ -122,23 +203,75 @@ result = validate_url("https://www.cherokee.org")
 # result.valid → True
 
 result = validate_url("www.cherokee.org")
-# result.valid → False
+# result.valid → True (coerced to https://www.cherokee.org)
+
+# HEARTBEAT online check
+result = validate_url(
+    "https://www.cherokee.org",
+    validation_policy=ValidationPolicy.HEARTBEAT,
+)
+# Performs HEAD request through mash.fetch_url_resource
+
+# ACTIONABLE online check with content retrieval
+config = ValidationPolicyConfig(
+    request_accept="text/html,application/xhtml+xml",
+)
+result = validate_url(
+    "https://www.cherokee.org",
+    validation_policy=ValidationPolicy.ACTIONABLE,
+    policy_config=config,
+)
+# Performs GET request and records content-type warning metadata
 ```
+
+Coercion accepts a wider input set while preserving uncertainty signals:
+
+- `www.example.org` → `https://www.example.org`
+- `example.org/resource` → `https://example.org/resource`
 
 ---
 
 ### `validate_time(value)`
 
-Validates a Wikibase time dict. Requires `time`, `timezone`, `before`, `after`, and `calendarmodel` fields.
+Validates and coerces user-style time inputs into a full Wikibase time payload.
+
+Accepted input shapes include:
+
+- Full Wikibase dict (`time`, `timezone`, `before`, `after`, `calendarmodel`)
+- Minimal dict with only `time`
+- Component dict (`year`, optional `month`/`day`/`hour`/`minute`/`second`)
+- Year integer (`2024`)
+- Date/time strings (`YYYY`, `YYYY-MM`, `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM[:SS]`)
 
 ```python
 from gkc.fermenter import validate_time
 
+result = validate_time("2024")
+# result.value -> {
+#   "time": "+2024-01-01T00:00:00Z",
+#   "timezone": 0,
+#   "before": 0,
+#   "after": 0,
+#   "precision": 9,
+#   "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+# }
+
+result = validate_time("2024-05")
+# precision derived from granularity -> 10 (month)
+
+result = validate_time({"year": 2024, "month": 5, "day": 6})
+# precision derived from provided components -> 11 (day)
+
+result = validate_time({"time": "+2020-01-15T00:00:00Z"})
+# missing timezone/before/after/calendarmodel auto-filled
+
+# Full explicit dict still supported
 result = validate_time({
     "time": "+2020-01-15T00:00:00Z",
     "timezone": 0,
     "before": 0,
     "after": 0,
+    "precision": 11,
     "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
 })
 # result.valid → True
@@ -164,12 +297,35 @@ result = validate_quantity({
 
 ### `validate_globe_coordinate(value)`
 
-Validates a globe-coordinate dict. Requires `latitude`, `longitude`, `precision`, and `globe` fields.
-Latitude must be in `[-90, 90]` and longitude in `[-180, 180]`.
+Validates and coerces broad coordinate input forms into Wikibase globe-coordinate payloads.
+
+Accepted input shapes include:
+
+- Full coordinate dict (`latitude`, `longitude`, optional `altitude`, optional `precision`, optional `globe`)
+- Shorthand dict keys (`lat`/`lon`/`lng`)
+- String pair (`"42.1234,-121.5000"`)
+- Sequence pair (`[42.1234, -121.5]`)
+- DMS-style coordinate strings (`"42 30 0 N"`, `"121 30 0 W"`)
+
+If `precision` is omitted, it is derived from input granularity (decimal places or DMS resolution).
+Latitude must be in `[-90, 90]` and longitude in `[-180, 180]` after coercion.
 
 ```python
 from gkc.fermenter import validate_globe_coordinate
 
+result = validate_globe_coordinate("42.1234,-121.5000")
+# precision derived from decimal granularity
+
+result = validate_globe_coordinate({"lat": "42.5", "lng": "-121.25"})
+# shorthand keys normalized to latitude/longitude
+
+result = validate_globe_coordinate({
+    "latitude": "42 30 0 N",
+    "longitude": "121 30 0 W",
+})
+# DMS input converted to decimal degrees
+
+# Full explicit dict remains supported
 result = validate_globe_coordinate({
     "latitude": 35.5,
     "longitude": -95.0,
@@ -184,14 +340,54 @@ result = validate_globe_coordinate({
 
 ### `validate_commons_media(value)`
 
-Validates a Wikimedia Commons filename string. Must be a non-empty string.
+Validates a Wikimedia Commons filename against the Commons MediaWiki API.
+Accepts filenames with or without the `File:` prefix—the canonical form is always returned.
 
 ```python
-from gkc.fermenter import validate_commons_media
+from gkc.fermenter import validate_commons_media, ValidationPolicy, ValidationPolicyConfig
 
+# STRUCTURE (default, offline) — normalizes filename only
 result = validate_commons_media("Cherokee Nation seal.svg")
 # result.valid → True
+# result.value → "File:Cherokee Nation seal.svg"
+
+# HEARTBEAT — confirms the file exists on Commons
+result = validate_commons_media(
+    "Cherokee Nation seal.svg",
+    validation_policy=ValidationPolicy.HEARTBEAT,
+)
+# Calls Commons API action=query&prop=imageinfo for the file
+# result.valid → False + error if the file is not found
+
+# ACTIONABLE — retrieves full file metadata
+result = validate_commons_media(
+    "File:Cherokee Nation seal.svg",
+    validation_policy=ValidationPolicy.ACTIONABLE,
+)
+# result.warnings may include:
+#   "Commons resource URL: https://upload.wikimedia.org/..."
+#   "Commons MIME type: image/svg+xml"
+#   "Commons file size: 12345 bytes"
+
+# Custom Commons API endpoint (e.g., for testing)
+config = ValidationPolicyConfig(
+    commons_api_url="https://test.commons.example.org/w/api.php",
+)
+result = validate_commons_media(
+    "File:Example.jpg",
+    validation_policy=ValidationPolicy.HEARTBEAT,
+    policy_config=config,
+)
 ```
+
+Coercion behavior:
+
+- Filenames without `File:` prefix receive it automatically.
+- Lowercase `file:` prefix is normalized to `File:` with a warning.
+- Non-string values are coerced to string with a warning and uncertainty signal.
+
+Online checks use `gkc.mash.fetch_commons_file_info()` via a `WikibaseApiClient` pointed at
+`commons_api_url`, keeping the retrieval layer consistent with other Wikibase API consumers in mash.
 
 ---
 
@@ -266,3 +462,233 @@ result, notice = enforce_fixed_value(
 ```
 
 Returns `(ValidationResult, ConformanceNotice | None)`. The notice is `None` when the user value matches the required fixed value exactly.
+
+## Conformance Outcome Types
+
+Fermenter now provides explicit conformance outcome types for statement- and entity-level evaluation.
+
+### `ConformanceOutcome`
+
+```python
+from gkc.fermenter import ConformanceOutcome
+
+print(ConformanceOutcome.CONFORMANT.value)              # "conformant"
+print(ConformanceOutcome.NON_CONFORMANT_MAPPABLE.value) # "non_conformant_mappable"
+print(ConformanceOutcome.TO_BE_DEFINED.value)           # "to_be_defined"
+print(ConformanceOutcome.MISSING.value)                 # "missing"
+```
+
+### `StatementEvaluation`
+
+Atomic statement evaluation envelope:
+
+| Field | Type | Description |
+|---|---|---|
+| `outcome` | `ConformanceOutcome` | Classification of statement evaluation result |
+| `statement_ref` | `str \| None` | Statement id/entity/name_identifier reference |
+| `property_ref` | `str \| None` | Mapped property identifier (for example, PID) |
+| `normalized_value` | `Any` | Normalized/coerced value payload |
+| `raw_claims` | `list[dict]` | Original inbound claim objects used for evaluation |
+| `notices` | `list[ConformanceNotice]` | Statement-scoped notices emitted during evaluation |
+
+### `EntityEvaluation`
+
+Aggregate entity envelope with outcome buckets:
+
+| Field | Type | Description |
+|---|---|---|
+| `entity_ref` | `str` | Entity being evaluated |
+| `profile_ref` | `str` | Active profile reference |
+| `conformant` | `list[StatementEvaluation]` | Statements that conform to profile rules |
+| `non_conformant_mappable` | `list[StatementEvaluation]` | Recognized statements with retained non-conforming values |
+| `to_be_defined` | `list[StatementEvaluation]` | Statements present in source but not defined by profile |
+| `missing` | `list[StatementEvaluation]` | Statements expected by profile but absent in input |
+
+Convenience properties:
+
+- `all_notices` returns a flattened list of notices across all buckets.
+- `is_conformant` is `True` only when both `non_conformant_mappable` and `missing` are empty.
+
+## Statement and Entity Evaluation
+
+### `normalize_claim_value(raw_claim, data_type)`
+
+Normalizes a raw claim payload and dispatches validation through datatype validators.
+
+- Handles `snaktype=novalue` and `snaktype=somevalue` safely.
+- Returns `ValidationResult` with normalized value, warnings, and errors.
+
+```python
+from gkc.fermenter import normalize_claim_value
+
+raw_claim = {
+    "mainsnak": {
+        "snaktype": "value",
+        "datavalue": {
+            "value": {
+                "entity-type": "item",
+                "numeric-id": 5,
+                "id": "Q5",
+            }
+        },
+    }
+}
+
+result = normalize_claim_value(raw_claim, "wikibase-item")
+print(result.valid)          # True
+print(result.value["id"])    # Q5
+```
+
+### `evaluate_statement_claim(profile_statement, raw_claim_list, *, entity_ref="", value_list_root=None)`
+
+Evaluates one profile statement against claim candidates and profile constraints.
+
+Checks include:
+
+- required/missing evaluation
+- datatype normalization
+- fixed-value enforcement
+- value-list cache validation
+- max-count handling
+
+```python
+from gkc.fermenter import evaluate_statement_claim
+
+statement = {
+    "id": "https://datadistillery.wikibase.cloud/entity/Q16",
+    "max_count": 1,
+    "value": {"type": "wikibase-item"},
+    "io_map": [{"to": "http://www.wikidata.org/entity/P31"}],
+}
+
+claims = [{
+    "mainsnak": {
+        "snaktype": "value",
+        "datavalue": {"value": {"entity-type": "item", "numeric-id": 5, "id": "Q5"}},
+    }
+}]
+
+evaluation = evaluate_statement_claim(statement, claims, entity_ref="Q195562")
+print(evaluation.outcome.value)  # "conformant"
+```
+
+### `evaluate_entity(profile_statements, wikidata_item, *, io_map_index, entity_ref="", value_list_root=None)`
+
+Evaluates one source entity against all active profile statements and classifies output into the four conformance buckets.
+
+```python
+from gkc.fermenter import evaluate_entity
+
+entity_eval = evaluate_entity(
+    profile_statements=[...],
+    wikidata_item={"id": "Q195562", "claims": {...}},
+    io_map_index={"P31": {...}, "P17": {...}},
+    entity_ref="Q195562",
+)
+
+print(len(entity_eval.conformant))
+print(len(entity_eval.non_conformant_mappable))
+print(len(entity_eval.to_be_defined))
+print(len(entity_eval.missing))
+```
+
+## Packet Integrity and Validation Entry Points
+
+### `check_packet_integrity(packet)`
+
+Verifies metadata digest integrity before any data validation.
+
+- Returns `None` when digest is valid.
+- Returns an `error` `ConformanceNotice` on missing metadata integrity fields or digest mismatch.
+
+```python
+import hashlib
+import json
+from gkc.fermenter import check_packet_integrity
+
+metadata = {
+    "primary_profile": {"id": "https://datadistillery.wikibase.cloud/entity/Q4"},
+    "profiles": [],
+    "graph": {"nodes": [], "edges": []},
+    "mint": {"minted_at": "2026-03-26T00:00:00Z", "generator": "example"},
+}
+digest = hashlib.sha256(
+    json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode("utf-8")
+).hexdigest()
+
+packet = {
+    "packet_id": "pkt-example",
+    "metadata": {
+        **metadata,
+        "integrity": {
+            "metadata_canonicalization": "json-sort-keys-v1",
+            "metadata_digest_algorithm": "sha256",
+            "metadata_digest": digest,
+        },
+    },
+    "data": {"entities": []},
+}
+
+notice = check_packet_integrity(packet)
+print(notice is None)  # True
+```
+
+### `validate_packet_inline(packet, *, value_list_root=None)`
+
+Validates an in-memory packet object.
+
+- Performs integrity check first.
+- On integrity mismatch, hard-fails immediately and returns only the integrity notice.
+- On success, returns `(True, [info notice])` with `packet_integrity_pass`.
+
+```python
+from gkc.fermenter import validate_packet_inline
+
+packet = {
+    "packet_id": "pkt-example",
+    "metadata": {
+        "primary_profile": {"id": "https://datadistillery.wikibase.cloud/entity/Q4"},
+        "profiles": [],
+        "graph": {"nodes": [], "edges": []},
+        "mint": {"minted_at": "2026-03-26T00:00:00Z", "generator": "example"},
+        "integrity": {
+            "metadata_canonicalization": "json-sort-keys-v1",
+            "metadata_digest_algorithm": "sha256",
+            "metadata_digest": "replace-with-computed-digest",
+        },
+    },
+    "data": {"entities": []},
+}
+
+ok, notices = validate_packet_inline(packet)
+print(ok)
+print([n.code for n in notices])
+```
+
+### `validate_packet_from_file(path, *, value_list_root=None)`
+
+Loads packet JSON from file, then delegates to `validate_packet_inline`.
+
+This provides file/inline parity for notebook and CLI testing workflows.
+
+```python
+from pathlib import Path
+from gkc.fermenter import validate_packet_from_file, validate_packet_inline
+
+packet = {...}
+ok_inline, notices_inline = validate_packet_inline(packet)
+ok_file, notices_file = validate_packet_from_file(Path("/tmp/packet.json"))
+```
+
+## Local Test Coverage
+
+New evaluator and packet-validation behavior is covered in:
+
+- `tests/test_fermenter_evaluator.py`
+
+This suite exercises:
+
+- conformant, non-conformant, missing, and to-be-defined classification paths
+- value-list mismatch handling in statement evaluation
+- packet integrity pass/fail behavior
+- file-vs-inline validation parity

--- a/gkc/__init__.py
+++ b/gkc/__init__.py
@@ -59,6 +59,7 @@ from gkc.fermenter import (
     validate_url,
     validate_value_from_list,
     validate_wikibase_item,
+    validate_with_pattern,
 )
 
 # Mash (inbound data retrieval)
@@ -240,6 +241,7 @@ __all__ = [
     "validate_by_datatype",
     "validate_wikibase_item",
     "validate_string",
+    "validate_with_pattern",
     "validate_monolingualtext",
     "validate_url",
     "validate_time",

--- a/gkc/fermenter.py
+++ b/gkc/fermenter.py
@@ -9,10 +9,20 @@ All validation surfaces return a shared ConformanceNotice envelope for consisten
 reporting across wizard, CLI, and bulk pipelines.
 """
 
+import hashlib
 import json
+import re
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
+
+from gkc.mash import (
+    WikibaseApiClient,
+    fetch_commons_file_info,
+    fetch_url_resource,
+)
 
 
 @dataclass
@@ -27,6 +37,8 @@ class ValidationResult:
     value: Any
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    uncertainty: float = 0.0
+    uncertainty_reasons: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -58,12 +70,1203 @@ ChargeIssue = ConformanceNotice
 BarrelIssue = ConformanceNotice
 
 
+class ValidationPolicy(str, Enum):
+    """Validation depth policy for structure and online checks."""
+
+    STRUCTURE = "structure"
+    HEARTBEAT = "heartbeat"
+    ACTIONABLE = "actionable"
+
+
+@dataclass
+class ValidationPolicyConfig:
+    """Configurable transport and endpoint options for validation policies."""
+
+    policy: ValidationPolicy = ValidationPolicy.STRUCTURE
+    wikibase_api_url: str = "https://www.wikidata.org/w/api.php"
+    commons_api_url: str = "https://commons.wikimedia.org/w/api.php"
+    timeout_seconds: int = 10
+    allow_redirects: bool = True
+    request_accept: Optional[str] = None
+
+
+def _resolve_validation_policy_config(
+    validation_policy: ValidationPolicy,
+    policy_config: Optional[ValidationPolicyConfig],
+) -> ValidationPolicyConfig:
+    if policy_config is None:
+        return ValidationPolicyConfig(policy=validation_policy)
+    return ValidationPolicyConfig(
+        policy=validation_policy,
+        wikibase_api_url=policy_config.wikibase_api_url,
+        commons_api_url=policy_config.commons_api_url,
+        timeout_seconds=policy_config.timeout_seconds,
+        allow_redirects=policy_config.allow_redirects,
+        request_accept=policy_config.request_accept,
+    )
+
+
+_DOMAIN_LIKE_PATTERN = re.compile(r"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(:\d+)?(/.*)?$")
+_WIKIBASE_DEFAULT_CALENDAR_MODEL = "http://www.wikidata.org/entity/Q1985727"
+_WIKIBASE_DEFAULT_GLOBE = "http://www.wikidata.org/entity/Q2"
+_TIME_COMPONENT_PATTERN = re.compile(
+    r"^(?P<sign>[+-])?(?P<year>\d{1,16})(?:[-/](?P<month>\d{1,2})(?:[-/](?P<day>\d{1,2})(?:[T ](?P<hour>\d{1,2})(?::(?P<minute>\d{1,2})(?::(?P<second>\d{1,2}))?)?(?:Z)?)?)?)?$"
+)
+_COORD_DECIMAL_HEMISPHERE_PATTERN = re.compile(
+    r"^\s*([+-]?\d+(?:\.\d+)?)\s*([NSEW])?\s*$",
+    flags=re.IGNORECASE,
+)
+_COORD_DMS_PATTERN = re.compile(
+    r"^\s*(?P<deg>[+-]?\d+(?:\.\d+)?)\D+(?P<min>\d+(?:\.\d+)?)?(?:\D+(?P<sec>\d+(?:\.\d+)?))?\D*(?P<hem>[NSEW])?\s*$",
+    flags=re.IGNORECASE,
+)
+
+
+def _coerce_wikibase_item_reference(
+    value: Any,
+) -> tuple[Optional[str], list[str], list[str]]:
+    """Coerce common item reference formats to a canonical QID."""
+    warnings: list[str] = []
+    uncertainty_reasons: list[str] = []
+
+    if isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None, warnings, ["Empty item reference string"]
+
+        if candidate.startswith(("http://", "https://")):
+            qid_candidate = candidate.rstrip("/").split("/")[-1]
+            if qid_candidate.upper().startswith("Q") and qid_candidate[1:].isdigit():
+                qid = qid_candidate.upper()
+                warnings.append("Coerced item URI to QID")
+                uncertainty_reasons.append("item_uri_input")
+                return qid, warnings, uncertainty_reasons
+
+        normalized = candidate.upper()
+        if normalized.startswith("Q") and normalized[1:].isdigit():
+            if normalized != candidate:
+                warnings.append("Normalized lowercase qid to uppercase")
+                uncertainty_reasons.append("qid_case_normalized")
+            return normalized, warnings, uncertainty_reasons
+
+        return (
+            None,
+            warnings,
+            [f"Invalid QID format: {value}. Expected Q-prefixed numeric ID."],
+        )
+
+    if isinstance(value, dict):
+        for key in ("id", "item"):
+            ref = value.get(key)
+            if isinstance(ref, str):
+                qid, child_warnings, child_uncertainty = (
+                    _coerce_wikibase_item_reference(ref)
+                )
+                if qid:
+                    warnings.extend(child_warnings)
+                    uncertainty_reasons.extend(child_uncertainty)
+                    if key != "id" or child_warnings or child_uncertainty:
+                        warnings.append(
+                            f"Coerced wikibase-item from dict field '{key}'"
+                        )
+                        uncertainty_reasons.append("dict_item_reference")
+                    return qid, warnings, uncertainty_reasons
+
+    return (
+        None,
+        warnings,
+        [
+            f"wikibase-item must be a string/URI or dict with id/item, got {type(value).__name__}"
+        ],
+    )
+
+
+def _coerce_url_candidate(value: Any) -> tuple[Optional[str], list[str], list[str]]:
+    """Coerce flexible URL-like inputs into explicit HTTP(S) URLs."""
+    warnings: list[str] = []
+    uncertainty_reasons: list[str] = []
+
+    if value is None:
+        return None, warnings, ["url value cannot be null"]
+
+    if not isinstance(value, str):
+        original_type = type(value).__name__
+        try:
+            value = str(value)
+            warnings.append(f"Coerced {original_type} to string")
+            uncertainty_reasons.append("non_string_url_input")
+        except Exception as exc:
+            return None, warnings, [f"url must be coercible to string: {exc}"]
+
+    candidate = value.strip()
+    if not candidate:
+        return None, warnings, ["url value cannot be empty"]
+
+    if candidate.startswith("www."):
+        candidate = f"https://{candidate}"
+        warnings.append("Added https:// scheme to URL beginning with www.")
+        uncertainty_reasons.append("scheme_added_from_www")
+    elif _DOMAIN_LIKE_PATTERN.match(candidate):
+        candidate = f"https://{candidate}"
+        warnings.append("Added https:// scheme to bare domain URL")
+        uncertainty_reasons.append("scheme_added_from_domain")
+
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None, warnings, ["url must include a valid http(s) scheme and host"]
+
+    return candidate, warnings, uncertainty_reasons
+
+
+def _uncertainty_score(reasons: list[str]) -> float:
+    if not reasons:
+        return 0.0
+    return min(1.0, 0.2 + (0.15 * len(set(reasons))))
+
+
+def _count_decimal_places(value: str) -> int:
+    candidate = value.strip()
+    if not candidate or "." not in candidate:
+        return 0
+    fractional = candidate.split(".", 1)[1]
+    digits = "".join(ch for ch in fractional if ch.isdigit())
+    return len(digits)
+
+
+def _format_wikibase_time(
+    *,
+    year: int,
+    month: int,
+    day: int,
+    hour: int,
+    minute: int,
+    second: int,
+) -> str:
+    sign = "+" if year >= 0 else "-"
+    year_abs = str(abs(year)).rjust(4, "0")
+    return (
+        f"{sign}{year_abs}-{month:02d}-{day:02d}T{hour:02d}:{minute:02d}:{second:02d}Z"
+    )
+
+
+def _coerce_time_value(
+    value: Any,
+) -> tuple[Optional[dict[str, Any]], list[str], list[str]]:
+    """Coerce common user time inputs into full Wikibase time payloads."""
+    warnings: list[str] = []
+    uncertainty_reasons: list[str] = []
+
+    if value is None:
+        return None, warnings, ["time value cannot be null"]
+
+    timezone = 0
+    before = 0
+    after = 0
+    calendarmodel = _WIKIBASE_DEFAULT_CALENDAR_MODEL
+
+    if isinstance(value, dict) and "time" in value:
+        raw_time = value.get("time")
+        if not isinstance(raw_time, str) or not raw_time.strip():
+            return None, warnings, ["time dict field 'time' must be a non-empty string"]
+        candidate = raw_time.strip()
+        timezone = int(value.get("timezone", 0) or 0)
+        before = int(value.get("before", 0) or 0)
+        after = int(value.get("after", 0) or 0)
+        calendarmodel = value.get("calendarmodel") or _WIKIBASE_DEFAULT_CALENDAR_MODEL
+        if any(
+            k not in value for k in ("timezone", "before", "after", "calendarmodel")
+        ):
+            warnings.append("Filled missing Wikibase time fields with defaults")
+            uncertainty_reasons.append("time_defaults_filled")
+    elif isinstance(value, dict) and any(k in value for k in ("year", "month", "day")):
+        year = value.get("year")
+        if year is None:
+            return (
+                None,
+                warnings,
+                ["time dict with component fields must include 'year'"],
+            )
+        month = value.get("month", 1)
+        day = value.get("day", 1)
+        hour = value.get("hour", 0)
+        minute = value.get("minute", 0)
+        second = value.get("second", 0)
+        try:
+            year_i = int(year)
+            month_i = int(month)
+            day_i = int(day)
+            hour_i = int(hour)
+            minute_i = int(minute)
+            second_i = int(second)
+        except (TypeError, ValueError):
+            return None, warnings, ["time component fields must be numeric"]
+
+        if not (1 <= month_i <= 12):
+            return None, warnings, [f"month must be between 1 and 12, got {month_i}"]
+        if not (1 <= day_i <= 31):
+            return None, warnings, [f"day must be between 1 and 31, got {day_i}"]
+        if not (0 <= hour_i <= 23):
+            return None, warnings, [f"hour must be between 0 and 23, got {hour_i}"]
+        if not (0 <= minute_i <= 59):
+            return None, warnings, [f"minute must be between 0 and 59, got {minute_i}"]
+        if not (0 <= second_i <= 59):
+            return None, warnings, [f"second must be between 0 and 59, got {second_i}"]
+
+        if "precision" in value:
+            precision = int(value["precision"])
+        elif "second" in value:
+            precision = 14
+        elif "minute" in value:
+            precision = 13
+        elif "hour" in value:
+            precision = 12
+        elif "day" in value:
+            precision = 11
+        elif "month" in value:
+            precision = 10
+        else:
+            precision = 9
+
+        return (
+            {
+                "time": _format_wikibase_time(
+                    year=year_i,
+                    month=month_i,
+                    day=day_i,
+                    hour=hour_i,
+                    minute=minute_i,
+                    second=second_i,
+                ),
+                "timezone": int(value.get("timezone", 0) or 0),
+                "before": int(value.get("before", 0) or 0),
+                "after": int(value.get("after", 0) or 0),
+                "precision": precision,
+                "calendarmodel": value.get("calendarmodel")
+                or _WIKIBASE_DEFAULT_CALENDAR_MODEL,
+            },
+            ["Coerced time component fields to Wikibase time payload"],
+            ["time_component_input"],
+        )
+    elif isinstance(value, int):
+        candidate = str(value)
+        warnings.append("Coerced numeric year to Wikibase time payload")
+        uncertainty_reasons.append("time_numeric_year_input")
+    elif isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None, warnings, ["time value cannot be empty"]
+    else:
+        return (
+            None,
+            warnings,
+            [f"time must be a dict/string/year, got {type(value).__name__}"],
+        )
+
+    match = _TIME_COMPONENT_PATTERN.match(candidate)
+    if not match:
+        return (
+            None,
+            warnings,
+            [
+                "time must be in YYYY, YYYY-MM, YYYY-MM-DD, or YYYY-MM-DDTHH:MM[:SS] format"
+            ],
+        )
+
+    sign = match.group("sign") or "+"
+    year_i = int(match.group("year"))
+    if sign == "-":
+        year_i = -year_i
+
+    month_s = match.group("month")
+    day_s = match.group("day")
+    hour_s = match.group("hour")
+    minute_s = match.group("minute")
+    second_s = match.group("second")
+
+    month_i = int(month_s) if month_s is not None else 1
+    day_i = int(day_s) if day_s is not None else 1
+    hour_i = int(hour_s) if hour_s is not None else 0
+    minute_i = int(minute_s) if minute_s is not None else 0
+    second_i = int(second_s) if second_s is not None else 0
+
+    if not (1 <= month_i <= 12):
+        return None, warnings, [f"month must be between 1 and 12, got {month_i}"]
+    if not (1 <= day_i <= 31):
+        return None, warnings, [f"day must be between 1 and 31, got {day_i}"]
+    if not (0 <= hour_i <= 23):
+        return None, warnings, [f"hour must be between 0 and 23, got {hour_i}"]
+    if not (0 <= minute_i <= 59):
+        return None, warnings, [f"minute must be between 0 and 59, got {minute_i}"]
+    if not (0 <= second_i <= 59):
+        return None, warnings, [f"second must be between 0 and 59, got {second_i}"]
+
+    if second_s is not None:
+        precision = 14
+    elif minute_s is not None:
+        precision = 13
+    elif hour_s is not None:
+        precision = 12
+    elif day_s is not None:
+        precision = 11
+    elif month_s is not None:
+        precision = 10
+    else:
+        precision = 9
+
+    return (
+        {
+            "time": _format_wikibase_time(
+                year=year_i,
+                month=month_i,
+                day=day_i,
+                hour=hour_i,
+                minute=minute_i,
+                second=second_i,
+            ),
+            "timezone": timezone,
+            "before": before,
+            "after": after,
+            "precision": precision,
+            "calendarmodel": calendarmodel,
+        },
+        warnings,
+        uncertainty_reasons,
+    )
+
+
+def _parse_coordinate_component(
+    raw: Any,
+    *,
+    is_latitude: bool,
+) -> tuple[Optional[float], Optional[float], Optional[str]]:
+    """Parse a coordinate component into decimal degrees and a precision hint."""
+    if isinstance(raw, (int, float)):
+        return float(raw), None, None
+
+    if not isinstance(raw, str):
+        return (
+            None,
+            None,
+            f"coordinate component must be numeric/string, got {type(raw).__name__}",
+        )
+
+    candidate = raw.strip()
+    if not candidate:
+        return None, None, "coordinate component cannot be empty"
+
+    decimal_match = _COORD_DECIMAL_HEMISPHERE_PATTERN.match(candidate)
+    if decimal_match:
+        numeric_text = decimal_match.group(1)
+        hemisphere = decimal_match.group(2).upper() if decimal_match.group(2) else None
+        value = float(numeric_text)
+        if hemisphere in {"S", "W"}:
+            value = -abs(value)
+        elif hemisphere in {"N", "E"}:
+            value = abs(value)
+        decimals = _count_decimal_places(numeric_text)
+        precision_hint = 10 ** (-decimals) if decimals > 0 else 1.0
+        return value, precision_hint, None
+
+    dms_match = _COORD_DMS_PATTERN.match(candidate)
+    if dms_match:
+        numbers = re.findall(r"[+-]?\d+(?:\.\d+)?", candidate)
+        if not numbers:
+            return None, None, "DMS coordinate did not contain numeric parts"
+
+        degrees = float(numbers[0])
+        minutes = float(numbers[1]) if len(numbers) > 1 else 0.0
+        seconds = float(numbers[2]) if len(numbers) > 2 else 0.0
+
+        hemisphere = None
+        for ch in reversed(candidate.upper()):
+            if ch in {"N", "S", "E", "W"}:
+                hemisphere = ch
+                break
+
+        if minutes < 0 or minutes >= 60:
+            return None, None, f"DMS minutes out of range: {minutes}"
+        if seconds < 0 or seconds >= 60:
+            return None, None, f"DMS seconds out of range: {seconds}"
+
+        absolute = abs(degrees) + (minutes / 60.0) + (seconds / 3600.0)
+        sign = -1.0 if degrees < 0 else 1.0
+        if hemisphere in {"S", "W"}:
+            sign = -1.0
+        elif hemisphere in {"N", "E"}:
+            sign = 1.0
+
+        precision_hint = 1.0
+        if len(numbers) > 2:
+            precision_hint = 1.0 / 3600.0
+        elif len(numbers) > 1:
+            precision_hint = 1.0 / 60.0
+
+        return sign * absolute, precision_hint, None
+
+    axis = "latitude" if is_latitude else "longitude"
+    return None, None, f"could not parse {axis} coordinate: {raw}"
+
+
+def _coerce_globe_coordinate_value(
+    value: Any,
+) -> tuple[Optional[dict[str, Any]], list[str], list[str]]:
+    """Coerce broad coordinate input forms into Wikibase globe-coordinate payloads."""
+    warnings: list[str] = []
+    uncertainty_reasons: list[str] = []
+
+    lat_raw: Any = None
+    lon_raw: Any = None
+    altitude: Any = None
+    precision_input: Any = None
+    globe: Any = _WIKIBASE_DEFAULT_GLOBE
+
+    if value is None:
+        return None, warnings, ["globe-coordinate value cannot be null"]
+
+    if isinstance(value, dict):
+        lat_raw = value.get("latitude", value.get("lat", value.get("y")))
+        lon_raw = value.get(
+            "longitude", value.get("lon", value.get("lng", value.get("x")))
+        )
+        altitude = value.get("altitude")
+        precision_input = value.get("precision")
+        globe = value.get("globe", _WIKIBASE_DEFAULT_GLOBE)
+        if (
+            "lat" in value
+            or "lon" in value
+            or "lng" in value
+            or "x" in value
+            or "y" in value
+        ):
+            warnings.append(
+                "Normalized shorthand coordinate keys to latitude/longitude"
+            )
+            uncertainty_reasons.append("coordinate_shorthand_keys")
+    elif isinstance(value, (list, tuple)) and len(value) >= 2:
+        lat_raw = value[0]
+        lon_raw = value[1]
+        altitude = value[2] if len(value) > 2 else None
+        warnings.append("Coerced coordinate sequence to globe-coordinate object")
+        uncertainty_reasons.append("coordinate_sequence_input")
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None, warnings, ["globe-coordinate value cannot be empty"]
+
+        if "," in text:
+            parts = [p.strip() for p in text.split(",") if p.strip()]
+        else:
+            parts = text.split()
+
+        if len(parts) < 2:
+            return (
+                None,
+                warnings,
+                ["globe-coordinate string must include latitude and longitude"],
+            )
+
+        lat_raw = parts[0]
+        lon_raw = parts[1]
+        warnings.append("Coerced coordinate string to globe-coordinate object")
+        uncertainty_reasons.append("coordinate_string_input")
+    else:
+        return (
+            None,
+            warnings,
+            [f"globe-coordinate must be dict/list/string, got {type(value).__name__}"],
+        )
+
+    if lat_raw is None:
+        return None, warnings, ["globe-coordinate dict must contain latitude/lat/y"]
+    if lon_raw is None:
+        return (
+            None,
+            warnings,
+            ["globe-coordinate dict must contain longitude/lon/lng/x"],
+        )
+
+    lat, lat_precision_hint, lat_error = _parse_coordinate_component(
+        lat_raw, is_latitude=True
+    )
+    if lat_error:
+        return None, warnings, [lat_error]
+
+    lon, lon_precision_hint, lon_error = _parse_coordinate_component(
+        lon_raw, is_latitude=False
+    )
+    if lon_error:
+        return None, warnings, [lon_error]
+
+    if not (-90 <= lat <= 90):
+        return None, warnings, [f"latitude must be between -90 and 90, got {lat}"]
+    if not (-180 <= lon <= 180):
+        return None, warnings, [f"longitude must be between -180 and 180, got {lon}"]
+
+    if precision_input is not None:
+        try:
+            precision = float(precision_input)
+        except (TypeError, ValueError):
+            return None, warnings, [f"precision must be numeric, got {precision_input}"]
+        if precision <= 0:
+            return None, warnings, [f"precision must be > 0, got {precision}"]
+    else:
+        hints = [h for h in (lat_precision_hint, lon_precision_hint) if h is not None]
+        precision = min(hints) if hints else 1.0
+        warnings.append(
+            f"Derived coordinate precision from input granularity: {precision}"
+        )
+        uncertainty_reasons.append("coordinate_precision_derived")
+
+    normalized = {
+        "latitude": lat,
+        "longitude": lon,
+        "altitude": altitude,
+        "precision": precision,
+        "globe": globe or _WIKIBASE_DEFAULT_GLOBE,
+    }
+    return normalized, warnings, uncertainty_reasons
+
+
+class ConformanceOutcome(str, Enum):
+    """Statement and entity conformance classification outcomes."""
+
+    CONFORMANT = "conformant"
+    NON_CONFORMANT_MAPPABLE = "non_conformant_mappable"
+    TO_BE_DEFINED = "to_be_defined"
+    MISSING = "missing"
+
+
+@dataclass
+class StatementEvaluation:
+    """Atomic evaluation result for a single statement instance."""
+
+    outcome: ConformanceOutcome
+    statement_ref: Optional[str]
+    property_ref: Optional[str]
+    normalized_value: Any
+    raw_claims: list[dict[str, Any]]
+    notices: list[ConformanceNotice] = field(default_factory=list)
+
+
+@dataclass
+class EntityEvaluation:
+    """Aggregate evaluation result for one entity against profile statements."""
+
+    entity_ref: str
+    profile_ref: str
+    conformant: list[StatementEvaluation] = field(default_factory=list)
+    non_conformant_mappable: list[StatementEvaluation] = field(default_factory=list)
+    to_be_defined: list[StatementEvaluation] = field(default_factory=list)
+    missing: list[StatementEvaluation] = field(default_factory=list)
+
+    @property
+    def all_notices(self) -> list[ConformanceNotice]:
+        notices: list[ConformanceNotice] = []
+        for bucket in (
+            self.conformant,
+            self.non_conformant_mappable,
+            self.to_be_defined,
+            self.missing,
+        ):
+            for evaluation in bucket:
+                notices.extend(evaluation.notices)
+        return notices
+
+    @property
+    def is_conformant(self) -> bool:
+        return not self.non_conformant_mappable and not self.missing
+
+
+def _canonical_json_digest(payload: dict[str, Any]) -> str:
+    """Return deterministic SHA256 digest for JSON payloads."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _statement_ref_from_profile_statement(
+    profile_statement: dict[str, Any],
+) -> Optional[str]:
+    for key in ("id", "entity", "name_identifier"):
+        value = profile_statement.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _statement_property_ref(profile_statement: dict[str, Any]) -> Optional[str]:
+    io_map = profile_statement.get("io_map")
+    if not isinstance(io_map, list):
+        return None
+
+    for mapping in io_map:
+        if not isinstance(mapping, dict):
+            continue
+        target = mapping.get("to")
+        if isinstance(target, str) and target:
+            return target.rsplit("/", 1)[-1]
+    return None
+
+
+def _statement_data_type(profile_statement: dict[str, Any]) -> Optional[str]:
+    value_block = profile_statement.get("value")
+    if not isinstance(value_block, dict):
+        return None
+
+    data_type = value_block.get("type")
+    if not isinstance(data_type, str) or not data_type:
+        return None
+
+    if data_type == "item":
+        return "wikibase-item"
+    return data_type
+
+
+def _statement_max_count(profile_statement: dict[str, Any]) -> Optional[int]:
+    max_count = profile_statement.get("max_count")
+    if isinstance(max_count, int):
+        return max_count
+    if isinstance(max_count, float) and max_count.is_integer():
+        return int(max_count)
+    if isinstance(max_count, str) and max_count.isdigit():
+        return int(max_count)
+    return None
+
+
+def _statement_is_required(profile_statement: dict[str, Any]) -> bool:
+    required = profile_statement.get("required")
+    if isinstance(required, bool):
+        return required
+
+    max_count = _statement_max_count(profile_statement)
+    return isinstance(max_count, int) and max_count > 0
+
+
+def _statement_fixed_value(profile_statement: dict[str, Any]) -> Any:
+    value_block = profile_statement.get("value")
+    if not isinstance(value_block, dict):
+        return None
+
+    fixed_value = value_block.get("fixed_value")
+    if fixed_value is not None:
+        return fixed_value
+
+    value_list = value_block.get("value_list")
+    if isinstance(value_list, list) and len(value_list) == 1:
+        return value_list[0]
+    return None
+
+
+def _resolve_statement_value_list_path(
+    profile_statement: dict[str, Any],
+    *,
+    value_list_root: Optional[Path],
+) -> Optional[Path]:
+    if value_list_root is None:
+        return None
+
+    value_block = profile_statement.get("value")
+    if not isinstance(value_block, dict):
+        return None
+
+    reference = value_block.get("value_list_reference")
+    if not isinstance(reference, str) or not reference:
+        return None
+
+    reference_path = Path(reference)
+    if reference_path.is_absolute():
+        return reference_path
+    return value_list_root / reference_path
+
+
+def normalize_claim_value(
+    raw_claim: dict[str, Any], data_type: str
+) -> ValidationResult:
+    """Normalize and validate a single raw Wikidata claim value."""
+    if not isinstance(raw_claim, dict):
+        return ValidationResult(
+            valid=False,
+            value=None,
+            errors=["Raw claim must be a dictionary"],
+        )
+
+    mainsnak = raw_claim.get("mainsnak", {})
+    if not isinstance(mainsnak, dict):
+        return ValidationResult(
+            valid=False,
+            value=None,
+            errors=["Claim mainsnak must be a dictionary"],
+        )
+
+    snaktype = mainsnak.get("snaktype")
+    if snaktype == "novalue":
+        return ValidationResult(valid=True, value=None)
+    if snaktype == "somevalue":
+        return ValidationResult(
+            valid=True,
+            value=None,
+            warnings=["Claim uses somevalue; no concrete value to validate"],
+        )
+
+    datavalue = mainsnak.get("datavalue", {})
+    if not isinstance(datavalue, dict) or "value" not in datavalue:
+        return ValidationResult(
+            valid=False,
+            value=None,
+            errors=["Claim is missing mainsnak.datavalue.value"],
+        )
+
+    return validate_by_datatype(data_type, datavalue.get("value"))
+
+
+def evaluate_statement_claim(
+    profile_statement: dict[str, Any],
+    raw_claim_list: list[dict[str, Any]],
+    *,
+    entity_ref: str = "",
+    value_list_root: Optional[Path] = None,
+) -> StatementEvaluation:
+    """Evaluate one statement against claim candidates using profile constraints."""
+    statement_ref = _statement_ref_from_profile_statement(profile_statement)
+    property_ref = _statement_property_ref(profile_statement)
+    data_type = _statement_data_type(profile_statement)
+    fixed_value = _statement_fixed_value(profile_statement)
+    max_count = _statement_max_count(profile_statement)
+    value_list_path = _resolve_statement_value_list_path(
+        profile_statement,
+        value_list_root=value_list_root,
+    )
+
+    notices: list[ConformanceNotice] = []
+    normalized_values: list[Any] = []
+    claim_candidates = raw_claim_list if isinstance(raw_claim_list, list) else []
+
+    if not claim_candidates:
+        if fixed_value is not None:
+            result, notice = enforce_fixed_value(None, fixed_value, statement_ref or "")
+            if notice is not None:
+                notice.entity_ref = entity_ref
+                notices.append(notice)
+            return StatementEvaluation(
+                outcome=ConformanceOutcome.CONFORMANT,
+                statement_ref=statement_ref,
+                property_ref=property_ref,
+                normalized_value=result.value,
+                raw_claims=[],
+                notices=notices,
+            )
+
+        if _statement_is_required(profile_statement):
+            notices.append(
+                ConformanceNotice(
+                    severity="error",
+                    entity_ref=entity_ref,
+                    statement_ref=statement_ref,
+                    code="statement_missing",
+                    message="Expected statement is missing from input data",
+                )
+            )
+            return StatementEvaluation(
+                outcome=ConformanceOutcome.MISSING,
+                statement_ref=statement_ref,
+                property_ref=property_ref,
+                normalized_value=None,
+                raw_claims=[],
+                notices=notices,
+            )
+
+        return StatementEvaluation(
+            outcome=ConformanceOutcome.CONFORMANT,
+            statement_ref=statement_ref,
+            property_ref=property_ref,
+            normalized_value=None,
+            raw_claims=[],
+            notices=notices,
+        )
+
+    if (
+        isinstance(max_count, int)
+        and max_count > 0
+        and len(claim_candidates) > max_count
+    ):
+        notices.append(
+            ConformanceNotice(
+                severity="warning",
+                entity_ref=entity_ref,
+                statement_ref=statement_ref,
+                code="max_count_exceeded",
+                message=(
+                    f"Received {len(claim_candidates)} values but max_count is {max_count}; "
+                    "extra values retained in raw_claims"
+                ),
+            )
+        )
+        claim_candidates = claim_candidates[:max_count]
+
+    if not data_type:
+        notices.append(
+            ConformanceNotice(
+                severity="error",
+                entity_ref=entity_ref,
+                statement_ref=statement_ref,
+                code="statement_type_missing",
+                message="Profile statement has no value.type for validation",
+            )
+        )
+        return StatementEvaluation(
+            outcome=ConformanceOutcome.NON_CONFORMANT_MAPPABLE,
+            statement_ref=statement_ref,
+            property_ref=property_ref,
+            normalized_value=None,
+            raw_claims=raw_claim_list,
+            notices=notices,
+        )
+
+    for raw_claim in claim_candidates:
+        result = normalize_claim_value(raw_claim, data_type)
+        if not result.valid:
+            for error in result.errors:
+                notices.append(
+                    ConformanceNotice(
+                        severity="error",
+                        entity_ref=entity_ref,
+                        statement_ref=statement_ref,
+                        code="datatype_mismatch",
+                        message=error,
+                    )
+                )
+            continue
+
+        for warning in result.warnings:
+            notices.append(
+                ConformanceNotice(
+                    severity="warning",
+                    entity_ref=entity_ref,
+                    statement_ref=statement_ref,
+                    code="datatype_coercion_warning",
+                    message=warning,
+                    normalized_value=result.value,
+                )
+            )
+        normalized_values.append(result.value)
+
+    if not normalized_values:
+        return StatementEvaluation(
+            outcome=ConformanceOutcome.NON_CONFORMANT_MAPPABLE,
+            statement_ref=statement_ref,
+            property_ref=property_ref,
+            normalized_value=None,
+            raw_claims=raw_claim_list,
+            notices=notices,
+        )
+
+    if fixed_value is not None:
+        for idx, value in enumerate(normalized_values):
+            result, notice = enforce_fixed_value(
+                value, fixed_value, statement_ref or ""
+            )
+            if notice is not None:
+                notice.entity_ref = entity_ref
+                notices.append(notice)
+            if not result.valid:
+                return StatementEvaluation(
+                    outcome=ConformanceOutcome.NON_CONFORMANT_MAPPABLE,
+                    statement_ref=statement_ref,
+                    property_ref=property_ref,
+                    normalized_value=normalized_values[idx],
+                    raw_claims=raw_claim_list,
+                    notices=notices,
+                )
+            normalized_values[idx] = result.value
+
+    if value_list_path is not None:
+        for value in normalized_values:
+            list_result = validate_value_from_list(value, value_list_path)
+            if not list_result.valid:
+                for error in list_result.errors:
+                    notices.append(
+                        ConformanceNotice(
+                            severity="error",
+                            entity_ref=entity_ref,
+                            statement_ref=statement_ref,
+                            code="value_list_miss",
+                            message=error,
+                        )
+                    )
+                return StatementEvaluation(
+                    outcome=ConformanceOutcome.NON_CONFORMANT_MAPPABLE,
+                    statement_ref=statement_ref,
+                    property_ref=property_ref,
+                    normalized_value=value,
+                    raw_claims=raw_claim_list,
+                    notices=notices,
+                )
+
+    normalized_payload: Any
+    if len(normalized_values) == 1:
+        normalized_payload = normalized_values[0]
+    else:
+        normalized_payload = normalized_values
+
+    if any(notice.code == "max_count_exceeded" for notice in notices):
+        return StatementEvaluation(
+            outcome=ConformanceOutcome.NON_CONFORMANT_MAPPABLE,
+            statement_ref=statement_ref,
+            property_ref=property_ref,
+            normalized_value=normalized_payload,
+            raw_claims=raw_claim_list,
+            notices=notices,
+        )
+
+    return StatementEvaluation(
+        outcome=ConformanceOutcome.CONFORMANT,
+        statement_ref=statement_ref,
+        property_ref=property_ref,
+        normalized_value=normalized_payload,
+        raw_claims=raw_claim_list,
+        notices=notices,
+    )
+
+
+def evaluate_entity(
+    profile_statements: list[dict[str, Any]],
+    wikidata_item: dict[str, Any],
+    *,
+    io_map_index: dict[str, dict[str, Any]],
+    entity_ref: str = "",
+    value_list_root: Optional[Path] = None,
+) -> EntityEvaluation:
+    """Evaluate one entity item against profile statements and classify outcomes."""
+    claims = wikidata_item.get("claims", {})
+    if not isinstance(claims, dict):
+        claims = {}
+
+    profile_ref = entity_ref or str(wikidata_item.get("id") or "")
+    evaluation = EntityEvaluation(
+        entity_ref=entity_ref or "unknown", profile_ref=profile_ref
+    )
+    covered_properties: set[str] = set()
+
+    for profile_statement in profile_statements:
+        if not isinstance(profile_statement, dict):
+            continue
+
+        statement_property_ids: list[str] = []
+        io_map = profile_statement.get("io_map")
+        if isinstance(io_map, list):
+            for mapping in io_map:
+                if not isinstance(mapping, dict):
+                    continue
+                target = mapping.get("to")
+                if isinstance(target, str) and target:
+                    statement_property_ids.append(target.rsplit("/", 1)[-1])
+
+        if not statement_property_ids:
+            fallback_property = _statement_property_ref(profile_statement)
+            if fallback_property:
+                statement_property_ids.append(fallback_property)
+
+        raw_claim_list: list[dict[str, Any]] = []
+        for property_id in statement_property_ids:
+            covered_properties.add(property_id)
+            claim_values = claims.get(property_id, [])
+            if isinstance(claim_values, list):
+                raw_claim_list.extend(
+                    claim for claim in claim_values if isinstance(claim, dict)
+                )
+
+        statement_eval = evaluate_statement_claim(
+            profile_statement,
+            raw_claim_list,
+            entity_ref=evaluation.entity_ref,
+            value_list_root=value_list_root,
+        )
+
+        if statement_eval.outcome == ConformanceOutcome.CONFORMANT:
+            evaluation.conformant.append(statement_eval)
+        elif statement_eval.outcome == ConformanceOutcome.NON_CONFORMANT_MAPPABLE:
+            evaluation.non_conformant_mappable.append(statement_eval)
+        elif statement_eval.outcome == ConformanceOutcome.TO_BE_DEFINED:
+            evaluation.to_be_defined.append(statement_eval)
+        elif statement_eval.outcome == ConformanceOutcome.MISSING:
+            evaluation.missing.append(statement_eval)
+
+    known_properties = set(covered_properties)
+    known_properties.update(
+        property_id
+        for property_id, statement in io_map_index.items()
+        if isinstance(property_id, str) and property_id and isinstance(statement, dict)
+    )
+
+    for property_id, claim_values in claims.items():
+        if property_id in known_properties:
+            continue
+        if not isinstance(claim_values, list):
+            claim_values = []
+
+        notice = ConformanceNotice(
+            severity="info",
+            entity_ref=evaluation.entity_ref,
+            statement_ref=None,
+            code="statement_uncovered",
+            message=f"Property {property_id} is not defined in active profile",
+        )
+        evaluation.to_be_defined.append(
+            StatementEvaluation(
+                outcome=ConformanceOutcome.TO_BE_DEFINED,
+                statement_ref=None,
+                property_ref=property_id,
+                normalized_value=None,
+                raw_claims=[claim for claim in claim_values if isinstance(claim, dict)],
+                notices=[notice],
+            )
+        )
+
+    return evaluation
+
+
+def check_packet_integrity(packet: dict[str, Any]) -> Optional[ConformanceNotice]:
+    """Verify packet metadata digest integrity before evaluating packet data."""
+    if not isinstance(packet, dict):
+        return ConformanceNotice(
+            severity="error",
+            entity_ref="packet",
+            code="packet_invalid",
+            message="Packet payload must be a JSON object",
+        )
+
+    metadata = packet.get("metadata")
+    if not isinstance(metadata, dict):
+        return ConformanceNotice(
+            severity="error",
+            entity_ref=str(packet.get("packet_id") or "packet"),
+            code="metadata_missing",
+            message="Packet metadata section is missing",
+        )
+
+    integrity = metadata.get("integrity")
+    if not isinstance(integrity, dict):
+        return ConformanceNotice(
+            severity="error",
+            entity_ref=str(packet.get("packet_id") or "packet"),
+            code="metadata_integrity_missing",
+            message="Packet metadata.integrity section is missing",
+        )
+
+    declared_digest = integrity.get("metadata_digest")
+    if not isinstance(declared_digest, str) or not declared_digest:
+        return ConformanceNotice(
+            severity="error",
+            entity_ref=str(packet.get("packet_id") or "packet"),
+            code="metadata_digest_missing",
+            message="Packet metadata digest is missing",
+        )
+
+    metadata_without_integrity = dict(metadata)
+    metadata_without_integrity.pop("integrity", None)
+    computed_digest = _canonical_json_digest(metadata_without_integrity)
+
+    if computed_digest != declared_digest:
+        return ConformanceNotice(
+            severity="error",
+            entity_ref=str(packet.get("packet_id") or "packet"),
+            code="metadata_digest_mismatch",
+            message="Packet metadata digest mismatch; validation halted",
+            normalized_value={
+                "expected": declared_digest,
+                "computed": computed_digest,
+            },
+        )
+
+    return None
+
+
+def validate_packet_inline(
+    packet: dict[str, Any],
+    *,
+    value_list_root: Optional[Path] = None,
+) -> tuple[bool, list[ConformanceNotice]]:
+    """Validate an in-memory packet object with integrity-first gating."""
+    del value_list_root
+
+    integrity_notice = check_packet_integrity(packet)
+    if integrity_notice is not None:
+        return False, [integrity_notice]
+
+    notices: list[ConformanceNotice] = []
+    data = packet.get("data")
+    entities = data.get("entities") if isinstance(data, dict) else None
+
+    if not isinstance(entities, list):
+        notices.append(
+            ConformanceNotice(
+                severity="error",
+                entity_ref=str(packet.get("packet_id") or "packet"),
+                code="packet_entities_missing",
+                message="Packet data.entities must be a list",
+            )
+        )
+        return False, notices
+
+    notices.append(
+        ConformanceNotice(
+            severity="info",
+            entity_ref=str(packet.get("packet_id") or "packet"),
+            code="packet_integrity_pass",
+            message="Packet metadata integrity check passed",
+        )
+    )
+    return True, notices
+
+
+def validate_packet_from_file(
+    path: Path,
+    *,
+    value_list_root: Optional[Path] = None,
+) -> tuple[bool, list[ConformanceNotice]]:
+    """Validate packet JSON loaded from a file path."""
+    packet_path = Path(path)
+    try:
+        packet_payload = json.loads(packet_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return (
+            False,
+            [
+                ConformanceNotice(
+                    severity="error",
+                    entity_ref=str(packet_path),
+                    code="packet_file_load_failed",
+                    message=f"Failed to load packet file: {exc}",
+                )
+            ],
+        )
+
+    if not isinstance(packet_payload, dict):
+        return (
+            False,
+            [
+                ConformanceNotice(
+                    severity="error",
+                    entity_ref=str(packet_path),
+                    code="packet_file_invalid",
+                    message="Packet file must contain a JSON object",
+                )
+            ],
+        )
+
+    return validate_packet_inline(packet_payload, value_list_root=value_list_root)
+
+
 # ============================================================================
 # Wikibase datatype validators (all 8 primitive types)
 # ============================================================================
 
 
-def validate_wikibase_item(value: Any) -> ValidationResult:
+def validate_wikibase_item(
+    value: Any,
+    *,
+    validation_policy: ValidationPolicy = ValidationPolicy.STRUCTURE,
+    policy_config: Optional[ValidationPolicyConfig] = None,
+) -> ValidationResult:
     """Validate a wikibase-item value.
 
     Expected Wikibase JSON structure:
@@ -71,53 +1274,59 @@ def validate_wikibase_item(value: Any) -> ValidationResult:
 
     Accepts either a dict matching the structure above or a QID string (will coerce).
     """
-    if value is None:
+    policy = _resolve_validation_policy_config(validation_policy, policy_config)
+    qid, warnings, issues = _coerce_wikibase_item_reference(value)
+    if not qid:
+        return ValidationResult(valid=False, value=value, errors=issues)
+
+    normalized = {
+        "entity-type": "item",
+        "numeric-id": int(qid[1:]) if qid[1:].isdigit() else None,
+        "id": qid,
+        "wikibase-api-url": policy.wikibase_api_url,
+    }
+
+    uncertainty_reasons = list(issues) if issues else []
+    if policy.policy == ValidationPolicy.STRUCTURE:
         return ValidationResult(
-            valid=False, value=None, errors=["wikibase-item value cannot be null"]
+            valid=True,
+            value=normalized,
+            warnings=warnings,
+            uncertainty=_uncertainty_score(uncertainty_reasons),
+            uncertainty_reasons=uncertainty_reasons,
         )
 
-    # If it's already a dict, validate structure
-    if isinstance(value, dict):
-        if (
-            "id" in value
-            and isinstance(value["id"], str)
-            and value["id"].startswith("Q")
-        ):
-            normalized = {
-                "entity-type": "item",
-                "numeric-id": (
-                    int(value["id"][1:]) if value["id"][1:].isdigit() else None
-                ),
-                "id": value["id"],
-            }
-            return ValidationResult(valid=True, value=normalized)
+    try:
+        client = WikibaseApiClient(
+            api_url=policy.wikibase_api_url,
+            timeout=policy.timeout_seconds,
+        )
+        client.get_entity(qid)
+    except Exception as exc:
         return ValidationResult(
             valid=False,
-            value=value,
-            errors=["wikibase-item dict must contain 'id' field with Q-prefixed QID"],
+            value=normalized,
+            warnings=warnings,
+            errors=[
+                "Online Wikibase validation failed: "
+                f"could not resolve {qid} at {policy.wikibase_api_url}: {exc}"
+            ],
+            uncertainty=1.0,
+            uncertainty_reasons=["online_wikibase_lookup_failed"],
         )
 
-    # If it's a string, treat as QID
-    if isinstance(value, str):
-        if value.startswith("Q") and value[1:].isdigit():
-            return ValidationResult(
-                valid=True,
-                value={
-                    "entity-type": "item",
-                    "numeric-id": int(value[1:]),
-                    "id": value,
-                },
-            )
-        return ValidationResult(
-            valid=False,
-            value=value,
-            errors=[f"Invalid QID format: {value}. Expected Q-prefixed numeric ID."],
+    actionable_warnings: list[str] = []
+    if policy.policy == ValidationPolicy.ACTIONABLE:
+        actionable_warnings.append(
+            "ACTIONABLE policy currently verifies entity resolvability; extended intent checks are pending policy-rule integration"
         )
 
     return ValidationResult(
-        valid=False,
-        value=value,
-        errors=[f"wikibase-item must be a dict or string, got {type(value).__name__}"],
+        valid=True,
+        value=normalized,
+        warnings=warnings + actionable_warnings,
+        uncertainty=_uncertainty_score(uncertainty_reasons),
+        uncertainty_reasons=uncertainty_reasons,
     )
 
 
@@ -146,6 +1355,67 @@ def validate_string(value: Any) -> ValidationResult:
         return ValidationResult(
             valid=False, value=value, errors=[f"Failed to coerce to string: {e}"]
         )
+
+
+def validate_with_pattern(
+    value: Any,
+    pattern: str,
+    *,
+    flags: int = 0,
+) -> ValidationResult:
+    """Validate a string-like value against a regex pattern.
+
+    This is a constraint-layer validator intended for profile/statement-sourced
+    regex rules. It first applies ``validate_string()`` and then checks the
+    normalized string against the supplied regex.
+
+    Pattern semantics use ``re.search`` so profile-authored regexes can choose
+    their own anchoring strategy.
+    """
+    base_result = validate_string(value)
+    if not base_result.valid:
+        return base_result
+
+    if not isinstance(pattern, str) or not pattern:
+        return ValidationResult(
+            valid=False,
+            value=base_result.value,
+            warnings=base_result.warnings,
+            errors=["pattern must be a non-empty regex string"],
+        )
+
+    try:
+        compiled = re.compile(pattern, flags)
+    except re.error as exc:
+        return ValidationResult(
+            valid=False,
+            value=base_result.value,
+            warnings=base_result.warnings,
+            errors=[f"Invalid regex pattern: {exc}"],
+        )
+
+    normalized_value = base_result.value
+    if not isinstance(normalized_value, str):
+        return ValidationResult(
+            valid=False,
+            value=normalized_value,
+            warnings=base_result.warnings,
+            errors=["Pattern validation requires a normalized string value"],
+        )
+
+    if compiled.search(normalized_value) is None:
+        return ValidationResult(
+            valid=False,
+            value=normalized_value,
+            warnings=base_result.warnings,
+            errors=[f"String does not match required pattern: {pattern}"],
+        )
+
+    return ValidationResult(
+        valid=True,
+        value=normalized_value,
+        warnings=base_result.warnings,
+    )
 
 
 def validate_monolingualtext(value: Any) -> ValidationResult:
@@ -183,66 +1453,104 @@ def validate_monolingualtext(value: Any) -> ValidationResult:
     return ValidationResult(valid=True, value=value)
 
 
-def validate_url(value: Any) -> ValidationResult:
+def validate_url(
+    value: Any,
+    *,
+    validation_policy: ValidationPolicy = ValidationPolicy.STRUCTURE,
+    policy_config: Optional[ValidationPolicyConfig] = None,
+) -> ValidationResult:
     """Validate a URL value.
 
     Accepts string URLs. Validates basic URL structure (starts with http:// or https://).
     """
-    if value is None:
+    policy = _resolve_validation_policy_config(validation_policy, policy_config)
+    normalized_url, warnings, issues = _coerce_url_candidate(value)
+    if not normalized_url:
+        return ValidationResult(valid=False, value=value, errors=issues)
+
+    uncertainty_reasons = list(issues) if issues else []
+    uncertainty_reasons.extend(
+        reason
+        for reason in [
+            "url_coerced" if warnings else None,
+        ]
+        if reason
+    )
+
+    if policy.policy == ValidationPolicy.STRUCTURE:
         return ValidationResult(
-            valid=False, value=None, errors=["url value cannot be null"]
+            valid=True,
+            value=normalized_url,
+            warnings=warnings,
+            uncertainty=_uncertainty_score(uncertainty_reasons),
+            uncertainty_reasons=uncertainty_reasons,
         )
 
-    if not isinstance(value, str):
+    retrieval_mode = "head" if policy.policy == ValidationPolicy.HEARTBEAT else "get"
+    retrieval = fetch_url_resource(
+        normalized_url,
+        mode=retrieval_mode,
+        timeout=policy.timeout_seconds,
+        allow_redirects=policy.allow_redirects,
+        accept=policy.request_accept,
+    )
+
+    if not retrieval.ok:
         return ValidationResult(
             valid=False,
-            value=value,
-            errors=[f"url must be a string, got {type(value).__name__}"],
+            value=normalized_url,
+            warnings=warnings,
+            errors=[
+                f"Online URL validation failed for {normalized_url}: {retrieval.error or retrieval.status_code}"
+            ],
+            uncertainty=1.0,
+            uncertainty_reasons=["online_url_lookup_failed"],
         )
 
-    # Basic URL validation
-    if not (value.startswith("http://") or value.startswith("https://")):
+    if retrieval.status_code is not None and retrieval.status_code >= 400:
         return ValidationResult(
-            valid=False, value=value, errors=["url must start with http:// or https://"]
+            valid=False,
+            value=normalized_url,
+            warnings=warnings,
+            errors=[f"Online URL validation received HTTP {retrieval.status_code}"],
+            uncertainty=1.0,
+            uncertainty_reasons=["online_url_http_error"],
         )
 
-    return ValidationResult(valid=True, value=value)
+    actionable_warnings = []
+    if policy.policy == ValidationPolicy.ACTIONABLE and retrieval.content_type:
+        actionable_warnings.append(f"Retrieved content-type: {retrieval.content_type}")
+
+    return ValidationResult(
+        valid=True,
+        value=normalized_url,
+        warnings=warnings + actionable_warnings,
+        uncertainty=_uncertainty_score(uncertainty_reasons),
+        uncertainty_reasons=uncertainty_reasons,
+    )
 
 
 def validate_time(value: Any) -> ValidationResult:
-    """Validate a time value.
+    """Validate and coerce a time value to full Wikibase time structure.
 
-    Expected Wikibase structure:
-        {
-            "time": "+2020-01-15T00:00:00Z",
-            "timezone": 0,
-            "before": 0,
-            "after": 0,
-            "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
-        }
+    Accepts:
+    - Full Wikibase time dicts
+    - Partial dicts (for example, only ``time``)
+    - Component dicts (``year``, ``month``, ``day``)
+    - Year integers
+    - Date/time strings (``YYYY``, ``YYYY-MM``, ``YYYY-MM-DD``, ``YYYY-MM-DDTHH:MM[:SS]``)
     """
-    if value is None:
-        return ValidationResult(
-            valid=False, value=None, errors=["time value cannot be null"]
-        )
+    normalized, warnings, issues = _coerce_time_value(value)
+    if not normalized:
+        return ValidationResult(valid=False, value=value, errors=issues)
 
-    if not isinstance(value, dict):
-        return ValidationResult(
-            valid=False,
-            value=value,
-            errors=[f"time must be a dict, got {type(value).__name__}"],
-        )
-
-    required_fields = ["time", "timezone", "before", "after", "calendarmodel"]
-    for field_name in required_fields:
-        if field_name not in value:
-            return ValidationResult(
-                valid=False,
-                value=value,
-                errors=[f"time dict must contain '{field_name}' field"],
-            )
-
-    return ValidationResult(valid=True, value=value)
+    return ValidationResult(
+        valid=True,
+        value=normalized,
+        warnings=warnings,
+        uncertainty=_uncertainty_score(issues),
+        uncertainty_reasons=issues,
+    )
 
 
 def validate_quantity(value: Any) -> ValidationResult:
@@ -281,82 +1589,155 @@ def validate_quantity(value: Any) -> ValidationResult:
 
 
 def validate_globe_coordinate(value: Any) -> ValidationResult:
-    """Validate a globe-coordinate value.
+    """Validate and coerce a globe-coordinate value.
 
-    Expected Wikibase structure:
-        {
-            "latitude": 40.7128,
-            "longitude": -74.0060,
-            "altitude": None,
-            "precision": 0.0001,
-            "globe": "http://www.wikidata.org/entity/Q2"  # Earth
-        }
+    Accepts:
+    - Full Wikibase coordinate dicts
+    - Dicts with shorthand keys (``lat``/``lon``/``lng``)
+    - Coordinate strings (for example, ``"42.5,-121.3"``)
+    - DMS-like coordinate strings (for example, ``"42 30 00 N"``)
+    - Coordinate sequences ``[latitude, longitude]``
     """
-    if value is None:
-        return ValidationResult(
-            valid=False, value=None, errors=["globe-coordinate value cannot be null"]
-        )
+    normalized, warnings, issues = _coerce_globe_coordinate_value(value)
+    if not normalized:
+        return ValidationResult(valid=False, value=value, errors=issues)
 
-    if not isinstance(value, dict):
-        return ValidationResult(
-            valid=False,
-            value=value,
-            errors=[f"globe-coordinate must be a dict, got {type(value).__name__}"],
-        )
-
-    required_fields = ["latitude", "longitude", "precision", "globe"]
-    for field_name in required_fields:
-        if field_name not in value:
-            return ValidationResult(
-                valid=False,
-                value=value,
-                errors=[f"globe-coordinate dict must contain '{field_name}' field"],
-            )
-
-    # Validate lat/long ranges
-    lat = value.get("latitude")
-    lon = value.get("longitude")
-
-    if not isinstance(lat, (int, float)) or not (-90 <= lat <= 90):
-        return ValidationResult(
-            valid=False,
-            value=value,
-            errors=[f"latitude must be between -90 and 90, got {lat}"],
-        )
-
-    if not isinstance(lon, (int, float)) or not (-180 <= lon <= 180):
-        return ValidationResult(
-            valid=False,
-            value=value,
-            errors=[f"longitude must be between -180 and 180, got {lon}"],
-        )
-
-    return ValidationResult(valid=True, value=value)
+    return ValidationResult(
+        valid=True,
+        value=normalized,
+        warnings=warnings,
+        uncertainty=_uncertainty_score(issues),
+        uncertainty_reasons=issues,
+    )
 
 
-def validate_commons_media(value: Any) -> ValidationResult:
-    """Validate a commonsMedia value.
+_COMMONS_FILE_PREFIX = "File:"
 
-    Accepts a string representing a Wikimedia Commons filename.
+
+def _coerce_commons_filename(value: Any) -> tuple[Optional[str], list[str], list[str]]:
+    """Coerce flexible Commons filename inputs to a canonical ``File:``-prefixed form.
+
+    Normalizes:
+    - Non-string values (coerced to string with a warning)
+    - Missing ``File:`` prefix (added silently — expected omission in data)
+    - Spaces normalized to underscores for API consistency
+
+    Returns:
+        Tuple of (canonical_filename, warnings, uncertainty_reasons).
+        canonical_filename is None when the value cannot be coerced.
     """
+    warnings: list[str] = []
+    uncertainty_reasons: list[str] = []
+
     if value is None:
-        return ValidationResult(
-            valid=False, value=None, errors=["commonsMedia value cannot be null"]
-        )
+        return None, warnings, ["commonsMedia value cannot be null"]
 
     if not isinstance(value, str):
+        try:
+            value = str(value)
+            warnings.append(
+                f"Coerced {type(value).__name__} to string for commonsMedia"
+            )
+            uncertainty_reasons.append("filename_type_coerced")
+        except Exception:
+            return (
+                None,
+                warnings,
+                [f"commonsMedia must be a string, got {type(value).__name__}"],
+            )
+
+    filename = value.strip()
+    if not filename:
+        return None, warnings, ["commonsMedia filename cannot be empty"]
+
+    if filename.startswith("File:"):
+        canonical = filename
+    elif filename.startswith("file:"):
+        canonical = _COMMONS_FILE_PREFIX + filename[5:]
+        warnings.append("Normalized lowercase 'file:' prefix to 'File:'")
+        uncertainty_reasons.append("filename_prefix_normalized")
+    else:
+        canonical = _COMMONS_FILE_PREFIX + filename
+
+    return canonical, warnings, uncertainty_reasons
+
+
+def validate_commons_media(
+    value: Any,
+    *,
+    validation_policy: ValidationPolicy = ValidationPolicy.STRUCTURE,
+    policy_config: Optional[ValidationPolicyConfig] = None,
+) -> ValidationResult:
+    """Validate a commonsMedia value against Wikimedia Commons.
+
+    Accepts a string representing a Wikimedia Commons filename, with or without
+    the ``File:`` prefix.
+
+    - STRUCTURE: structural coercion and format check only (offline)
+    - HEARTBEAT: confirms the file exists on Commons via the MediaWiki API
+    - ACTIONABLE: retrieves full file metadata (MIME type, size, SHA-1, resource URL)
+    """
+    policy = _resolve_validation_policy_config(validation_policy, policy_config)
+    canonical, warnings, issues = _coerce_commons_filename(value)
+    if not canonical:
+        return ValidationResult(valid=False, value=value, errors=issues)
+
+    uncertainty_reasons = list(issues) if issues else []
+
+    if policy.policy == ValidationPolicy.STRUCTURE:
+        return ValidationResult(
+            valid=True,
+            value=canonical,
+            warnings=warnings,
+            uncertainty=_uncertainty_score(uncertainty_reasons),
+            uncertainty_reasons=uncertainty_reasons,
+        )
+
+    fetch_mode = (
+        "heartbeat" if policy.policy == ValidationPolicy.HEARTBEAT else "actionable"
+    )
+    try:
+        client = WikibaseApiClient(
+            api_url=policy.commons_api_url,
+            timeout=policy.timeout_seconds,
+        )
+        result = fetch_commons_file_info(client, canonical, mode=fetch_mode)
+    except Exception as exc:
         return ValidationResult(
             valid=False,
-            value=value,
-            errors=[f"commonsMedia must be a string, got {type(value).__name__}"],
+            value=canonical,
+            warnings=warnings,
+            errors=[f"Online Commons validation failed for {canonical}: {exc}"],
+            uncertainty=1.0,
+            uncertainty_reasons=["online_commons_lookup_failed"],
         )
 
-    if not value.strip():
+    if not result.ok or not result.exists:
         return ValidationResult(
-            valid=False, value=value, errors=["commonsMedia filename cannot be empty"]
+            valid=False,
+            value=canonical,
+            warnings=warnings,
+            errors=[result.error or f"File not found on Commons: {canonical}"],
+            uncertainty=1.0,
+            uncertainty_reasons=["online_commons_lookup_failed"],
         )
 
-    return ValidationResult(valid=True, value=value)
+    actionable_warnings: list[str] = []
+    if policy.policy == ValidationPolicy.ACTIONABLE:
+        if result.resource_url:
+            actionable_warnings.append(f"Commons resource URL: {result.resource_url}")
+        if result.mime_type:
+            actionable_warnings.append(f"Commons MIME type: {result.mime_type}")
+        if result.size is not None:
+            actionable_warnings.append(f"Commons file size: {result.size} bytes")
+
+    return ValidationResult(
+        valid=True,
+        value=canonical,
+        warnings=warnings + actionable_warnings,
+        uncertainty=_uncertainty_score(uncertainty_reasons),
+        uncertainty_reasons=uncertainty_reasons,
+    )
 
 
 # Dispatcher for datatype validators
@@ -372,12 +1753,24 @@ _DATATYPE_VALIDATORS = {
 }
 
 
-def validate_by_datatype(datatype: str, value: Any) -> ValidationResult:
+def validate_by_datatype(
+    datatype: str,
+    value: Any,
+    *,
+    validation_policy: ValidationPolicy = ValidationPolicy.STRUCTURE,
+    policy_config: Optional[ValidationPolicyConfig] = None,
+) -> ValidationResult:
     """Dispatch validation to the appropriate datatype validator."""
     validator = _DATATYPE_VALIDATORS.get(datatype)
     if not validator:
         return ValidationResult(
             valid=False, value=value, errors=[f"Unknown datatype: {datatype}"]
+        )
+    if datatype in {"wikibase-item", "url", "commonsMedia"}:
+        return validator(
+            value,
+            validation_policy=validation_policy,
+            policy_config=policy_config,
         )
     return validator(value)
 

--- a/gkc/mash/__init__.py
+++ b/gkc/mash/__init__.py
@@ -5,7 +5,9 @@ This package provides source-loading templates and loaders used by GKC.
 
 from gkc.mash.core import (
     ClaimSummary,
+    CommonsFileInfoResult,
     DataTemplate,
+    URLFetchResult,
     WikibaseApiClient,
     WikibaseCacheRefreshResult,
     WikibaseEntitySchemaTemplate,
@@ -21,12 +23,14 @@ from gkc.mash.core import (
     apply_template_language_filter,
     extract_first_sparql_block,
     extract_sparql_blocks,
+    fetch_commons_file_info,
     fetch_entity_rdf,
     fetch_entity_schema_json,
     fetch_entity_schema_specification,
     fetch_mediawiki_page_wikitext,
     fetch_property_labels,
     fetch_recent_entity_changes,
+    fetch_url_resource,
     get_latest_cache_timestamp,
     refresh_entity_cache_from_recentchanges,
     strip_entity_identifiers,
@@ -35,7 +39,9 @@ from gkc.mash.protocols import MashSourceAdapter
 
 __all__ = [
     "ClaimSummary",
+    "CommonsFileInfoResult",
     "DataTemplate",
+    "URLFetchResult",
     "WikibaseCacheRefreshResult",
     "MashSourceAdapter",
     "WikibaseMashSourceAdapter",
@@ -56,6 +62,8 @@ __all__ = [
     "fetch_mediawiki_page_wikitext",
     "fetch_entity_schema_json",
     "fetch_entity_schema_specification",
+    "fetch_commons_file_info",
+    "fetch_url_resource",
     "fetch_property_labels",
     "fetch_recent_entity_changes",
     "get_latest_cache_timestamp",

--- a/gkc/mash/core.py
+++ b/gkc/mash/core.py
@@ -160,6 +160,197 @@ class WikibaseCacheRefreshResult:
     missing_ids: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class URLFetchResult:
+    """Result envelope for generic URL retrieval checks."""
+
+    url: str
+    ok: bool
+    status_code: Optional[int] = None
+    final_url: Optional[str] = None
+    content_type: Optional[str] = None
+    response_size: Optional[int] = None
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CommonsFileInfoResult:
+    """Result envelope for Wikimedia Commons file existence and metadata checks.
+
+    Parallels URLFetchResult for consistent result handling in validation workflows.
+
+    Attributes:
+        filename: Canonical Commons filename with ``File:`` prefix.
+        ok: Whether the API request completed without error.
+        exists: Whether the file exists on Wikimedia Commons.
+        page_url: URL of the file description page on Commons.
+        resource_url: Direct URL of the media resource itself.
+        mime_type: MIME type reported by Commons (e.g., ``image/jpeg``).
+        size: File size in bytes.
+        width: Image width in pixels (images only).
+        height: Image height in pixels (images only).
+        sha1: SHA-1 hash of the file content.
+        error: Error message if the fetch failed or the file was not found.
+    """
+
+    filename: str
+    ok: bool
+    exists: bool = False
+    page_url: Optional[str] = None
+    resource_url: Optional[str] = None
+    mime_type: Optional[str] = None
+    size: Optional[int] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    sha1: Optional[str] = None
+    error: Optional[str] = None
+
+
+def fetch_commons_file_info(
+    api_client: WikibaseApiClient,
+    filename: str,
+    *,
+    mode: str = "heartbeat",
+) -> CommonsFileInfoResult:
+    """Fetch file existence and metadata from the Wikimedia Commons MediaWiki API.
+
+    Accepts a Commons filename with or without the ``File:`` prefix.  The canonical
+    form (with prefix) is always stored in the result.
+
+    Args:
+        api_client: Configured client pointing at the Commons API endpoint.
+            Typically ``WikibaseApiClient(api_url="https://commons.wikimedia.org/w/api.php")``.
+        filename: Commons filename, e.g. ``File:Example.jpg`` or ``Example.jpg``.
+        mode: ``"heartbeat"`` checks file existence only; ``"actionable"`` retrieves
+            full imageinfo (URL, MIME type, size, SHA-1).
+
+    Returns:
+        CommonsFileInfoResult with existence flag and, for ACTIONABLE mode, full
+        file metadata.
+    """
+    canonical = filename if filename.startswith("File:") else f"File:{filename}"
+
+    iiprop = "url|mime|size|sha1" if mode == "actionable" else "url"
+    params: dict[str, Any] = {
+        "action": "query",
+        "format": "json",
+        "formatversion": 2,
+        "prop": "imageinfo",
+        "iiprop": iiprop,
+        "titles": canonical,
+    }
+
+    try:
+        payload = api_client.request(params)
+    except RuntimeError as exc:
+        return CommonsFileInfoResult(filename=canonical, ok=False, error=str(exc))
+
+    pages = payload.get("query", {}).get("pages", [])
+    if not isinstance(pages, list) or not pages:
+        return CommonsFileInfoResult(
+            filename=canonical,
+            ok=True,
+            exists=False,
+            error=f"File not found on Commons: {canonical}",
+        )
+
+    page = pages[0]
+    if not isinstance(page, dict) or page.get("missing"):
+        return CommonsFileInfoResult(
+            filename=canonical,
+            ok=True,
+            exists=False,
+            error=f"File not found on Commons: {canonical}",
+        )
+
+    imageinfo_list = page.get("imageinfo", [])
+    if not isinstance(imageinfo_list, list) or not imageinfo_list:
+        return CommonsFileInfoResult(filename=canonical, ok=True, exists=True)
+
+    info = imageinfo_list[0] if isinstance(imageinfo_list[0], dict) else {}
+    return CommonsFileInfoResult(
+        filename=canonical,
+        ok=True,
+        exists=True,
+        page_url=f"https://commons.wikimedia.org/wiki/{canonical.replace(' ', '_')}",
+        resource_url=info.get("url"),
+        mime_type=info.get("mime") if mode == "actionable" else None,
+        size=info.get("size") if mode == "actionable" else None,
+        width=info.get("width") if mode == "actionable" else None,
+        height=info.get("height") if mode == "actionable" else None,
+        sha1=info.get("sha1") if mode == "actionable" else None,
+    )
+
+
+def fetch_url_resource(
+    url: str,
+    *,
+    mode: str = "head",
+    timeout: int = 10,
+    allow_redirects: bool = True,
+    accept: Optional[str] = None,
+    session: Optional[requests.Session] = None,
+) -> URLFetchResult:
+    """Fetch URL metadata or content for policy-driven online validation workflows.
+
+    Args:
+        url: Absolute URL to retrieve.
+        mode: ``head`` for HEARTBEAT checks or ``get`` for ACTIONABLE checks.
+        timeout: Request timeout in seconds.
+        allow_redirects: Whether redirects should be followed.
+        accept: Optional Accept header for content negotiation.
+        session: Optional requests session. New session is created when omitted.
+
+    Returns:
+        URLFetchResult with status, content type, and retrieval metadata.
+    """
+    request_mode = mode.lower().strip()
+    if request_mode not in {"head", "get"}:
+        return URLFetchResult(
+            url=url,
+            ok=False,
+            error=f"Unsupported fetch mode: {mode}",
+        )
+
+    client = session or requests.Session()
+    headers: dict[str, str] = {}
+    if accept:
+        headers["Accept"] = accept
+
+    try:
+        response = client.request(
+            request_mode,
+            url,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            headers=headers or None,
+        )
+    except requests.RequestException as exc:
+        return URLFetchResult(
+            url=url,
+            ok=False,
+            error=str(exc),
+        )
+
+    content_type = response.headers.get("Content-Type")
+    body_size: Optional[int] = None
+    if request_mode == "get":
+        try:
+            body_size = len(response.content)
+        except Exception:
+            body_size = None
+
+    return URLFetchResult(
+        url=url,
+        ok=response.ok,
+        status_code=response.status_code,
+        final_url=str(response.url) if response.url else None,
+        content_type=content_type,
+        response_size=body_size,
+        error=None if response.ok else f"HTTP {response.status_code}",
+    )
+
+
 _ENTITY_ID_PATTERN = re.compile(r"\b([QP]\d+)\b")
 _SPARQL_BLOCK_PATTERN = re.compile(
     r"<\s*sparql(?:\s+[^>]*)?>(.*?)</\s*sparql\s*>",

--- a/tests/test_fermenter_evaluator.py
+++ b/tests/test_fermenter_evaluator.py
@@ -1,0 +1,220 @@
+import hashlib
+import json
+from pathlib import Path
+
+from gkc.fermenter import (
+    ConformanceOutcome,
+    EntityEvaluation,
+    evaluate_entity,
+    evaluate_statement_claim,
+    validate_packet_from_file,
+    validate_packet_inline,
+)
+
+
+def _claim(value: object) -> dict:
+    return {
+        "mainsnak": {
+            "snaktype": "value",
+            "datavalue": {
+                "value": value,
+            },
+        }
+    }
+
+
+def _statement(
+    *,
+    statement_id: str,
+    data_type: str,
+    property_id: str,
+    max_count: int = 1,
+    value_list_reference: str | None = None,
+) -> dict:
+    value_block: dict[str, object] = {"type": data_type}
+    if value_list_reference:
+        value_block["value_list_reference"] = value_list_reference
+
+    return {
+        "id": statement_id,
+        "max_count": max_count,
+        "value": value_block,
+        "io_map": [{"to": f"http://www.wikidata.org/entity/{property_id}"}],
+    }
+
+
+def _canonical_digest(payload: dict) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _packet_template() -> dict:
+    metadata = {
+        "primary_profile": {
+            "name_identifier": "tribal_government_us",
+            "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+        },
+        "profiles": [],
+        "graph": {"nodes": [], "edges": []},
+        "mint": {
+            "minted_at": "2026-03-25T00:00:00Z",
+            "generator": "tests",
+            "gkc_version": "test",
+        },
+    }
+    metadata["integrity"] = {
+        "metadata_canonicalization": "json-sort-keys-v1",
+        "metadata_digest_algorithm": "sha256",
+        "metadata_digest": _canonical_digest(metadata),
+    }
+    return {
+        "packet_id": "pkt-test",
+        "operation_mode": "single",
+        "metadata": metadata,
+        "data": {"entities": []},
+    }
+
+
+def test_evaluate_statement_claim_conformant():
+    statement = _statement(
+        statement_id="https://datadistillery.wikibase.cloud/entity/Q19",
+        data_type="wikibase-item",
+        property_id="P31",
+    )
+    claim = _claim({"entity-type": "item", "numeric-id": 5, "id": "Q5"})
+
+    evaluation = evaluate_statement_claim(statement, [claim], entity_ref="Q195562")
+
+    assert evaluation.outcome == ConformanceOutcome.CONFORMANT
+    assert evaluation.normalized_value["id"] == "Q5"
+    assert not evaluation.notices
+
+
+def test_evaluate_statement_claim_missing_required():
+    statement = _statement(
+        statement_id="https://datadistillery.wikibase.cloud/entity/Q19",
+        data_type="wikibase-item",
+        property_id="P31",
+        max_count=1,
+    )
+
+    evaluation = evaluate_statement_claim(statement, [], entity_ref="Q195562")
+
+    assert evaluation.outcome == ConformanceOutcome.MISSING
+    assert any(notice.code == "statement_missing" for notice in evaluation.notices)
+
+
+def test_evaluate_statement_claim_non_conformant_mappable_datatype():
+    statement = _statement(
+        statement_id="https://datadistillery.wikibase.cloud/entity/Q29",
+        data_type="url",
+        property_id="P856",
+    )
+    claim = _claim("not-a-url")
+
+    evaluation = evaluate_statement_claim(statement, [claim], entity_ref="Q195562")
+
+    assert evaluation.outcome == ConformanceOutcome.NON_CONFORMANT_MAPPABLE
+    assert any(notice.code == "datatype_mismatch" for notice in evaluation.notices)
+
+
+def test_evaluate_statement_claim_non_conformant_mappable_value_list(tmp_path: Path):
+    cache_file = tmp_path / "cache" / "queries" / "Q28.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {
+                        "item": "http://www.wikidata.org/entity/Q5",
+                        "itemLabel": "human",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    statement = _statement(
+        statement_id="https://datadistillery.wikibase.cloud/entity/Q16",
+        data_type="wikibase-item",
+        property_id="P31",
+        value_list_reference="cache/queries/Q28.json",
+    )
+    claim = _claim({"entity-type": "item", "numeric-id": 1, "id": "Q1"})
+
+    evaluation = evaluate_statement_claim(
+        statement,
+        [claim],
+        entity_ref="Q195562",
+        value_list_root=tmp_path,
+    )
+
+    assert evaluation.outcome == ConformanceOutcome.NON_CONFORMANT_MAPPABLE
+    assert any(notice.code == "value_list_miss" for notice in evaluation.notices)
+
+
+def test_evaluate_entity_classifies_all_buckets():
+    s_instance_of = _statement(
+        statement_id="https://datadistillery.wikibase.cloud/entity/Q16",
+        data_type="wikibase-item",
+        property_id="P31",
+    )
+    s_country = _statement(
+        statement_id="https://datadistillery.wikibase.cloud/entity/Q40",
+        data_type="wikibase-item",
+        property_id="P17",
+    )
+
+    wikidata_item = {
+        "id": "Q195562",
+        "claims": {
+            "P31": [_claim({"entity-type": "item", "numeric-id": 5, "id": "Q5"})],
+            "P999": [_claim({"entity-type": "item", "numeric-id": 2, "id": "Q2"})],
+        },
+    }
+
+    evaluation: EntityEvaluation = evaluate_entity(
+        [s_instance_of, s_country],
+        wikidata_item,
+        io_map_index={"P31": s_instance_of, "P17": s_country},
+        entity_ref="Q195562",
+    )
+
+    assert len(evaluation.conformant) == 1
+    assert len(evaluation.missing) == 1
+    assert len(evaluation.to_be_defined) == 1
+    assert evaluation.is_conformant is False
+
+
+def test_validate_packet_inline_integrity_passes():
+    packet = _packet_template()
+
+    passed, notices = validate_packet_inline(packet)
+
+    assert passed is True
+    assert any(notice.code == "packet_integrity_pass" for notice in notices)
+
+
+def test_validate_packet_inline_integrity_mismatch_fails():
+    packet = _packet_template()
+    packet["metadata"]["mint"]["generator"] = "tampered"
+
+    passed, notices = validate_packet_inline(packet)
+
+    assert passed is False
+    assert notices[0].code == "metadata_digest_mismatch"
+
+
+def test_validate_packet_file_and_inline_parity(tmp_path: Path):
+    packet = _packet_template()
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    inline_result = validate_packet_inline(packet)
+    file_result = validate_packet_from_file(packet_path)
+
+    assert inline_result[0] is file_result[0]
+    assert [notice.code for notice in inline_result[1]] == [
+        notice.code for notice in file_result[1]
+    ]

--- a/tests/test_fermenter_validation_policy.py
+++ b/tests/test_fermenter_validation_policy.py
@@ -1,0 +1,397 @@
+import re
+
+from gkc.fermenter import (
+    ValidationPolicy,
+    ValidationPolicyConfig,
+    validate_by_datatype,
+    validate_commons_media,
+    validate_globe_coordinate,
+    validate_time,
+    validate_url,
+    validate_wikibase_item,
+    validate_with_pattern,
+)
+from gkc.mash import CommonsFileInfoResult, URLFetchResult
+
+
+def test_validate_url_coerces_www_prefix():
+    result = validate_url("www.wikidata.org")
+
+    assert result.valid is True
+    assert result.value == "https://www.wikidata.org"
+    assert any("Added https://" in warning for warning in result.warnings)
+    assert result.uncertainty > 0
+
+
+def test_validate_url_coerces_bare_domain_with_path():
+    result = validate_url("example.org/resource")
+
+    assert result.valid is True
+    assert result.value == "https://example.org/resource"
+
+
+def test_validate_url_heartbeat_online_success(monkeypatch):
+    policy = ValidationPolicy.HEARTBEAT
+
+    def fake_fetch(url: str, **kwargs):
+        assert url == "https://www.wikidata.org"
+        assert kwargs.get("mode") == "head"
+        return URLFetchResult(
+            url=url,
+            ok=True,
+            status_code=200,
+            final_url=url,
+            content_type="text/html",
+        )
+
+    monkeypatch.setattr("gkc.fermenter.fetch_url_resource", fake_fetch)
+
+    result = validate_url("https://www.wikidata.org", validation_policy=policy)
+
+    assert result.valid is True
+    assert not result.errors
+
+
+def test_validate_url_actionable_online_failure(monkeypatch):
+    policy = ValidationPolicy.ACTIONABLE
+
+    def fake_fetch(url: str, **kwargs):
+        assert kwargs.get("mode") == "get"
+        return URLFetchResult(
+            url=url,
+            ok=False,
+            status_code=503,
+            error="HTTP 503",
+        )
+
+    monkeypatch.setattr("gkc.fermenter.fetch_url_resource", fake_fetch)
+
+    result = validate_url("https://www.wikidata.org", validation_policy=policy)
+
+    assert result.valid is False
+    assert any("Online URL validation failed" in error for error in result.errors)
+    assert result.uncertainty == 1.0
+
+
+def test_validate_wikibase_item_coerces_uri_and_lowercase_qid():
+    uri_result = validate_wikibase_item("https://www.wikidata.org/entity/Q42")
+    lower_result = validate_wikibase_item("q42")
+
+    assert uri_result.valid is True
+    assert uri_result.value["id"] == "Q42"
+    assert any("Coerced item URI" in warning for warning in uri_result.warnings)
+
+    assert lower_result.valid is True
+    assert lower_result.value["id"] == "Q42"
+    assert any("Normalized lowercase" in warning for warning in lower_result.warnings)
+
+
+def test_validate_wikibase_item_online_with_custom_instance(monkeypatch):
+    class FakeClient:
+        def __init__(self, api_url: str, timeout: int):
+            self.api_url = api_url
+            self.timeout = timeout
+
+        def get_entity(self, entity_id: str):
+            assert self.api_url == "https://example.wikibase.org/w/api.php"
+            assert entity_id == "Q42"
+            return {"id": "Q42"}
+
+    monkeypatch.setattr("gkc.fermenter.WikibaseApiClient", FakeClient)
+
+    policy_config = ValidationPolicyConfig(
+        wikibase_api_url="https://example.wikibase.org/w/api.php",
+    )
+    result = validate_wikibase_item(
+        "Q42",
+        validation_policy=ValidationPolicy.HEARTBEAT,
+        policy_config=policy_config,
+    )
+
+    assert result.valid is True
+    assert result.value["wikibase-api-url"] == "https://example.wikibase.org/w/api.php"
+
+
+def test_validate_by_datatype_passes_validation_policy_for_url(monkeypatch):
+    policy = ValidationPolicy.HEARTBEAT
+
+    def fake_fetch(url: str, **kwargs):
+        return URLFetchResult(url=url, ok=True, status_code=200)
+
+    monkeypatch.setattr("gkc.fermenter.fetch_url_resource", fake_fetch)
+
+    result = validate_by_datatype(
+        "url",
+        "https://www.wikidata.org",
+        validation_policy=policy,
+    )
+
+    assert result.valid is True
+
+
+def test_validate_with_pattern_matches_string():
+    result = validate_with_pattern("AB-1234", r"^[A-Z]{2}-\d{4}$")
+
+    assert result.valid is True
+    assert result.value == "AB-1234"
+
+
+def test_validate_with_pattern_coerces_before_matching():
+    result = validate_with_pattern(2024, r"^2024$")
+
+    assert result.valid is True
+    assert result.value == "2024"
+    assert any("Coerced int to string" in warning for warning in result.warnings)
+
+
+def test_validate_with_pattern_rejects_non_matching_value():
+    result = validate_with_pattern("invalid", r"^[A-Z]{2}-\d{4}$")
+
+    assert result.valid is False
+    assert any("does not match required pattern" in error for error in result.errors)
+
+
+def test_validate_with_pattern_supports_regex_flags():
+    result = validate_with_pattern("cherokee nation", r"CHEROKEE", flags=re.IGNORECASE)
+
+    assert result.valid is True
+
+
+def test_validate_with_pattern_rejects_invalid_pattern():
+    result = validate_with_pattern("Cherokee", r"([A-Z]")
+
+    assert result.valid is False
+    assert any("Invalid regex pattern" in error for error in result.errors)
+
+
+# ============================================================================
+# commonsMedia validation policy tests
+# ============================================================================
+
+
+def test_validate_commons_media_structure_coerces_missing_prefix():
+    result = validate_commons_media("Example distillery.jpg")
+
+    assert result.valid is True
+    assert result.value == "File:Example distillery.jpg"
+    assert not result.errors
+
+
+def test_validate_commons_media_structure_preserves_file_prefix():
+    result = validate_commons_media("File:Example distillery.jpg")
+
+    assert result.valid is True
+    assert result.value == "File:Example distillery.jpg"
+    assert not result.errors
+
+
+def test_validate_commons_media_structure_normalizes_lowercase_prefix():
+    result = validate_commons_media("file:Example.jpg")
+
+    assert result.valid is True
+    assert result.value == "File:Example.jpg"
+    assert any("Normalized lowercase" in w for w in result.warnings)
+
+
+def test_validate_commons_media_structure_rejects_empty():
+    result = validate_commons_media("")
+
+    assert result.valid is False
+    assert any("cannot be empty" in e for e in result.errors)
+
+
+def test_validate_commons_media_heartbeat_file_exists(monkeypatch):
+    def fake_fetch_info(client, filename, *, mode="heartbeat"):
+        assert mode == "heartbeat"
+        assert filename == "File:Example.jpg"
+        return CommonsFileInfoResult(
+            filename=filename,
+            ok=True,
+            exists=True,
+            page_url="https://commons.wikimedia.org/wiki/File:Example.jpg",
+        )
+
+    monkeypatch.setattr("gkc.fermenter.fetch_commons_file_info", fake_fetch_info)
+
+    result = validate_commons_media(
+        "Example.jpg",
+        validation_policy=ValidationPolicy.HEARTBEAT,
+    )
+
+    assert result.valid is True
+    assert result.value == "File:Example.jpg"
+    assert not result.errors
+
+
+def test_validate_commons_media_heartbeat_file_missing(monkeypatch):
+    def fake_fetch_info(client, filename, *, mode="heartbeat"):
+        return CommonsFileInfoResult(
+            filename=filename,
+            ok=True,
+            exists=False,
+            error=f"File not found on Commons: {filename}",
+        )
+
+    monkeypatch.setattr("gkc.fermenter.fetch_commons_file_info", fake_fetch_info)
+
+    result = validate_commons_media(
+        "File:DoesNotExist.jpg",
+        validation_policy=ValidationPolicy.HEARTBEAT,
+    )
+
+    assert result.valid is False
+    assert any("not found" in e for e in result.errors)
+    assert result.uncertainty == 1.0
+
+
+def test_validate_commons_media_actionable_returns_metadata(monkeypatch):
+    def fake_fetch_info(client, filename, *, mode="heartbeat"):
+        assert mode == "actionable"
+        return CommonsFileInfoResult(
+            filename=filename,
+            ok=True,
+            exists=True,
+            page_url="https://commons.wikimedia.org/wiki/File:Example.jpg",
+            resource_url="https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg",
+            mime_type="image/jpeg",
+            size=102400,
+        )
+
+    monkeypatch.setattr("gkc.fermenter.fetch_commons_file_info", fake_fetch_info)
+
+    result = validate_commons_media(
+        "File:Example.jpg",
+        validation_policy=ValidationPolicy.ACTIONABLE,
+    )
+
+    assert result.valid is True
+    assert any("MIME type: image/jpeg" in w for w in result.warnings)
+    assert any("resource URL" in w for w in result.warnings)
+    assert any("102400 bytes" in w for w in result.warnings)
+
+
+def test_validate_commons_media_actionable_uses_custom_commons_url(monkeypatch):
+    captured = {}
+
+    def fake_client_init(api_url, timeout):
+        captured["api_url"] = api_url
+
+    class FakeClient:
+        def __init__(self, api_url, timeout):
+            captured["api_url"] = api_url
+
+    def fake_fetch_info(client, filename, *, mode="heartbeat"):
+        return CommonsFileInfoResult(filename=filename, ok=True, exists=True)
+
+    monkeypatch.setattr("gkc.fermenter.WikibaseApiClient", FakeClient)
+    monkeypatch.setattr("gkc.fermenter.fetch_commons_file_info", fake_fetch_info)
+
+    policy_config = ValidationPolicyConfig(
+        commons_api_url="https://test.commons.example.org/w/api.php",
+    )
+    validate_commons_media(
+        "File:Example.jpg",
+        validation_policy=ValidationPolicy.HEARTBEAT,
+        policy_config=policy_config,
+    )
+
+    assert captured["api_url"] == "https://test.commons.example.org/w/api.php"
+
+
+def test_validate_by_datatype_passes_validation_policy_for_commons_media(monkeypatch):
+    def fake_fetch_info(client, filename, *, mode="heartbeat"):
+        return CommonsFileInfoResult(filename=filename, ok=True, exists=True)
+
+    monkeypatch.setattr("gkc.fermenter.fetch_commons_file_info", fake_fetch_info)
+
+    result = validate_by_datatype(
+        "commonsMedia",
+        "File:Example.jpg",
+        validation_policy=ValidationPolicy.HEARTBEAT,
+    )
+
+    assert result.valid is True
+
+
+# ============================================================================
+# time and globe-coordinate coercion tests
+# ============================================================================
+
+
+def test_validate_time_accepts_year_string_and_fills_wikibase_fields():
+    result = validate_time("2024")
+
+    assert result.valid is True
+    assert result.value["time"] == "+2024-01-01T00:00:00Z"
+    assert result.value["precision"] == 9
+    assert result.value["timezone"] == 0
+    assert result.value["before"] == 0
+    assert result.value["after"] == 0
+    assert result.value["calendarmodel"] == "http://www.wikidata.org/entity/Q1985727"
+
+
+def test_validate_time_accepts_partial_iso_date_and_derives_precision():
+    result = validate_time("2024-03")
+
+    assert result.valid is True
+    assert result.value["time"] == "+2024-03-01T00:00:00Z"
+    assert result.value["precision"] == 10
+
+
+def test_validate_time_accepts_component_dict():
+    result = validate_time({"year": 2024, "month": 5, "day": 6})
+
+    assert result.valid is True
+    assert result.value["time"] == "+2024-05-06T00:00:00Z"
+    assert result.value["precision"] == 11
+    assert any("component fields" in warning for warning in result.warnings)
+
+
+def test_validate_time_accepts_minimal_wikibase_dict_and_fills_defaults():
+    result = validate_time({"time": "+2024-05-06T00:00:00Z"})
+
+    assert result.valid is True
+    assert result.value["timezone"] == 0
+    assert result.value["before"] == 0
+    assert result.value["after"] == 0
+    assert result.value["calendarmodel"] == "http://www.wikidata.org/entity/Q1985727"
+    assert any(
+        "Filled missing Wikibase time fields" in warning for warning in result.warnings
+    )
+
+
+def test_validate_globe_coordinate_accepts_string_pair_and_derives_precision():
+    result = validate_globe_coordinate("42.1234,-121.5000")
+
+    assert result.valid is True
+    assert result.value["latitude"] == 42.1234
+    assert result.value["longitude"] == -121.5
+    assert result.value["globe"] == "http://www.wikidata.org/entity/Q2"
+    assert result.value["precision"] > 0
+    assert any("Derived coordinate precision" in warning for warning in result.warnings)
+
+
+def test_validate_globe_coordinate_accepts_shorthand_dict_keys():
+    result = validate_globe_coordinate({"lat": "42.5", "lng": "-121.25"})
+
+    assert result.valid is True
+    assert result.value["latitude"] == 42.5
+    assert result.value["longitude"] == -121.25
+    assert any("shorthand coordinate keys" in warning for warning in result.warnings)
+
+
+def test_validate_globe_coordinate_accepts_dms_components():
+    result = validate_globe_coordinate(
+        {"latitude": "42 30 0 N", "longitude": "121 30 0 W"}
+    )
+
+    assert result.valid is True
+    assert result.value["latitude"] == 42.5
+    assert result.value["longitude"] == -121.5
+
+
+def test_validate_globe_coordinate_rejects_out_of_range_after_coercion():
+    result = validate_globe_coordinate("91.0,10.0")
+
+    assert result.valid is False
+    assert any("latitude must be between -90 and 90" in err for err in result.errors)

--- a/tests/test_mash.py
+++ b/tests/test_mash.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+import requests
 
 import gkc
 from gkc.mash import (
@@ -20,6 +21,7 @@ from gkc.mash import (
     extract_sparql_blocks,
     fetch_mediawiki_page_wikitext,
     fetch_recent_entity_changes,
+    fetch_url_resource,
     get_latest_cache_timestamp,
     refresh_entity_cache_from_recentchanges,
     strip_entity_identifiers,
@@ -476,6 +478,50 @@ def test_fetch_mediawiki_page_wikitext_from_revision_slots():
 
     text = fetch_mediawiki_page_wikitext(client, "Item_talk:Q4")
     assert "SELECT * WHERE" in text
+
+
+def test_fetch_url_resource_head_success():
+    """URL resource fetch supports HEARTBEAT HEAD checks."""
+
+    class FakeResponse:
+        ok = True
+        status_code = 200
+        url = "https://www.wikidata.org"
+        headers = {"Content-Type": "text/html"}
+        content = b""
+
+    class FakeSession:
+        def request(self, method, url, **kwargs):
+            assert method == "head"
+            assert url == "https://www.wikidata.org"
+            return FakeResponse()
+
+    result = fetch_url_resource(
+        "https://www.wikidata.org",
+        mode="head",
+        session=FakeSession(),
+    )
+
+    assert result.ok is True
+    assert result.status_code == 200
+    assert result.content_type == "text/html"
+
+
+def test_fetch_url_resource_get_failure():
+    """URL resource fetch returns deterministic errors on request failures."""
+
+    class FakeSession:
+        def request(self, method, url, **kwargs):
+            raise requests.RequestException("network unavailable")
+
+    result = fetch_url_resource(
+        "https://www.wikidata.org",
+        mode="get",
+        session=FakeSession(),
+    )
+
+    assert result.ok is False
+    assert result.error
 
 
 def test_wikidata_loader_snak_to_value_entity():


### PR DESCRIPTION
## Summary

This PR delivers the first full atomic validator suite for the fermenter module, completing the coercion-first validator contract and the evaluator scaffolding defined in issue #164 Phase C.

## What ships

### Core datatype validators (coercion-first)
- `validate_url` — www-prefix and bare-domain coercion; HEARTBEAT and ACTIONABLE policy stages
- `validate_time` — year string, partial ISO date, component dict, and full Wikibase dict coercion with precision derivation
- `validate_globe_coordinate` — DMS, string-pair, and shorthand dict coercion with precision derivation
- `validate_wikibase_item` — QID, URI, and lowercase-QID coercion with online instance resolution
- `validate_with_pattern` — constraint-layer regex validator composing over validate_string
- `validate_commons_media` — File:-prefix coercion; HEARTBEAT and ACTIONABLE policy stages with metadata enrichment

### Value-list and constraint validation
- `validate_value_from_list` — multi-format resolver (full URI, QID string, wizard dict, Wikibase snak, fuzzy label); supports items-array and SPARQL-bindings cache formats
- `enforce_fixed_value` — exact and fuzzy match enforcement with uncertainty model

### Evaluator scaffolding (issue #164 Phase C)
- `ConformanceOutcome`, `StatementEvaluation`, `EntityEvaluation` — atomic result types
- `normalize_claim_value` — extract and coerce from raw Wikidata claim dict
- `evaluate_statement_claim` — four-outcome classifier: CONFORMANT, NON_CONFORMANT_MAPPABLE, UNCOVERED, MISSING_REQUIRED
- `evaluate_entity` — aggregate evaluation across all profile statements
- `check_packet_integrity` — sha256 metadata digest gate (hard-fail before data validation)
- `validate_packet_inline` / `validate_packet_from_file` — notebook-friendly parity entry points

### Mash module
- `fetch_url_resource`, `CommonsFileInfoResult`, `fetch_commons_file_info`
- `WikibaseApiClient` for online item and schema resolution

## Tests
- 56 test functions across 3 new test files
- `test_fermenter_validation_policy.py`: 29 tests (URL, wikibase item, time, coordinate, commons media, pattern)
- `test_fermenter_evaluator.py`: 8 tests (four-outcome classification, packet integrity gate, file/inline parity)
- `test_mash.py`: expanded mash module coverage

## Docs
- Full public API coverage in `docs/gkc/api/fermenter.md` with usage code blocks for all public functions
- Updated `docs/architecture/validation-architecture.md` — coercion-first contract, policy stages, evaluator model
- Updated `docs/architecture/DataDistillery-Wikibase.md` — evaluation architecture notes

## Validation
- `bash scripts/pre-merge-check.sh` — full pass (ruff, black, pytest 503 tests, mkdocs strict, package build)

## Closes
- #107 URL coercion and normalization
- #104 Time datatype coercion and precision normalization
- #105 Item QID coercion and allowed-items validation
