### PR TITLE
Docs cleanup: remove YAML-era profile methodology references

### DIFF
--- a/docs/architecture/DataDistillery-Wikibase.md
+++ b/docs/architecture/DataDistillery-Wikibase.md
@@ -6,7 +6,7 @@ Data Distillery Wikibase (`datadistillery.wikibase.cloud`) is the semantic regis
 
 The runtime and collaboration needs are different:
 
-- SpiritSafe YAML is optimized for offline execution and deterministic profile consumption.
+- SpiritSafe JSON profile artifacts are optimized for offline execution and deterministic profile consumption.
 - Wikibase is optimized for semantic relationships, multilingual fields, and query-oriented discovery.
 
 The Data Distillery uses a hybrid model where both sides are maintained in sync.
@@ -15,7 +15,7 @@ The Data Distillery uses a hybrid model where both sides are maintained in sync.
 
 ### Source-of-Truth Position
 
-- Profile YAML remains the actionable artifact consumed by runtime code.
+- JSON Entity Profiles and cache artifacts remain the actionable artifacts consumed by runtime code.
 - Wikibase stores semantic linkage and metadata that improve queryability and collaboration.
 - Transformations between Wikibase and SpiritSafe must be lossless and testable.
 

--- a/docs/architecture/SpiritSafe-testing.md
+++ b/docs/architecture/SpiritSafe-testing.md
@@ -10,7 +10,7 @@ GKC's functionality depends deeply on SpiritSafe profiles—for validation, wiza
 
 This document describes:
 
-- Why we need a complete local SpiritSafe replica (not just profile YAMLs)
+- Why we need a complete local SpiritSafe replica (not just profile JSON files)
 - How test profiles are managed in the canonical SpiritSafe repository
 - How the fixture sync process works (manual and automated)
 - Testing patterns and best practices
@@ -23,7 +23,7 @@ This document describes:
 
 GKC's profile registry and curation functionality (and beyond) requires:
 
-- **Profile loading**: Parse YAML + metadata
+- **Profile loading**: Load JSON profile artifacts + metadata
 - **Manifest operations**: Discover profiles, query registry metadata
 - **Profile graphs**: Traverse relationships between profiles
 - **Curation packets**: Create multi-entity work units with cross-references
@@ -36,7 +36,7 @@ Testing these features requires access to:
 2. A valid manifest.json (generated from profiles)
 3. SPARQL query files (for choice lists)
 4. Cached query results (for hydration testing)
-5. Profile metadata.yaml files (for version/authorship info)
+5. Profile metadata objects embedded in profile JSON artifacts (for version/authorship info)
 
 ### The Solution
 
@@ -47,31 +47,15 @@ This is a **complete mirror** of the SpiritSafe repository structure, containing
 ```
 tests/fixtures/spiritsafe/
 ├── profiles/
-│   ├── TribalGovernmentUS/
-│   │   ├── profile.yaml               # Full profile with linkage metadata
-│   │   ├── metadata.yaml              # Version, authors, profile_graph edges
-│   │   ├── README.md                  # (Optional, for documentation tests)
-│   │   ├── CHANGELOG.md               # (Optional, for version history tests)
-│   │   └── queries/                   # Profile-specific SPARQL queries
-│   │       ├── bia_federal_register_issues.sparql
-│   │       └── wikidata_language_items_en.sparql
-│   │
-│   ├── OfficeHeldByHeadOfState/
-│   │   ├── profile.yaml
-│   │   └── metadata.yaml
-│   │
-│   └── EntityProfileExemplar/         # Purpose-built test profile
-│       ├── profile.yaml               # Exercises all datatypes, edge cases
-│       └── metadata.yaml
-│
+│   ├── Q4.json                        # Tribal Government profile artifact
+│   ├── Q39.json                       # Office profile artifact
+│   └── ...
 ├── cache/
-│   ├── manifest.json                  # Generated registry manifest
-│   └── profiles/
-│       └── TribalGovernmentUS/
-│           ├── bia_federal_register_issues.json
-│           └── wikidata_language_items_en.json
-│
-└── queries/                           # Shared queries (if any)
+│   ├── entities/                      # Raw Wikibase cache entities
+│   ├── queries/                       # Hydrated value-list results
+│   ├── manifest.json                  # Generated artifact manifest
+│   └── entity_index.json              # Normalized derived index
+└── queries/                           # SPARQL query files
 ```
 
 **Benefits**:
@@ -255,26 +239,23 @@ def spiritsafe_local_source():
 
 ```python
 def test_profile_linkage_metadata(spiritsafe_local_source):
-    """Verify linkage metadata is parsed from TribalGovernmentUS profile."""
-    from gkc.profiles import ProfileLoader
-    
-    loader = ProfileLoader()
-    profile_path = (
-        spiritsafe_local_source 
-        / "profiles" 
-        / "TribalGovernmentUS" 
-        / "profile.yaml"
+    """Verify linkage metadata is parsed from Q4 profile artifact."""
+    from gkc.spirit_safe import load_profile
+
+    profile = load_profile("Q4")
+
+    office_stmt = next(
+        (
+            statement
+            for statement in profile.get("statements", [])
+            if statement.get("name_identifier") == "office_held_by_head_of_state"
+        ),
+        None,
     )
-    profile = loader.load_from_file(profile_path)
-    
-    # Find office_held_by_head_of_state statement
-    office_stmt = profile.statement_by_id("office_held_by_head_of_state")
     assert office_stmt is not None
-    
-    # Verify linkage metadata parsed
-    assert office_stmt.linkage is not None
-    assert office_stmt.linkage.target_profile == "OfficeHeldByHeadOfState"
-    assert office_stmt.linkage.cardinality.max == 1
+
+    profile_graph = profile.get("metadata", {}).get("profile_graph", [])
+    assert any(edge.get("target_profile") for edge in profile_graph)
 ```
 
 ### Example Test: Manifest Loading
