### PR TITLE
Curation Packet documentation alignment for #164

### DIFF
--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -76,10 +76,13 @@ Current anchor surface:
 
 - `create_curation_packet`
 - `build_curation_packet_from_json_profile`
-- `charge_curation_packet`
-- `charge_packet_from_wikidata_items`
+- `charge_packet_from_wikidata_items` (active Wikidata charging path)
 - `ChargeReport`
 - `ChargeIssue`
+
+Legacy surface (preserved for existing integrations; new workflows should use `charge_packet_from_wikidata_items`):
+
+- `charge_curation_packet`
 
 ### Fermenter (`gkc.fermenter`)
 
@@ -100,9 +103,18 @@ Out of scope:
 Current anchor surface:
 
 - `ConformanceNotice`
+- `ConformanceOutcome` (string enum: `CONFORMANT`, `NON_CONFORMANT_MAPPABLE`, `UNCOVERED`, `MISSING_REQUIRED`)
+- `StatementEvaluation`
+- `EntityEvaluation`
 - `ValidationResult`
 - `validate_*` datatype validators
 - `coerce_*` datatype coercers
+- `normalize_claim_value`
+- `evaluate_statement_claim`
+- `evaluate_entity`
+- `check_packet_integrity`
+- `validate_packet_inline`
+- `validate_packet_from_file`
 
 ### Bottler (`gkc.bottler`)
 
@@ -259,12 +271,10 @@ When adding new functionality, assign ownership using this matrix:
 
 ## Current Gaps to Revisit During Critical Analysis
 