@@ -326,9 +307,9 @@ def test_profile_graph_traversal(spiritsafe_local_source):
 
 With the complete local SpiritSafe replica, tests should cover:
 
-- ✅ Profile YAML parsing (all datatypes, statements, qualifiers, references)
+- ✅ JSON Entity Profile loading (all datatypes, statements, qualifiers, references)
 - ✅ Linkage metadata extraction from statements
-- ✅ Metadata.yaml loading (version, authors, profile_graph)
+- ✅ Profile metadata loading (version, authors, profile_graph)
 - ✅ Manifest loading and integrity validation
 - ✅ Profile graph construction and traversal
 - ✅ Cardinality constraint validation

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -4,15 +4,16 @@
 
 The **Global Knowledge Commons (GKC)** is a framework for understanding and working with structured knowledge across multiple open public platforms. The initial design focuses on Wikidata, Wikimedia Commons, Wikipedia templates, and OpenStreetMap.
 
-The project uses a **data distillery** metaphor to describe the pipeline that converts raw, heterogeneous inputs into validated, platform-ready outputs. Mash Bills describe incoming structure, Modulation Profiles guide transformation, GKC Entity Profiles define canonical entity forms, and Barrel Profiles represent downstream platform-specific targets.
+The project uses a **data distillery** metaphor to describe the pipeline that converts heterogeneous inputs into validated, platform-ready outputs. GKC Entity Profiles define canonical entity forms made up of individual statements backed by evidence (references). Distilled data are bottled for outlets - GKC Partners - and shipped via authenticated Application Programming Interfaces (APIs).
 
-The GKC is built on three foundational architectural components that work together to transform declarative entity definitions into actionable curation workflows:
+The GKC is built on four foundational architectural components that work together to transform declarative entity definitions into actionable curation workflows:
 
-1. **GKC Entity Profiles** — Declarative YAML definitions of entity structure and semantics
-2. **GKC Entity JSON Schemas** — Machine-readable, serializable representations of profiles
-3. **GKC Curation Packets** — Actionable bundles of 1+ entities flowing through curation workflows
+1. **GKC Entity Profiles** — Declarative definitions of entity structure and semantics
+2. **GKC Entity Statements** - Individual statements that make up an entity profile
+3. **GKC Entity JSON Schemas** — Machine-readable, serializable representations of profiles
+4. **GKC Curation Packets** — Actionable bundles of one or more entities, all or a subset of statements, flowing through curation workflows
 
-These components enable a consistent pattern: **define once, use everywhere**. A profile written in YAML drives wizard UI generation, validation logic, bulk data operations, API contracts, and cross-platform serialization—all from a single source of truth.
+These components enable a consistent pattern: **define once, use everywhere**. Entity Statements, Entity Profiles, and helper utilities (e.g., Value Lists) are defined and organized within a dedicated Wikibase instance (a meta-wikibase) operated in the [Wikibase.cloud](https://wikibase.cloud/) environment. Configuration logic and rules from the [Data Distillery Wikibase](https://datadistillery.wikibase.cloud/) are written out to the [Spirit Safe](https://github.com/skybristol/SpiritSafe), a GitHub repository used to drive GKC operations.
 
 ---
 
@@ -33,7 +34,7 @@ Multiple platforms contribute to and consume a single GKC Entity:
 
 **Definition:** GKC Entity Profiles are declarative definitions of the canonical structure, semantics, and cross-platform meaning of a real-world entity in the Global Knowledge Commons.
 
-**Implementation:** Profiles exist as YAML files in the SpiritSafe registry (`profiles/<ProfileID>/profile.yaml`) and are loaded into Pydantic models at runtime, serving as the authoritative source of truth for:
+**Implementation:** Profiles are materialized as JSON Entity Profile artifacts in SpiritSafe (`profiles/<QID>.json`) and consumed directly by runtime modules, serving as the authoritative source of truth for:
 
 - **Entity structure** — What statements, qualifiers, and references constitute the entity
 - **Validation rules** — Constraints, datatypes, cardinality, required vs optional fields
@@ -44,7 +45,7 @@ Multiple platforms contribute to and consume a single GKC Entity:
 **Key Characteristics:**
 
 - **Declarative, not imperative** — Profiles describe *what* an entity is, not *how* to build it
-- **Human-readable and machine-executable** — YAML is both documentation and runtime specification
+- **Human-readable and machine-executable** — JSON artifacts provide stable runtime contracts while preserving curator-facing semantics
 - **Version-controlled** — Managed in SpiritSafe repository with CHANGELOG tracking
 - **Profile-driven workflows** — Wizards, validation engines, and serializers consume profiles directly
 
@@ -57,7 +58,7 @@ Multiple platforms contribute to and consume a single GKC Entity:
 
 **Definition:** GKC Entity JSON Schemas are machine-readable, serializable representations of GKC Entity Profiles that provide stable contracts for API routes, external tools, and inter-profile composition.
 
-**Implementation:** Generated programmatically from Pydantic models (which are in turn loaded from YAML profiles), JSON Schemas:
+**Implementation:** Generated programmatically from materialized JSON Entity Profile contracts and related runtime models, JSON Schemas:
 
 - **Define data contracts** — External tools can validate GKC Entity JSON without importing Python code
 - **Enable profile composition** — Profiles reference one another via `entity_profile` statements, forming graphs
@@ -67,9 +68,9 @@ Multiple platforms contribute to and consume a single GKC Entity:
 **Relationship to Profiles:**
 
 ```
-Profile YAML → Pydantic Model → JSON Schema → API Contract
-                      ↓               ↓
-                 Validation      External Tools
+SpiritSafe JSON Profile → Runtime Model → JSON Schema → API Contract
+                         ↓               ↓
+                    Validation      External Tools
 ```
 
 Profiles are the *source of truth*; JSON Schemas are the *machine interface*.
@@ -86,7 +87,7 @@ Profiles are the *source of truth*; JSON Schemas are the *machine interface*.
 - **Primary entity** — The entity being directly curated
 - **Related entities** — Secondary entities linked via profile graph (e.g., offices, organizations)
 - **Packet metadata** — Creation timestamps, curator username, status tracking
-- **Local reference system** — `packet_id` identifiers (e.g., `ent-001-primary`, `ent-002-office`) that resolve to Wikidata QIDs post-shipping
+- **Dual-key identity system** — `name_identifier` is the human-facing key while `id` (URI) remains canonical for joins, provenance, and round-trip mapping
 
 **Packet Lifecycle:**
 
@@ -119,7 +120,7 @@ This enables dependency ordering (ship entities depth-first), audit trails, and 
 
 ### SpiritSafe
 
-**SpiritSafe** is the profile registry and supporting query/cache infrastructure. It stores profile packages (`profile.yaml`, `metadata.yaml`, docs, and `queries/`) and provides a source for GKC runtime loading in local or GitHub-backed modes.
+**SpiritSafe** is the profile registry and supporting query/cache infrastructure. It stores materialized profile artifacts (`profiles/<QID>.json`), query files (`queries/*.sparql`), cache artifacts (`cache/entities`, `cache/queries`, `cache/manifest.json`), and the normalized index (`cache/entity_index.json`) used by runtime loading in local or GitHub-backed modes.
 
 For complete documentation on SpiritSafe, see [SpiritSafe Registry](SpiritSafe.md).
 
@@ -150,14 +151,14 @@ For detailed schema, consumption patterns, and examples, see [SpiritSafe Entity 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                     SpiritSafe Registry                         │
-│  profiles/TribalGovernmentUS/profile.yaml                       │
-│  profiles/OfficeHeldByHeadOfState/profile.yaml                  │
+│  profiles/Q4.json                                               │
+│  profiles/Q39.json                                              │
 └────────────────────┬────────────────────────────────────────────┘
                      │ Load profiles
                      ↓
 ┌─────────────────────────────────────────────────────────────────┐
 │                  GKC Spirit Safe Module                         │
-│  - Parse YAML → Pydantic EntityProfile models                   │
+│  - Load JSON Entity Profiles from SpiritSafe artifacts          │
 │  - Build profile graph (TribalGov → Office linkage)             │
 │  - Hydrate SPARQL allowed-items lists                           │
 └────────────────────┬────────────────────────────────────────────┘
@@ -166,7 +167,7 @@ For detailed schema, consumption patterns, and examples, see [SpiritSafe Entity 
 ┌─────────────────────────────────────────────────────────────────┐
 │                     GKC Wizard                                  │
 │  - Generate 5-step UI from profile metadata                     │
-│  - Create curation packet (ent-001 primary, ent-002 office)     │
+│  - Create curation packet (entity slots keyed by profile/name)  │
 │  - Collect user input with real-time validation                 │
 └────────────────────┬────────────────────────────────────────────┘
                      │ Curation packet (unsaved)
@@ -182,7 +183,7 @@ For detailed schema, consumption patterns, and examples, see [SpiritSafe Entity 
 ┌─────────────────────────────────────────────────────────────────┐
 │                      Shipper                                    │
 │  - Serialize GKC Entity JSON → Wikidata JSON                    │
-│  - Resolve cross-entity references (ent-002 → create office, get QID) │
+│  - Resolve cross-entity references via profile statements        │
 │  - Ship entities depth-first (office before tribal gov)         │
 └────────────────────┬────────────────────────────────────────────┘
                      │ Wikidata API calls
@@ -200,12 +201,12 @@ For detailed schema, consumption patterns, and examples, see [SpiritSafe Entity 
 When wizard loads `TribalGovernmentUS`, it:
 
 1. Scans statements for `entity_profile` types → finds `office_held_by_head_of_state`
-2. Reads `value.profile_name: OfficeHeldByHeadOfState`
-3. Loads `OfficeHeldByHeadOfState` profile recursively
-4. Builds profile graph: `TribalGovernmentUS` → `OfficeHeldByHeadOfState`
+2. Reads profile linkage metadata from statement value definitions
+3. Loads related profile artifacts recursively by profile URI/QID
+4. Builds profile graph from `metadata.profile_graph` edges
 5. Creates packet with placeholders for both entities
 
-Future metadata enhancement will make this explicit via `metadata.yaml` `profile_graph` section (see [Multi-Profile Configuration](../gkc/profiles.md#profile-graphs-cross-references)).
+Profile graph metadata is already carried in profile artifact `metadata.profile_graph` (see [Multi-Profile Configuration](../gkc/profiles.md#profile-graphs-cross-references)).
 
 ---
 
@@ -261,7 +262,7 @@ Following Wikipedia/Wikidata philosophy:
 
 **Stable & Production-Ready:**
 
-- Profile YAML loading and Pydantic model generation
+- JSON Entity Profile loading and runtime model generation
 - SPARQL allowed-items hydration with fallback lists
 - Single-entity curation packets
 - Wikidata JSON serialization
@@ -270,7 +271,7 @@ Following Wikipedia/Wikidata philosophy:
 **In Development (Wizard MVP):**
 
 - Multi-entity packets with cross-entity references
-- Profile graph metadata (`metadata.yaml` enhancements)
+- Expanded profile graph traversal and orchestration policy controls
 - Wizard multi-tab UI for related entities
 - Status tracking lifecycle
 
@@ -319,12 +320,12 @@ This architecture section includes detailed documentation on specific subsystems
 
 | Term | Definition |
 |------|------------|
-| **Profile** | YAML definition of entity structure in SpiritSafe registry |
+| **Profile** | JSON Entity Profile artifact defining entity structure in SpiritSafe |
 | **Packet** | Bundle of 1+ entities being curated together |
 | **Entity** | Single real-world thing represented in GKC (tribal government, office, person) |
 | **Statement** | Single property-value assertion about an entity (analogous to Wikidata claim) |
 | **Profile Graph** | Network of profiles linked via `entity_profile` statements |
-| **packet_id** | Local identifier (e.g., `ent-001`) used within a packet before QID assignment |
+| **packet_id** | UUID packet identifier used to track a specific packet instance |
 | **creation_path** | Breadcrumb showing how entity was created (e.g., `primary.office`) |
 | **Shipper** | Module that serializes packets to platform-specific formats (Wikidata JSON, etc.) |
 | **Allowed Items** | SPARQL-driven choice lists for statement values (e.g., Federal Register issues) |
@@ -343,6 +344,6 @@ These are retained as design intent for follow-on implementation work by the Wiz
 
 ---
 
-**Last Updated:** March 3, 2026  
+**Last Updated:** March 26, 2026  
 **Maintainer:** Profile Architect  
 **Status:** Stable (subject to enhancement as architecture evolves)

--- a/docs/architecture/profile-loading.md
+++ b/docs/architecture/profile-loading.md
@@ -6,16 +6,13 @@ This page documents implemented and architecturally committed behavior for profi
 
 ## Resolution Model
 
-GKC resolves a profile reference through `resolve_profile_path()` using the canonical registrant layout:
+GKC resolves a profile reference through `resolve_profile_path()` using the canonical artifact layout:
 
-- `ProfileName` → `profiles/ProfileName/profile.yaml`
-- `ProfileName.yaml` → `profiles/ProfileName/profile.yaml`
-- Explicit paths are preserved as provided.
+- `QID` (for example `Q4`) → `profiles/QID.json`
+- Full entity URI (for example `https://datadistillery.wikibase.cloud/entity/Q4`) → normalized to `profiles/Q4.json`
+- Explicit `.json` profile paths are preserved as provided.
 
-Compatibility fallback supports legacy flat layout during migration:
-
-- `profiles/Foo/profile.yaml` can fall back to `profiles/Foo.yaml`
-- `profiles/Foo.yaml` can fall back to `profiles/Foo/profile.yaml`
+Compatibility behavior for legacy YAML-era layouts remains migration-only and should not be used for new integrations.
 
 ## Source Modes
 

--- a/docs/architecture/validation-architecture.md
+++ b/docs/architecture/validation-architecture.md
@@ -29,7 +29,7 @@ At minimum, provenance must capture presentation circumstances: how, when, and b
 
 Validation in GKC is layered around profile-defined constraints:
 
-- Profile definition validation: YAML is parsed into typed profile models.
+- Profile definition validation: JSON Entity Profiles are loaded into typed runtime models.
 - Entity data validation: item and statement content is checked against profile requirements.
 - Hydration input validation: query references and templates are resolved before execution.
 - Packet evaluation validation: packet metadata integrity is verified before data evaluation runs.

--- a/docs/gkc/api/index.md
+++ b/docs/gkc/api/index.md
@@ -24,7 +24,7 @@ GKC modules are grouped by their role in the distillery pipeline:
 | **Utilities** | auth | Authentication for Wikidata and OSM |
 | | sitelinks | Manage Wikipedia sitelinks |
 | | [sparql](sparql.md) | Query Wikidata with SPARQL |
-| **Profiles** | [profiles](profiles.md) | YAML profile loading and validation |
+| **Profiles** | [profiles](profiles.md) | Profile loading and validation |
 | **Ontology** | [ontology](ontology.md) | Two-layer ontology extraction from Data Distillery Wikibase |
 
 ---
@@ -232,10 +232,10 @@ Query Wikidata and other SPARQL endpoints.
 
 ### [Profiles](profiles.md)
 
-YAML-first profiles for validation and form schema generation.
+Profile loading surfaces for validation and form schema generation.
 
 **Key classes:**
-- `ProfileLoader` - Load YAML profiles
+- `ProfileLoader` - Load profile artifacts
 - `ProfileValidator` - Validate Wikidata items
 - `FormSchemaGenerator` - Build form schemas
 

--- a/docs/gkc/api/profiles.md
+++ b/docs/gkc/api/profiles.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-The profiles module provides YAML-first entity profiles that drive validation, form schema generation, and profile-aware data workflows.
+The profiles module provides entity profile loading and validation surfaces for SpiritSafe-backed runtime workflows.
 
-**Current implementations:** YAML loading, JSON Schema validation, Pydantic model generation, form schema generation, Wikidata validation  
+**Current implementations:** JSON profile loading, JSON Schema validation, runtime model generation, form schema generation, Wikidata validation  
 **Future implementations:** profile registry, code generation, broader datatype support
 
 ## Quick Start
@@ -13,7 +13,7 @@ The profiles module provides YAML-first entity profiles that drive validation, f
 from gkc.profiles import ProfileLoader, ProfileValidator
 
 profile = ProfileLoader().load_from_file(
-    "/path/to/SpiritSafe/profiles/TribalGovernmentUS/profile.yaml"
+    "/path/to/SpiritSafe/profiles/Q4.json"
 )
 validator = ProfileValidator(profile)
 result = validator.validate_item(item_json, policy="lenient")
@@ -58,14 +58,14 @@ result = validator.validate_item(item_json, policy="lenient")
 
 ## Examples
 
-### Load a YAML Profile
+### Load a JSON Entity Profile
 
 ```python
 from gkc.profiles import ProfileLoader
 
 loader = ProfileLoader()
 profile = loader.load_from_file(
-    "/path/to/SpiritSafe/profiles/TribalGovernmentUS/profile.yaml"
+    "/path/to/SpiritSafe/profiles/Q4.json"
 )
 print(profile.name)
 ```
@@ -76,7 +76,7 @@ print(profile.name)
 from gkc.profiles import FormSchemaGenerator, ProfileLoader
 
 profile = ProfileLoader().load_from_file(
-    "/path/to/SpiritSafe/profiles/TribalGovernmentUS/profile.yaml"
+    "/path/to/SpiritSafe/profiles/Q4.json"
 )
 form_schema = FormSchemaGenerator(profile).build_schema()
 print(form_schema["statements"][0]["label"])
@@ -88,7 +88,7 @@ print(form_schema["statements"][0]["label"])
 from gkc.profiles import ProfileLoader, ProfileValidator
 
 profile = ProfileLoader().load_from_file(
-    "/path/to/SpiritSafe/profiles/TribalGovernmentUS/profile.yaml"
+    "/path/to/SpiritSafe/profiles/Q4.json"
 )
 validator = ProfileValidator(profile)
 result = validator.validate_item(item_json, policy="lenient")
@@ -105,7 +105,7 @@ if result.ok:
 from gkc.profiles import ProfileLoader, ProfileValidator
 
 profile = ProfileLoader().load_from_file(
-    "/path/to/SpiritSafe/profiles/TribalGovernmentUS/profile.yaml"
+    "/path/to/SpiritSafe/profiles/Q4.json"
 )
 validator = ProfileValidator(profile)
 result = validator.validate_item(item_json, policy="strict")
@@ -124,7 +124,7 @@ from gkc.profiles import ProfileLoader
 
 loader = ProfileLoader()
 try:
-    loader.load_from_file("bad_profile.yaml")
+    loader.load_from_file("bad_profile.json")
 except ValueError as exc:
     print(f"Schema error: {exc}")
 ```

--- a/docs/gkc/api/still_charger.md
+++ b/docs/gkc/api/still_charger.md
@@ -56,7 +56,7 @@ packet = create_curation_packet("Q4", operation_mode="single")
 | `profile_id` | `str` | Profile QID or full profile URI |
 | `operation_mode` | `str` | `single` for primary-only scaffold or `bulk` for profile-graph expansion |
 
-**Returns:** `dict` — Packet scaffold in the URI-keyed contract.
+**Returns:** `dict` — Packet scaffold in the dual-key packet contract (`name_identifier` for human-facing keys and `id` URI for canonical identity).
 
 ---
 
@@ -127,17 +127,6 @@ packet = build_curation_packet_from_json_profile(
   }
 }
 ```
-{
-  "packet_id": "pkt-...",
-  "operation_mode": "new",
-  "metadata": {
-    "primary_profile": {
-      "name_identifier": "Q4",
-      "id": "https://datadistillery.wikibase.cloud/entity/Q4"
-    },
-    "profiles": [],
-    "graph": {"nodes": [], "edges": []}
----
 
 ### `charge_packet_from_wikidata_items()`
 
@@ -208,7 +197,7 @@ from gkc.still_charger import ChargeIssue, ChargeReport
 
 issue = ChargeIssue(
     severity="warning",
-    entity_ref="ent-001",
+  entity_ref="https://datadistillery.wikibase.cloud/entity/Q4",
     code="specificationless_charge",
     message="Specificationless charging accepted unknown statements",
 )

--- a/docs/gkc/api/wikibase.md
+++ b/docs/gkc/api/wikibase.md
@@ -12,7 +12,7 @@ The `gkc.wikibase` module provides Data Distillery orchestration for:
 
 ### `load_foundation_profiles(profile_dir)`
 
-Loads foundation ontology definitions from profile YAML files.
+Loads foundation ontology definitions from foundation profile files.
 
 Expected files:
 
@@ -77,7 +77,7 @@ from gkc.wikibase import build_wikibase_write_plan
 result = build_wikibase_write_plan(
     profile_id="TribalGovernmentUS",
     source_values={
-        "ent-001": {
+        "https://datadistillery.wikibase.cloud/entity/Q4": {
             "labels": {"en": "Cherokee Nation"},
             "statements": {
                 "instance_of": [{"value": "Q7840353"}],
@@ -146,7 +146,7 @@ shipper = WikibaseShipper(auth=auth, dry_run_default=True)
 
 result = execute_wikibase_write_plan(
     profile_id="TribalGovernmentUS",
-    source_values={"ent-001": {"labels": {"en": "Cherokee Nation"}}},
+    source_values={"https://datadistillery.wikibase.cloud/entity/Q4": {"labels": {"en": "Cherokee Nation"}}},
     shipper=shipper,
     dry_run=True,
     write_summary="gkc wikibase execute-write",
@@ -168,7 +168,7 @@ Key fields:
 
 ## Exceptions
 
-- `FoundationProfileError`: profile directory or YAML structure is invalid
+- `FoundationProfileError`: profile directory or foundation profile structure is invalid
 - `FoundationAuditError`: audit request/lookup operations failed
 - `FoundationInitError`: init flow failed or required parameters were invalid
 

--- a/docs/gkc/cli/index.md
+++ b/docs/gkc/cli/index.md
@@ -45,7 +45,7 @@ gkc mash qid Q42
 Validate items against profiles, export JSON Entity Profiles from cache entities, generate form schemas, launch the Textual wizard, hydrate SPARQL value lists, and build SpiritSafe artifact manifests.
 
 ```bash
-gkc profile validate --profile /path/to/profile.yaml --qid Q123
+gkc profile package load --profile Q4 --source local --local-root /path/to/SpiritSafe
 ```
 
 ```bash

--- a/docs/gkc/profiles.md
+++ b/docs/gkc/profiles.md
@@ -79,19 +79,15 @@ Validation engines and form generators use the entity index to avoid repeated tr
 
 ## Profile Anatomy
 
-### Top-Level Keys (`profile.yaml`)
+### Top-Level Keys (JSON Entity Profile)
 
 | Key | Type | Required | Purpose |
 |-----|------|----------|---------|
-| `name` | string | YES | Human-readable profile name |
-| `description` | string | YES | Profile scope and domain description |
-| `labels` | object | NO | Multilingual label prompt and constraints |
-| `descriptions` | object | NO | Multilingual description prompt and constraints |
-| `aliases` | object | NO | Multilingual alias prompt and constraints |
-| `sitelinks` | object | NO | Sitelink capture and validation guidance |
-| `statements` | array | YES | Statement definitions |
-| `profile_graph` | object | NO | Cross-profile relationship declarations |
-| YAML anchors | any | NO | Reusable patterns for references/constraints |
+| `entity` | string | YES | Canonical profile URI |
+| `name_identifier` | string | YES | Human-facing stable profile key |
+| `identification` | object | YES | Multilingual label/description/alias prompts and constraints |
+| `statements` | array | YES | Statement specifications for packet scaffolding and validation |
+| `metadata` | object | YES | Profile graph, value-list graph, and publication metadata |
 
 ### Statement Keys
 
@@ -117,19 +113,17 @@ Validation engines and form generators use the entity index to avoid repeated tr
 
 ### Canonical Shape
 
-```yaml
-- id: instance_of
-  label: Instance of
-  type: statement
-  io_map:
-    - to: https://www.wikidata.org/entity/P31
-      value_transform: null
-    - to: https://datadistillery.wikibase.cloud/entity/P1
-      value_transform: null
-    - from: resolvable_input_fetcher
-      value_transform: normalize_to_item
-  value:
-    type: item
+```json
+{
+  "name_identifier": "instance_of",
+  "entity": "https://datadistillery.wikibase.cloud/entity/Q16",
+  "io_map": [
+    {"to": "https://www.wikidata.org/entity/P31", "value_transform": null},
+    {"to": "https://datadistillery.wikibase.cloud/entity/P1", "value_transform": null},
+    {"from": "resolvable_input_fetcher", "value_transform": "normalize_to_item"}
+  ],
+  "value": {"type": "item"}
+}
 ```
 
 ### Entry Contract
@@ -196,11 +190,14 @@ Use when all encountered values must satisfy profile constraints before contribu
 
 Canonical shape:
 
-```yaml
-behavior:
-  value: editable         # editable | fixed | derived
-  qualifiers: editable    # editable | fixed | derived
-  references: editable    # editable | fixed | derived
+```json
+{
+  "behavior": {
+    "value": "editable",
+    "qualifiers": "editable",
+    "references": "editable"
+  }
+}
 ```
 
 ## Datatype Reference
@@ -221,24 +218,27 @@ Datatype-specific constraints are declared under `value` and follow explicit sch
 
 ## References and Provenance
 
-Reference definitions are nested under `references` and can be reused with YAML anchors.
+Reference definitions are nested under `references` and reused by explicit statement identifiers.
 
 Example:
 
-```yaml
-standard_reference: &standard_reference
-  min_count: 1
-  allowed:
-    - id: stated_in
-      type: item
-      io_map:
-        - to: https://www.wikidata.org/entity/P248
-          value_transform: null
-    - id: reference_url
-      type: url
-      io_map:
-        - to: https://www.wikidata.org/entity/P854
-          value_transform: null
+```json
+{
+  "references": {
+    "allowed": [
+      {
+        "name_identifier": "stated_in",
+        "type": "item",
+        "io_map": [{"to": "https://www.wikidata.org/entity/P248", "value_transform": null}]
+      },
+      {
+        "name_identifier": "reference_url",
+        "type": "url",
+        "io_map": [{"to": "https://www.wikidata.org/entity/P854", "value_transform": null}]
+      }
+    ]
+  }
+}
 ```
 
 ## Qualifiers
@@ -247,16 +247,18 @@ Qualifier definitions are nested statement-like structures with their own `io_ma
 
 Example:
 
-```yaml
-qualifiers:
-  - id: point_in_time
-    label: Point in time
-    type: qualifier
-    io_map:
-      - to: https://www.wikidata.org/entity/P585
-        value_transform: null
-    value:
-      type: time
+```json
+{
+  "qualifiers": [
+    {
+      "name_identifier": "point_in_time",
+      "label": "Point in time",
+      "type": "qualifier",
+      "io_map": [{"to": "https://www.wikidata.org/entity/P585", "value_transform": null}],
+      "value": {"type": "time"}
+    }
+  ]
+}
 ```
 
 <a id="statement-types-reference"></a>
@@ -299,7 +301,7 @@ Current committed usage:
 
 Future implementations may use graph metadata for packet expansion and cross-profile recommendation logic.
 
-## Profile Metadata Schema (`metadata.yaml`)
+## Profile Metadata Schema (`metadata` object)
 
 Canonical fields:
 
@@ -322,38 +324,37 @@ Canonical fields:
 
 - Keep statements domain-cohesive and curator-readable.
 - Prefer explicit constraints over inferred behavior.
-- Reuse anchors for reference structures.
+- Reuse explicit statement identifiers for shared reference structures.
 - Keep `io_map` routes explicit and unambiguous.
 - Keep transform references declarative; enforce execution policy in code.
 - Keep examples synchronized with active schema decisions.
 
 ## Complete Example (Minimal)
 
-```yaml
-name: Federally Recognized Tribe
-description: Canonical profile for federally recognized tribal entities
-
-statements:
-  - id: instance_of
-    label: Instance of
-    type: statement
-    io_map:
-      - to: https://www.wikidata.org/entity/P31
-        value_transform: null
-      - to: https://datadistillery.wikibase.cloud/entity/P1
-        value_transform: null
-    value:
-      type: item
-      fixed: Q7840353
-
-  - id: official_website
-    label: Official website
-    type: statement
-    io_map:
-      - to: https://www.wikidata.org/entity/P856
-        value_transform: null
-    value:
-      type: url
+```json
+{
+  "entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+  "name_identifier": "tribal_government_us",
+  "statements": [
+    {
+      "name_identifier": "instance_of",
+      "label": "Instance of",
+      "type": "statement",
+      "io_map": [
+        {"to": "https://www.wikidata.org/entity/P31", "value_transform": null},
+        {"to": "https://datadistillery.wikibase.cloud/entity/P1", "value_transform": null}
+      ],
+      "value": {"type": "item", "fixed": "Q7840353"}
+    },
+    {
+      "name_identifier": "official_website",
+      "label": "Official website",
+      "type": "statement",
+      "io_map": [{"to": "https://www.wikidata.org/entity/P856", "value_transform": null}],
+      "value": {"type": "url"}
+    }
+  ]
+}
 ```
 
 ## Step-by-Step Authoring Flow
@@ -362,7 +363,7 @@ statements:
 2. Define statement set and datatypes.
 3. Add constraints and validation policy.
 4. Add `io_map` routes for outbound and inbound systems.
-5. Add references/qualifiers and reusable anchors.
+5. Add references/qualifiers and reusable nested statement definitions.
 6. Add metadata, README, and CHANGELOG.
 7. Validate profile package and run hydration checks.
 

--- a/docs/gkc/utilities.md
+++ b/docs/gkc/utilities.md
@@ -325,22 +325,23 @@ custom_cache = LookupCache(cache_dir="/path/to/cache")
 
 #### Profile Integration Example
 
-```yaml
-# In profiles/YourProfile/profile.yaml (SpiritSafe repo)
-value:
-  type: item
-  allowed_items:
-    source: sparql
-    query: |
-      PREFIX wd: <http://www.wikidata.org/entity/>
-      SELECT ?item ?itemLabel WHERE { ... }
-    refresh: weekly
-    fallback_items:
-      - id: Q123
-        label: Fallback option
+```json
+{
+  "value": {
+    "type": "item",
+    "allowed_items": {
+      "source": "sparql",
+      "query": "PREFIX wd: <http://www.wikidata.org/entity/> SELECT ?item ?itemLabel WHERE { ... }",
+      "refresh": "weekly",
+      "fallback_items": [
+        {"id": "Q123", "label": "Fallback option"}
+      ]
+    }
+  }
+}
 ```
 
-The profile loader currently parses and validates profile YAML only; it does **not** automatically execute SPARQL lookups. Run lookup hydration explicitly (for example, via a dedicated prefetch step or application startup job) to populate cache files.
+The profile loader validates profile artifact structure only; it does **not** automatically execute SPARQL lookups. Run lookup hydration explicitly (for example, via a dedicated prefetch step or application startup job) to populate cache files.
 
 ### See Also
 

--- a/docs/gkc/wizard.md
+++ b/docs/gkc/wizard.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-GKC Wizards are **profile-driven user interfaces** that transform declarative YAML entity definitions into guided, step-by-step data entry workflows. Every aspect of the wizard—field labels, validation rules, input widgets, help text, and workflow organization—derives directly from the profile with zero hardcoded entity logic.
+GKC Wizards are **profile-driven user interfaces** that transform declarative JSON Entity Profile definitions into guided, step-by-step data entry workflows. Every aspect of the wizard—field labels, validation rules, input widgets, help text, and workflow organization—derives directly from the profile with zero hardcoded entity logic.
 
 **Key Characteristics:**
 
@@ -197,7 +197,7 @@ Every wizard follows a consistent 5-step progression designed to match curator m
 
 **Statement Rendering Order:**
 
-Wizard renders statements in the exact order specified in profile YAML. Profile designers should order statements logically (e.g., classification statements first, then descriptive, then relationships).
+Wizard renders statements in the exact order specified in the JSON Entity Profile artifact. Profile designers should order statements logically (e.g., classification statements first, then descriptive, then relationships).
 
 **Widget Selection by Datatype:**
 
@@ -398,9 +398,9 @@ When a profile references other profiles via `entity_profile` statements, wizard
 1. Wizard loads `TribalGovernmentUS` profile
 2. Discovers `office_held_by_head_of_state` statement with `entity_profile: OfficeHeldByHeadOfState`
 3. Loads `OfficeHeldByHeadOfState` profile
-4. Creates packet with two entity placeholders:
-   - `ent-001-primary` (TribalGovernmentUS)
-   - `ent-002-office` (OfficeHeldByHeadOfState)
+4. Creates packet with two entity slots:
+  - Primary slot: profile `tribal_government_us`, id `https://datadistillery.wikibase.cloud/entity/Q4`
+  - Related slot: profile `office_held_by_head_of_state`, id `https://datadistillery.wikibase.cloud/entity/Q39`
 
 ### UI Presentation Strategy
 
@@ -443,20 +443,20 @@ Users can click side entities to switch between them at any time. Each entity ma
 
 **Workflow when curator clicks "Create new office":**
 
-1. Wizard creates new entity placeholder in packet (`ent-002-office`)
+1. Wizard creates a new related-entity slot in the packet for the linked profile
 2. Sets `creation_path: primary.office_held_by_head_of_state`
 3. Switches active entity in UI to office
 4. Runs through 5 steps for office (Plan → Identify → Statements → Links → Review)
 5. On office completion:
    - Returns focus to primary entity
-   - Populates `office_held_by_head_of_state` statement value with `"ent-002-office"`
+  - Populates `office_held_by_head_of_state` statement value with the related entity URI/QID reference
    - Shows office as "Related entity (completed)" in sidebar/tabs
 
 **Cardinality Enforcement:**
 
 If statement has `max_count: 1` and office is already created, "Create new office" button is disabled.
 
-If `max_count: null`, curator can create multiple offices; wizard assigns `ent-002-office`, `ent-003-office`, etc.
+If `max_count: null`, curator can create multiple offices; wizard adds additional related entity slots keyed by profile + canonical id.
 
 ### Review Stage for Multi-Entity Packets
 
@@ -499,13 +499,17 @@ Profile `guidance` fields appear as:
 - **Expandable help sections** for longer guidance
 - **Contextual captions** below input fields
 
-**Example from profile:**
+**Example from profile artifact:**
 
-```yaml
-- id: native_name
-  guidance: >
-    Use the tribe's preferred self-designation in their native language(s).
-    Consult tribal language preservation resources or official communications.
+```json
+{
+  "name_identifier": "native_name",
+  "messages": {
+    "guidance": {
+      "mul": "Use the tribe's preferred self-designation in their native language(s). Consult tribal language preservation resources or official communications."
+    }
+  }
+}
 ```
 
 **Rendered in wizard:**
@@ -529,9 +533,16 @@ Default input prompts:
 
 Profile can override:
 
-```yaml
-labels:
-  input_prompt: Use the name the tribe uses in referring to itself
+```json
+{
+  "identification": {
+    "labels": {
+      "mul": {
+        "input_prompt": "Use the name the tribe uses in referring to itself"
+      }
+    }
+  }
+}
 ```
 
 Rendered as placeholder text or caption.
@@ -549,26 +560,35 @@ Rendered as placeholder text or caption.
 
 **UI hint override:**
 
-```yaml
-allowed_items:
-  source: sparql
-  query_ref: queries/federal_register_issues.sparql
-  ui_hint: searchable_select  # Force specific widget
+```json
+{
+  "value": {
+    "allowed_items": {
+      "source": "sparql",
+      "query_ref": "queries/federal_register_issues.sparql",
+      "ui_hint": "searchable_select"
+    }
+  }
+}
 ```
 
 **Fallback behavior:**
 
 If SPARQL query fails or returns empty, wizard uses `fallback_items` from profile:
 
-```yaml
-allowed_items:
-  source: sparql
-  query_ref: queries/languages.sparql
-  fallback_items:
-    - id: Q1860
-      label: English
-    - id: Q1567
-      label: Cherokee
+```json
+{
+  "value": {
+    "allowed_items": {
+      "source": "sparql",
+      "query_ref": "queries/languages.sparql",
+      "fallback_items": [
+        {"id": "Q1860", "label": "English"},
+        {"id": "Q1567", "label": "Cherokee"}
+      ]
+    }
+  }
+}
 ```
 
 ---
@@ -614,11 +634,17 @@ User loads Q5093 (Cherokee Nation) with TribalGovernmentUS profile
 
 **Future:** Configurable depth in metadata:
 
-```yaml
-profile_graph:
-  edges:
-    - target_profile: OfficeHeldByHeadOfState
-      max_depth: 2  # Load office + its related entities
+```json
+{
+  "metadata": {
+    "profile_graph": [
+      {
+        "target_profile": "https://datadistillery.wikibase.cloud/entity/Q39",
+        "max_depth": 2
+      }
+    ]
+  }
+}
 ```
 
 ---
@@ -645,11 +671,18 @@ Profile constraints generate user-friendly error messages:
 
 **Profile constraint:**
 
-```yaml
-constraints:
-  - type: format
-    pattern: "^Q\\d+$"
-    error_message: Must be a valid QID (e.g., Q123456)
+```json
+{
+  "value": {
+    "constraints": [
+      {
+        "type": "format",
+        "pattern": "^Q\\d+$",
+        "error_message": "Must be a valid QID (e.g., Q123456)"
+      }
+    ]
+  }
+}
 ```
 
 **Rendered error:**
@@ -670,5 +703,5 @@ constraints:
 
 ---
 
-**Last Updated:** March 3, 2026  
+**Last Updated:** March 26, 2026  
 **Status:** Stable (Phase 0 documentation; implementation evolving in Wizard MVP)


### PR DESCRIPTION
## Summary

Implements the first cleanup pass for issue #173 to remove lingering YAML-era profile methodology references and legacy packet-local entity-id examples from active docs.

Updated docs now consistently describe:

- SpiritSafe JSON Entity Profile artifacts (`profiles/<QID>.json`) as runtime profile source
- Dual-key packet identity model (`name_identifier` + canonical `id` URI)
- Packet and wizard examples without `ent-001`/`ent-002` placeholder IDs

## Files Updated

- docs/architecture/index.md
- docs/architecture/validation-architecture.md
- docs/architecture/DataDistillery-Wikibase.md
- docs/architecture/profile-loading.md
- docs/architecture/SpiritSafe-testing.md
- docs/gkc/wizard.md
- docs/gkc/profiles.md
- docs/gkc/api/still_charger.md
- docs/gkc/api/profiles.md
- docs/gkc/api/index.md
- docs/gkc/api/wikibase.md
- docs/gkc/cli/index.md
- docs/gkc/utilities.md

## Validation

- `poetry run mkdocs build`
- `bash scripts/pre-merge-check.sh`

Both passed.

## Notes

Intentional YAML references were retained only where still semantically valid:

- Foundation bootstrap artifact names (`foundation_entities.yaml`, `foundation_properties.yaml`)
- CI workflow code block syntax in CI docs
- Explicit migration note in profile-loading docs referencing legacy YAML-era compatibility behavior

Closes #173