-- Still Charger URI-keyed packet assembly and source resolution are still in active migration from profile-name keyed behavior.
-- Fermenter module implementation is pending; current validation/coercion logic remains distributed and not yet unified.
+- Still Charger `charge_packet_from_wikidata_items` does not yet call the fermenter evaluator (`evaluate_entity`) to partition charged statements into conformant/non_conformant/uncovered/missing_required buckets. The fermenter evaluator API is implemented (PR #170); the still_charger integration is the next implementation step.
+- Still Charger does not yet emit `conformance_summary` in packet metadata or per-entity source provenance (`source_qid`, `lastrevid`, `pulled_at`).
 - Boundaries between wikibase write planning and bottler transformation stages still need explicit acceptance criteria per phase.
-- Wikibase orchestration should continue preferring composition over new transport abstractions.
 - Cross-module tests should identify failure source by layer (read, transform, payload-shape, write, orchestration).
-- Curation packet v2 contract migration from profile-name keys to entity-URI keys remains unfinished and is the next high-risk integration step.
 - Packet compatibility metadata, change classification, and forward-migration rules for long-lived offline packets remain to be implemented.
 
 ## Theoretical Design Notes

--- a/docs/architecture/spirit_safe_models.md
+++ b/docs/architecture/spirit_safe_models.md
@@ -1,6 +1,6 @@
 ---
 title: SpiritSafe Integration Architecture
-description: URI-keyed artifact indexing, profile graph traversal, and packet scaffolding
+description: Artifact indexing, profile graph traversal, and packet scaffolding
 ---
 
 # SpiritSafe Integration Architecture
@@ -36,9 +36,12 @@ Implemented and committed:
 
 ## Identity Model
 
-- Canonical identity is full entity URI.
-- QIDs are normalized from URI tails when needed for file resolution and graph keys.
-- Labels are display fields only and are never used as join keys.
+SpiritSafe artifacts and curation packets use a dual-key identity model:
+
+- `name_identifier` — primary human-facing key, derived from the DD Wikibase `name_identifier` property (P214). Used as statement slot keys in packet data, graph node identifiers, and profile reference labels.
+- Full entity URI — immutable canonical identity for joining, provenance, and round-trip mapping to the Wikibase instance. Stored in the `id` field throughout.
+
+QIDs are normalized from URI tails only where file path resolution requires them. Labels are display-only and are never used as join keys.
 
 ## Manifest Model
 
@@ -74,31 +77,37 @@ Normalization rules:
 
 ## Packet Scaffolding Model
 
-`still_charger.create_curation_packet()` outputs:
+`still_charger.create_curation_packet()` and `still_charger.build_curation_packet_from_json_profile()` produce a two-section packet:
 
-- `packet_id`
-- `operation_mode`
-- `created_at`
-- `primary_profile` and `primary_profile_entity`
-- `entities`
-- `cross_references`
-- `cardinality_constraints`
-- `profile_package`
+- `metadata` — the complete profile ruleset, unified graph, mint provenance, and SHA-256 integrity digest.
+- `data` — fillable entity slots.
 
-Entity scaffolds carry:
+Top-level packet fields:
 
-- packet-local ID (`ent-001`)
-- `profile` (QID)
-- `profile_entity` (URI)
-- empty `data`
-- `profile_structure` copied from JSON profile content
+- `packet_id` — UUID-based identifier
+- `operation_mode` — `new`, `single`, or `bulk`
+- `metadata.primary_profile` — `name_identifier` and `id` (URI) for the primary profile
+- `metadata.profiles` — array of full profile definitions (statements, identification, metadata) for all profiles in packet scope
+- `metadata.graph` — unified graph with `nodes` keyed by `name_identifier` and `edges` encoding both profile-to-profile and profile-to-value-list relationships
+- `metadata.mint` — `minted_at`, `generator`, `gkc_version`
+- `metadata.integrity` — SHA-256 digest of canonical metadata JSON; used as fermenter go/no-go gate on re-entry
+- `data.entities` — array of entity slots
 
-Within `profile_structure.statements[*].value`, SpiritSafe JSON can include derived-value hints for nested references/qualifiers:
+Entity slots in `data.entities` carry:
+
+- `profile` — profile `name_identifier`
+- `id` — profile URI (canonical entity identity for this slot)
+- Language-keyed `labels`, `descriptions`, `aliases` slots — each value is `{"data-value": ""}`; no inner language tag
+- `statements` — object keyed by statement `name_identifier`, each slot including `id` (statement URI), `data-type`, `data-value`, and optionally `value-list`, `qualifiers`, and `references`
+
+Qualifiers and references are omitted when the profile does not specify them. When used as a reference or qualifier, a statement does not carry its own nested references or qualifiers.
+
+Derived-value hints from SpiritSafe JSON (P213 semantics) appear within statement `value` objects:
 
 - `value_source: statement_value`
-- `value_source_statement: <statement URI>`
+- `value_source_statement: <parent statement URI>`
 
-These hints are derived from statement-level Wikibase semantics and are intended for downstream wizard/validation consumers.
+These are derived from DD Wikibase statement-level semantics and are intended for downstream wizard/validation consumers.
 
 ## Testing Strategy
 
@@ -112,5 +121,6 @@ These hints are derived from statement-level Wikibase semantics and are intended
 
 ## Theoretical Design Notes
 
-- Shared conformance notice envelopes across charging, barreling, and validation remain planned but are not yet a finalized runtime contract.
-- Wizard-facing packet consumption can move toward stricter URI-first keys and richer value-list routing metadata once downstream integration milestones land.
+**Packet migration tooling** — When a long-lived packet returns after SpiritSafe state has changed, a forward migration utility will classify drift and apply approved transforms before re-validation. The `metadata.mint` fields provide the provenance anchor. Change classification categories (`patch_compatible`, `minor_compatible`, `migration_required`, `breaking`) and a migration report are the planned output. Not yet implemented.
+
+**Fermenter-driven charged packet integration** — The `charge_packet_from_wikidata_items` path in `still_charger` does not yet use the fermenter evaluator (`evaluate_entity`) to partition charged statements into conformant/non_conformant/uncovered/missing_required buckets. This is the next implementation step; the fermenter evaluator API is ready. See [Cross-Module Contracts](module-contracts.md) for current gap notes.

--- a/docs/gkc/api/still_charger.md
+++ b/docs/gkc/api/still_charger.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-The `gkc.still_charger` module fills curation packet scaffolds with concrete source values before Wikibase write planning and shipper planning.
+The `gkc.still_charger` module assembles curation packet scaffolds from JSON Entity Profiles and fills them with concrete source values before Wikibase write planning.
 
-It supports both local-profile packet assembly (new URI-keyed contract) and specificationless charging for open-ended source data.
+All packets enforce a strict `metadata` / `data` split. The `metadata` section carries the full profile ruleset, unified graph, mint provenance, and an integrity digest. The `data` section contains fillable entity slots keyed by statement `name_identifier`.
+
 Validation and coercion notices are emitted as `ConformanceNotice` objects (see [Fermenter API](fermenter.md)).
 
 ## Quick Start: Build and Charge a Packet
@@ -12,36 +13,23 @@ Validation and coercion notices are emitted as `ConformanceNotice` objects (see 
 ```python
 from pathlib import Path
 from gkc.still_charger import (
-  create_curation_packet,
-    build_curation_packet_from_json_profile,
+    create_curation_packet,
     charge_packet_from_wikidata_items,
 )
-
 from gkc.spirit_safe import set_spirit_safe_source
 
 set_spirit_safe_source(mode="local", local_root="/path/to/SpiritSafe")
 
-# 0. Create scaffold directly from profile id (canonical entrypoint)
-packet = create_curation_packet("Q4", operation_mode="bulk")
-
-# 1. Load a JSON profile from local SpiritSafe
-import json
-profile_path = Path("/path/to/SpiritSafe/profiles/Q4.json")
-json_profile_doc = json.loads(profile_path.read_text())
-
-profile_entity = "https://datadistillery.wikibase.cloud/entity/Q4"
-
-# 2. Assemble the packet scaffold
-packet = build_curation_packet_from_json_profile(
-    profile_entity=profile_entity,
-    json_profile_doc=json_profile_doc,
-    source_root=Path("/path/to/SpiritSafe"),
-)
+# 1. Create uncharged scaffold from profile QID (canonical entrypoint)
+packet = create_curation_packet("Q4", operation_mode="single")
 
 print(packet["packet_id"])
-print(len(packet["data"]["entities"]))
+# Entity slots are keyed by name_identifier in data.entities
+for entity in packet["data"]["entities"]:
+    print(entity["profile"], list(entity["statements"].keys()))
 
-# 3. Charge from Wikidata (e.g., Cherokee Nation Q195562)
+# 2. Charge from Wikidata (Cherokee Nation Q195562)
+# qid_map accepts profile entity URI or name_identifier as keys
 qid_map = {entity["id"]: "Q195562" for entity in packet["data"]["entities"]}
 charged_packet, notices = charge_packet_from_wikidata_items(packet, qid_map)
 
@@ -95,9 +83,50 @@ packet = build_curation_packet_from_json_profile(
 | `json_profile_doc` | `dict` | Parsed JSON Entity Profile document |
 | `source_root` | `Path \| None` | Local SpiritSafe root for value-list route resolution (optional) |
 
-**Returns:** `dict` — The assembled packet with the frozen URI-keyed contract:
+**Returns:** `dict` — The assembled packet with the two-section contract:
 
 ```json
+{
+  "packet_id": "pkt-...",
+  "operation_mode": "new",
+  "metadata": {
+    "primary_profile": {
+      "name_identifier": "tribal_government_us",
+      "id": "https://datadistillery.wikibase.cloud/entity/Q4"
+    },
+    "profiles": [
+      {
+        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "name_identifier": "tribal_government_us",
+        "identification": {},
+        "statements": [],
+        "metadata": {}
+      }
+    ],
+    "graph": {"nodes": {}, "edges": []},
+    "mint": {"minted_at": "...", "generator": "...", "gkc_version": "..."},
+    "integrity": {"metadata_digest": "..."}
+  },
+  "data": {
+    "entities": [
+      {
+        "profile": "tribal_government_us",
+        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "labels": {"mul": {"data-value": ""}},
+        "descriptions": {"mul": {"data-value": ""}},
+        "aliases": {"mul": {"data-value": ""}},
+        "statements": {
+          "instance_of": {
+            "id": "https://datadistillery.wikibase.cloud/entity/Q16",
+            "data-type": "wikibase-item",
+            "data-value": "https://www.wikidata.org/entity/Q7840353"
+          }
+        }
+      }
+    ]
+  }
+}
+```
 {
   "packet_id": "pkt-...",
   "operation_mode": "new",
@@ -108,22 +137,6 @@ packet = build_curation_packet_from_json_profile(
     },
     "profiles": [],
     "graph": {"nodes": [], "edges": []}
-  },
-  "data": {
-    "entities": [
-      {
-        "profile": "Q4",
-        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
-        "labels": {},
-        "descriptions": {},
-        "aliases": {},
-        "statements": {}
-      }
-    ]
-  }
-}
-```
-
 ---
 
 ### `charge_packet_from_wikidata_items()`
@@ -150,33 +163,31 @@ warnings = [n for n in notices if n.severity == "warning"]
 | `qid_map` | `dict[str, str]` | Maps entity IDs or profile entity URIs to Wikidata QIDs |
 | `mash_client` | `Any \| None` | Optional pre-configured mash client; creates a new one if not supplied |
 
-**Returns:** `tuple[dict, list[ConformanceNotice]]`
-
-- `dict`: The charged packet with each entity's `data` populated from Wikidata
-- `list[ConformanceNotice]`: Notices emitted during charging (errors, warnings, info)
-
 **QID resolution order for entity slots:**
 
-1. Intra-packet UUID → exact key match in `qid_map`
-2. Full entity URI → key match in `qid_map`
-3. Profile entity URI tail QID → direct Wikidata lookup
+1. Full profile entity URI — exact key match in `qid_map`
+2. Profile `name_identifier` — key match in `qid_map`
+3. Profile entity URI tail QID — direct Wikidata lookup fallback
+
+**Returns:** `tuple[dict, list[ConformanceNotice]]`
+
+- `dict`: Charged packet with `data-value` fields populated in each entity slot. Statements are partitioned into conformant, non_conformant (with `non_conformant: true` and `notices`), and uncovered (under `entity.uncovered_statements`). Missing-required statements remain with `data-value: null` and attached notices.
+- `list[ConformanceNotice]`: All conformance notices from the charging pass.
 
 ---
 
-### `charge_curation_packet()`
+### `charge_curation_packet()` (Legacy)
 
-Charge a packet directly from a source-values dict. Useful for bulk operations where
-data has already been fetched or transformed before packet assembly.
+Charge a packet directly from a source-values dict. This is a legacy path for bulk operations where data has already been fetched and transformed before packet assembly. New workflows should use `charge_packet_from_wikidata_items()` instead.
 
 ```python
 from gkc.still_charger import charge_curation_packet
 
 source_values = {
-    "ent-001": {
-        "labels": {"en": "Cherokee Nation"},
+    "https://datadistillery.wikibase.cloud/entity/Q4": {
+        "labels": {"mul": {"data-value": "Cherokee Nation"}},
         "statements": {
-            "instance_of": [{"value": "Q7840353"}],
-            "official_website": [{"value": "https://www.cherokee.org"}],
+            "instance_of": [{"data-value": "https://www.wikidata.org/entity/Q7840353"}],
         },
     }
 }

--- a/docs/gkc/cli/profiles.md
+++ b/docs/gkc/cli/profiles.md
@@ -134,10 +134,13 @@ gkc packet build --profile Q4 --source github --repo skybristol/SpiritSafe --ref
 The output packet includes:
 
 - `packet_id` — UUID for this packet
-- `operation_mode` — Scaffold mode indicator
-- `metadata.primary_profile` — Full URI and identifier for the source profile
-- `metadata.graph.edges[]` — Linked-profile graph edges for packet traversal
-- `data.entities[]` — Entity slots with statement slots pre-scaffolded
+- `operation_mode` — scaffold mode indicator
+- `metadata.primary_profile` — `name_identifier` and full URI for the source profile
+- `metadata.profiles` — full profile definitions (statements, identification, metadata) for all profiles in scope
+- `metadata.graph` — unified graph combining profile-to-profile and profile-to-value-list relationships, with `name_identifier` as primary node identifier
+- `metadata.mint` — `minted_at`, `generator`, `gkc_version`
+- `metadata.integrity` — SHA-256 digest of canonical metadata JSON
+- `data.entities[]` — entity slots with statement slots pre-scaffolded, keyed by statement `name_identifier`
 
 ### `gkc packet charge`
 
@@ -169,7 +172,15 @@ gkc packet charge \
 | `--mapping-file` | Alternatively to `--qid` | JSON file mapping entity IDs to QIDs |
 | `-o` / `--output` | No | Write charged packet JSON to file instead of stdout |
 
-The output is the charged packet with each entity slot's `data` populated and `notices[]` listing any `ConformanceNotice` items raised during charging.
+The output is the charged packet with each entity slot’s statement slots populated. Charged packets include:
+
+- `data-value` fields filled in for conformant statements
+- Non-conformant statements flagged with `non_conformant: true` and a `notices` array of reason codes
+- `entity.uncovered_statements` for Wikidata properties not modeled in the profile, keyed by Wikidata PID
+- Missing-required statements left with `data-value: null` and attached notices
+- `metadata.conformance_summary` with per-outcome counts (`conformant`, `non_conformant`, `uncovered`, `missing_required`) and observed notice codes
+
+All `ConformanceNotice` items raised during charging are also listed in the top-level `notices[]` array.
 
 ### `gkc packet info`
 

--- a/docs/gkc/entity-json-schema.md
+++ b/docs/gkc/entity-json-schema.md
@@ -29,12 +29,14 @@ The current pipeline is:
 6. Bottling transforms packet content to destination-specific payloads.
 7. Shipping sends destination-specific payloads to Commons Partners (Wikidata, etc.).
 
-## Canonical Identity Rules
+## Identity Model
 
-- Canonical profile and statement identity is URI-first.
-- QIDs are convenience forms derived from URI tails.
-- Labels are display content and are not join keys.
-- Cross-entity references inside packets use packet-local entity IDs until shipping resolves external IDs.
+Curation packets use a dual-key identity model:
+
+- `name_identifier` is the primary human-facing key for all interaction surfaces — statement slots in packet data, graph node identifiers, and the profile reference label on each entity slot.
+- `id` (full entity URI) is the immutable canonical identity used for joining, provenance, and round-trip mapping to the Wikibase instance.
+
+Neither key is optional. QIDs are convenience forms derived from URI tails and are used only where file paths require them. Labels are display content and are never used as join keys.
 
 ## JSON Entity Profile Contract
 
@@ -67,9 +69,14 @@ Within `value`, profiles may include derived-default hints for nested statements
 
 These are consumed by downstream wizard/validation paths and are not UI-only fields.
 
-## Curation Packet Scaffold Contract
+## Curation Packet Structure
 
-The active scaffold contract produced by `build_curation_packet_from_json_profile(...)` is:
+All curation packets enforce a strict two-section top-level structure:
+
+- `metadata` — the ruleset, provenance, and integrity information for this packet. This section is sealed with a SHA-256 digest at mint time and must not be modified after generation.
+- `data` — the fillable data slots for each entity in the packet.
+
+### Top-Level Packet Shape
 
 ```json
 {
@@ -77,13 +84,38 @@ The active scaffold contract produced by `build_curation_packet_from_json_profil
   "operation_mode": "new",
   "metadata": {
     "primary_profile": {
-      "name_identifier": "Q4",
+      "name_identifier": "tribal_government_us",
       "id": "https://datadistillery.wikibase.cloud/entity/Q4"
     },
-    "profiles": [],
+    "profiles": [
+      {
+        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "name_identifier": "tribal_government_us",
+        "identification": {},
+        "statements": [],
+        "metadata": {}
+      }
+    ],
     "graph": {
-      "nodes": [],
+      "nodes": {
+        "tribal_government_us": {
+          "kind": "profile",
+          "name_identifier": "tribal_government_us",
+          "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+          "label": "Tribal Government in the United States"
+        }
+      },
       "edges": []
+    },
+    "mint": {
+      "minted_at": "2026-03-26T00:00:00Z",
+      "generator": "gkc.still_charger.build_curation_packet_from_json_profile",
+      "gkc_version": "0.x.y"
+    },
+    "integrity": {
+      "metadata_canonicalization": "json-sort-keys-v1",
+      "metadata_digest_algorithm": "sha256",
+      "metadata_digest": "<sha256 hex digest of canonical metadata JSON>"
     }
   },
   "data": {
@@ -92,94 +124,166 @@ The active scaffold contract produced by `build_curation_packet_from_json_profil
 }
 ```
 
-### Packet Fields
+### Packet Metadata Fields
 
-| Field | Type | Required | Meaning |
-|---|---|---|---|
-| `packet_id` | string | Yes | Packet-local identifier |
-| `operation_mode` | string | Yes | Current mode (`new` in scaffold builder) |
-| `metadata.primary_profile.id` | string | Yes | Primary profile URI used to mint packet |
-| `metadata.profiles` | array | Yes | Profile metadata and statement definitions in packet scope |
-| `metadata.graph.edges` | array | Yes | URI-aware profile graph edges |
-| `data.entities` | array | Yes | Entity slots in this packet |
-| `minted_from` | object | No (recommended) | Provenance and compatibility metadata |
-| `compatibility_status` | string | No | Re-entry compatibility outcome |
-| `migration_report` | object | No | Migration actions and warnings |
+| Field | Type | Meaning |
+|---|---|---|
+| `packet_id` | string | UUID-based packet identifier |
+| `operation_mode` | string | `new` for uncharged scaffold; `single` or `bulk` for scoped charging |
+| `metadata.primary_profile.name_identifier` | string | Human-facing name identifier for the primary profile |
+| `metadata.primary_profile.id` | string | Canonical URI for the primary profile |
+| `metadata.profiles` | array | Full profile definitions (statements, identification, metadata) for all profiles in scope |
+| `metadata.graph` | object | Unified profile and value-list graph with `nodes` (by name_identifier) and `edges` |
+| `metadata.mint` | object | Mint provenance: `minted_at`, `generator`, `gkc_version` |
+| `metadata.integrity` | object | SHA-256 digest of canonical metadata JSON; used as a fermenter go/no-go gate on re-entry |
 
-### Entity Slot Scaffold Shape
+### Uncharged Entity Slot Shape
 
-Each entry in `data.entities[]` includes:
+Each entry in `data.entities[]` is pre-scaffolded from profile definitions with empty value slots ready to be filled:
 
 ```json
 {
-  "profile": "Q4",
+  "profile": "tribal_government_us",
   "id": "https://datadistillery.wikibase.cloud/entity/Q4",
   "labels": {"mul": {"data-value": ""}},
   "descriptions": {"mul": {"data-value": ""}},
   "aliases": {"mul": {"data-value": ""}},
   "statements": {
-    "Q16": {
+    "instance_of": {
       "id": "https://datadistillery.wikibase.cloud/entity/Q16",
-      "data-type": "item",
-      "data-value": ""
+      "data-type": "wikibase-item",
+      "data-value": "https://www.wikidata.org/entity/Q7840353"
+    },
+    "official_website": {
+      "id": "https://datadistillery.wikibase.cloud/entity/Q19",
+      "data-type": "url",
+      "data-value": null,
+      "value-list": "cache/queries/Q28.json",
+      "references": {
+        "stated_in": [
+          {
+            "id": "https://datadistillery.wikibase.cloud/entity/Q30",
+            "data-type": "wikibase-item",
+            "data-value": null
+          }
+        ],
+        "reference_url": [
+          {
+            "id": "https://datadistillery.wikibase.cloud/entity/Q29",
+            "data-type": "url",
+            "data-value": null
+          }
+        ]
+      }
     }
   }
 }
 ```
 
-| Field | Type | Required | Meaning |
-|---|---|---|---|
-| `profile` | string | Yes | Profile name identifier for this entity slot |
-| `id` | string | Yes | Entity URI for this slot |
-| `labels/descriptions/aliases` | object | Yes | Identification field slots |
-| `statements` | object | Yes | Statement slot map keyed by statement identifier |
+| Field | Type | Meaning |
+|---|---|---|
+| `profile` | string | Profile `name_identifier` for this entity slot |
+| `id` | string | Profile URI — canonical entity identity for this slot |
+| `labels` / `descriptions` / `aliases` | object | Language-keyed slots. Each value is `{"data-value": ""}` — no inner language tag. |
+| `statements` | object | Statement slots keyed by statement `name_identifier` |
 
-## Charged Entity Data Contract
+**Statement slot fields:**
 
-After charging, `entity.data` is populated with normalized content.
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | string | Statement entity URI |
+| `data-type` | string | Wikibase data type (e.g., `wikibase-item`, `url`, `string`, `time`) |
+| `data-value` | any | The value — empty string or `null` when uncharged; pre-filled for fixed/single-option defaults |
+| `value-list` | string | Relative path to the value-list cache file, when applicable |
+| `qualifiers` | object | Present only when the profile specifies qualifiers; same slot shape, keyed by qualifier `name_identifier` |
+| `references` | object | Present only when the profile specifies references; keyed by reference statement `name_identifier`, each an array of slot objects |
 
-Common fields:
+Qualifiers and references are omitted entirely when the profile does not specify them. When a statement is used as a reference or qualifier, it does not carry its own nested `references` or `qualifiers`.
 
-- `labels`
-- `descriptions`
-- `aliases`
-- `statements`
+## Charged Entity Slot Shape
 
-`data.statements` is keyed by statement URI, not by display label.
-
-Example:
+Charging populates each entity slot's `data-value` fields and partitions statements into conformance buckets. The entity slot structure expands from the uncharged shape:
 
 ```json
 {
-  "data": {
-    "labels": {
-      "en": "Cherokee Nation"
+  "profile": "tribal_government_us",
+  "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+  "labels": {"mul": {"data-value": "Cherokee Nation"}},
+  "descriptions": {"mul": {"data-value": "federally recognized Native American tribe"}},
+  "aliases": {"mul": {"data-value": ""}},
+  "statements": {
+    "instance_of": {
+      "id": "https://datadistillery.wikibase.cloud/entity/Q16",
+      "data-type": "wikibase-item",
+      "data-value": "https://www.wikidata.org/entity/Q7840353"
     },
-    "descriptions": {},
-    "aliases": {},
-    "statements": {
-      "https://datadistillery.wikibase.cloud/entity/Q16": [
-        {
-          "value": {"id": "Q7840353"},
-          "qualifiers": {},
-          "references": []
-        }
-      ]
+    "official_website": {
+      "id": "https://datadistillery.wikibase.cloud/entity/Q19",
+      "data-type": "url",
+      "data-value": "https://www.cherokee.org",
+      "value-list": "cache/queries/Q28.json"
+    },
+    "population": {
+      "id": "https://datadistillery.wikibase.cloud/entity/Q21",
+      "data-type": "quantity",
+      "data-value": null,
+      "non_conformant": true,
+      "notices": ["datatype_mismatch"]
     }
+  },
+  "uncovered_statements": {
+    "P18": [
+      {
+        "data-type": null,
+        "data-value": "Cherokee_Nation_Capitol.jpg"
+      }
+    ]
   }
 }
 ```
 
-### Nested Qualifier and Reference Shape
+### Conformance Buckets
 
-Nested qualifiers and references may appear in statement-shaped map form keyed by nested statement URI.
+Charged statements are classified by the fermenter evaluator into four outcomes:
 
-Typical nested shape:
+| Outcome | Meaning | Packet location |
+|---|---|---|
+| `CONFORMANT` | Value matched profile data-type, value-list, and fixed-value constraints | `statements[name_identifier].data-value` populated |
+| `NON_CONFORMANT_MAPPABLE` | Value present but failed a constraint; retained for curator review | `statements[name_identifier]` with `non_conformant: true` and `notices` array |
+| `MISSING_REQUIRED` | Profile expected this statement but source had none | `statements[name_identifier].data-value` remains `null`; notice attached |
+| `UNCOVERED` | Source had this property but the profile does not model it | `entity.uncovered_statements` keyed by Wikidata PID |
 
-- `qualifiers`: object keyed by statement URI with list values.
-- `references`: object keyed by statement URI with list values, or an empty list where no references are provided.
+### Source Provenance (per entity, in metadata)
 
-Validation/coercion layers should normalize accepted nested forms and report shape violations as conformance notices.
+When charging from Wikidata, each entity's source metadata is recorded under `metadata.profiles[i]` alongside the profile definition:
+
+```json
+{
+  "source_qid": "Q195562",
+  "lastrevid": 1234567890,
+  "pulled_at": "2026-03-26T10:00:00Z"
+}
+```
+
+`lastrevid` is used when a charged packet reaches the bottling/shipping stage to detect whether the Wikidata item has changed since the packet was minted.
+
+### Conformance Summary (in packet metadata)
+
+A `conformance_summary` field is added to packet metadata after charging:
+
+```json
+{
+  "conformance_summary": {
+    "conformant": 5,
+    "non_conformant": 1,
+    "uncovered": 2,
+    "missing_required": 0,
+    "notice_codes": ["datatype_mismatch", "statement_uncovered"]
+  }
+}
+```
+
+This allows callers to do a single-field go/no-go check without walking the full notice list.
 
 ## Conformance and Blocking Policy
 
@@ -192,60 +296,15 @@ Current policy direction:
 - `max_count` is an upper-bound target; effective lower bound is zero unless explicit minimum policy is introduced.
 - Derived-value and fixed/list constraints are enforced according to profile directives and resolver context.
 
-## Packet Re-entry, Compatibility, and Migration
+## Packet Re-entry and Integrity
 
-Long-lived packets may return after SpiritSafe/Wikibase state has changed.
+Curation packets carry a SHA-256 digest of their canonical metadata at mint time (`metadata.integrity.metadata_digest`). When a packet is presented back to the fermenter for validation, this digest is recomputed and compared. A digest mismatch is a hard failure — no data validation proceeds until integrity is confirmed. This ensures that the ruleset embedded in the packet has not drifted from the one used during curation.
 
-To support deterministic handling, packets should carry `minted_from` metadata.
+For long-lived packets that return after SpiritSafe or Data Distillery state has changed, the `metadata.mint` provenance fields (`minted_at`, `gkc_version`) provide a basis for drift classification. Formal packet migration tooling — including change classification (`patch_compatible`, `minor_compatible`, `migration_required`, `breaking`) and a migration report — is planned but not yet implemented.
 
-### Recommended `minted_from` Fields
+### Theoretical Design Notes
 
-| Field | Type | Meaning |
-|---|---|---|
-| `packet_contract_version` | string | Version of packet compatibility contract |
-| `spiritsafe_commit` | string | SpiritSafe git commit used at mint time |
-| `dd_revision` | string | Data Distillery revision watermark or snapshot ID |
-| `profiles` | array | Per-profile records used to mint packet |
-| `value_lists` | array | Value-list snapshot records used to mint packet |
-| `minted_at` | string | Mint timestamp (ISO 8601) |
-
-Per-profile metadata should include profile URI/QID and profile/statement digests.
-
-Per-value-list metadata should include value-list ID plus cache digest and refresh timestamp.
-
-### Compatibility Status Values
-
-Suggested runtime values:
-
-- `compatible`
-- `migration_available`
-- `manual_review_required`
-- `incompatible`
-
-### Change Classification
-
-Suggested drift classes:
-
-- `patch_compatible`
-- `minor_compatible`
-- `migration_required`
-- `breaking`
-
-### Re-entry Sequence
-
-1. Validate packet type and shape.
-2. Compare `minted_from` metadata to current SpiritSafe and DD state.
-3. Classify drift.
-4. Apply approved forward migrations when available.
-5. Re-run conformance validation/coercion.
-6. Emit compatibility and migration reporting.
-7. Proceed to shipping only when packet is structurally valid and required migrations succeeded.
-
-## Transition Notes
-
-Some legacy packet/documentation surfaces still reference older fields such as `profile_name`, profile-name keyed statement maps, or YAML-first assumptions.
-
-Current architecture direction is URI-first JSON profile and packet contracts, with compatibility shims preserved only where required during migration.
+**Packet migration tooling** — When a packet created from an older SpiritSafe state is re-presented, a forward migration utility will classify drift and apply approved transforms before re-validation. The `metadata.mint` fields provide the provenance anchor for this. Not yet implemented.
 
 ## Related Documentation
 

--- a/docs/gkc/wizard.md
+++ b/docs/gkc/wizard.md
@@ -23,27 +23,27 @@ GKC Wizards are **profile-driven user interfaces** that transform declarative YA
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│  SpiritSafe Profile YAML (TribalGovernmentUS)            │
+│  SpiritSafe JSON Entity Profile (Q4 — tribal_government_us) │
 │  - Entity metadata (labels, descriptions, aliases)       │
 │  - Statements with datatypes, constraints, guidance      │
-│  - Profile graph (links to OfficeHeldByHeadOfState)      │
-│  - SPARQL-driven allowed-items lists                     │
+│  - Profile graph (links to related profile types)        │
+│  - Value-list routes to SPARQL-hydrated cache files      │
 └──────────────────┬──────────────────────────────────────-┘
                    │ Load & parse
                    ↓
 ┌──────────────────────────────────────────────────────────┐
 │  GKC Spirit Safe Module                                  │
-│  - Parse YAML → Pydantic EntityProfile model             │
-│  - Discover profile graph (related profiles)             │
-│  - Hydrate SPARQL allowed-items caches                   │
+│  - Load JSON Entity Profile + related profiles           │
+│  - Discover profile graph (linked profile types)         │
+│  - Resolve value-list cache routes                       │
 └──────────────────┬──────────────────────────────────────-┘
                    │ Provide profile + graph
                    ↓
 ┌──────────────────────────────────────────────────────────┐
 │  Wizard Loader                                           │
-│  - Create GKC Curation Packet with placeholders          │
-│  - Primary entity: ent-001-primary                       │
-│  - Related entities: ent-002-office, etc.                │
+│  - Create GKC Curation Packet with uncharged slots       │
+│  - Entity slots keyed by profile name_identifier and ID  │
+│  - Statement slots keyed by statement name_identifier    │
 └──────────────────┬──────────────────────────────────────-┘
                    │ Pass packet + profile to renderer
                    ↓


### PR DESCRIPTION
## Summary

Pre-coding documentation alignment for #164 Curation Packet work. Updates six documentation files to match the current and target packet contract before the still_charger charged-packet implementation sprint begins.

## Files changed

- `docs/gkc/entity-json-schema.md` — Rewrites the identity rules (dual-key name_identifier + id model replaces URI-only), packet scaffold contract, and charged packet contract. Adds conformance bucket table, source provenance fields, conformance_summary shape, and integrity digest re-entry semantics.
- `docs/architecture/spirit_safe_models.md` — Replaces the stale ent-001/profile_structure Packet Scaffolding Model with the current metadata/data split contract. Updates the Identity Model section and Theoretical Design Notes.
- `docs/architecture/module-contracts.md` — Adds fermenter evaluator symbols to the Fermenter anchor surface. Marks charge_curation_packet as legacy. Replaces stale URI-key migration gap note with current still_charger/fermenter integration gap.
- `docs/gkc/api/still_charger.md` — Rewrites Quick Start with name_identifier-shaped packet. Updates return value example and charge descriptions. Marks charge_curation_packet as legacy.
- `docs/gkc/cli/profiles.md` — Updates packet build and charge output descriptions for unified graph and conformance classification.
- `docs/gkc/wizard.md` — Pipeline diagram updated: YAML to JSON Entity Profile; ent-001-primary IDs replaced with name_identifier/id slot descriptions.

## Validation

- poetry run pytest: 469 passed, 0 failures
- bash scripts/pre-merge-check.sh: all checks passed

Closes pre-coding alignment gate for #164.
