### PR TITLE
Preserve optional value-list fields during hydration

### DIFF
--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -1209,6 +1209,7 @@ def hydrate_value_list_query_caches(
                 max_results=max_results,
             )
             items = _normalize_value_list_items(rows)
+            columns = sorted({key for item in items for key in item.keys()})
             payload = {
                 "metadata": {
                     "entity": f"{base_uri}/entity/{entity_id}",
@@ -1218,6 +1219,7 @@ def hydrate_value_list_query_caches(
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "count": len(items),
+                    "columns": columns,
                 },
                 "items": items,
             }
@@ -1332,8 +1334,35 @@ def _normalize_value_list_items(rows: list[dict[str, str]]) -> list[dict[str, st
         item_label = row.get("itemLabel")
         if not item or not item_label:
             continue
-        if item not in deduped_by_item:
-            deduped_by_item[item] = {"item": item, "itemLabel": item_label}
+
+        normalized_row: dict[str, str] = {"item": item, "itemLabel": item_label}
+        for key, value in row.items():
+            if key in {"item", "itemLabel"}:
+                continue
+            if isinstance(value, str) and value:
+                normalized_row[key] = value
+
+        existing = deduped_by_item.get(item)
+        if existing is None:
+            deduped_by_item[item] = normalized_row
+            continue
+
+        # Duplicate rows are allowed only if non-core fields are identical.
+        existing_extra = {
+            key: value
+            for key, value in existing.items()
+            if key not in {"item", "itemLabel"}
+        }
+        candidate_extra = {
+            key: value
+            for key, value in normalized_row.items()
+            if key not in {"item", "itemLabel"}
+        }
+        if existing_extra != candidate_extra:
+            raise ValueError(
+                "Duplicate value-list row conflict for item "
+                f"{item}: non-core fields differ between rows"
+            )
 
     return sorted(
         deduped_by_item.values(),

--- a/tests/test_spirit_safe_value_lists.py
+++ b/tests/test_spirit_safe_value_lists.py
@@ -40,7 +40,7 @@ def test_hydrate_value_lists_from_cache_writes_query_and_cache(monkeypatch, tmp_
     monkeypatch.setattr(
         "gkc.spirit_safe.fetch_mediawiki_page_wikitext",
         lambda api_client, title: (
-            "<sparql>SELECT ?item ?itemLabel WHERE { ?item ?p ?o }</sparql>"
+            "<sparql>SELECT ?item ?itemLabel ?domain WHERE { ?item ?p ?o }</sparql>"
             "<sparql>SELECT ?ignored WHERE { ?ignored ?p ?o }</sparql>"
         ),
     )
@@ -48,9 +48,21 @@ def test_hydrate_value_lists_from_cache_writes_query_and_cache(monkeypatch, tmp_
     monkeypatch.setattr(
         "gkc.spirit_safe.paginate_query",
         lambda **kwargs: [
-            {"item": "http://www.wikidata.org/entity/Q2", "itemLabel": "Beta"},
-            {"item": "http://www.wikidata.org/entity/Q1", "itemLabel": "Alpha"},
-            {"item": "http://www.wikidata.org/entity/Q1", "itemLabel": "Alpha"},
+            {
+                "item": "http://www.wikidata.org/entity/Q2",
+                "itemLabel": "Beta",
+                "domain": "de.wikipedia.org",
+            },
+            {
+                "item": "http://www.wikidata.org/entity/Q1",
+                "itemLabel": "Alpha",
+                "domain": "en.wikipedia.org",
+            },
+            {
+                "item": "http://www.wikidata.org/entity/Q1",
+                "itemLabel": "Alpha",
+                "domain": "en.wikipedia.org",
+            },
         ],
     )
 
@@ -78,9 +90,18 @@ def test_hydrate_value_lists_from_cache_writes_query_and_cache(monkeypatch, tmp_
     assert payload["metadata"]["query"] == "queries/Q4.sparql"
     assert payload["metadata"]["source"].endswith("/wiki/Item_talk:Q4")
     assert payload["metadata"]["count"] == 2
+    assert payload["metadata"]["columns"] == ["domain", "item", "itemLabel"]
     assert payload["items"] == [
-        {"item": "http://www.wikidata.org/entity/Q1", "itemLabel": "Alpha"},
-        {"item": "http://www.wikidata.org/entity/Q2", "itemLabel": "Beta"},
+        {
+            "domain": "en.wikipedia.org",
+            "item": "http://www.wikidata.org/entity/Q1",
+            "itemLabel": "Alpha",
+        },
+        {
+            "domain": "de.wikipedia.org",
+            "item": "http://www.wikidata.org/entity/Q2",
+            "itemLabel": "Beta",
+        },
     ]
 
 
@@ -135,6 +156,79 @@ def test_hydrate_value_lists_keeps_existing_cache_on_failure(monkeypatch, tmp_pa
     assert result.discovered_ids == ["Q4"]
     assert result.hydrated_ids == []
     assert len(result.failures) == 1
+
+    payload = json.loads((cache_queries_dir / "Q4.json").read_text(encoding="utf-8"))
+    assert payload == existing_payload
+
+
+def test_hydrate_value_lists_fails_on_duplicate_non_core_conflict(
+    monkeypatch, tmp_path
+):
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    queries_dir = tmp_path / "queries"
+    cache_queries_dir = tmp_path / "cache" / "queries"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+    cache_queries_dir.mkdir(parents=True, exist_ok=True)
+
+    (cache_entities_dir / "Q4.json").write_text(
+        json.dumps(
+            {
+                "entity_id": "Q4",
+                "entity": {
+                    "claims": {
+                        "P1": [_claim_entity_id("Q7")],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    existing_payload = {
+        "metadata": {
+            "entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+            "query": "queries/Q4.sparql",
+        },
+        "items": [{"item": "http://www.wikidata.org/entity/Q999", "itemLabel": "Old"}],
+    }
+    (cache_queries_dir / "Q4.json").write_text(
+        json.dumps(existing_payload, indent=2),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "gkc.spirit_safe.fetch_mediawiki_page_wikitext",
+        lambda api_client, title: "<sparql>SELECT ?item ?itemLabel ?domain WHERE { ?item ?p ?o }</sparql>",
+    )
+    monkeypatch.setattr(
+        "gkc.spirit_safe.paginate_query",
+        lambda **kwargs: [
+            {
+                "item": "http://www.wikidata.org/entity/Q1",
+                "itemLabel": "Alpha",
+                "domain": "en.wikipedia.org",
+            },
+            {
+                "item": "http://www.wikidata.org/entity/Q1",
+                "itemLabel": "Alpha",
+                "domain": "fr.wikipedia.org",
+            },
+        ],
+    )
+
+    result = gkc.hydrate_value_lists_from_cache(
+        cache_entities_dir=cache_entities_dir,
+        queries_dir=queries_dir,
+        cache_queries_dir=cache_queries_dir,
+        api_url="https://datadistillery.wikibase.cloud/w/api.php",
+        endpoint="https://datadistillery.wikibase.cloud/query/sparql",
+        fail_on_hydration_error=False,
+    )
+
+    assert result.discovered_ids == ["Q4"]
+    assert result.hydrated_ids == []
+    assert len(result.failures) == 1
+    assert "Duplicate value-list row conflict" in result.failures[0]["error"]
 
     payload = json.loads((cache_queries_dir / "Q4.json").read_text(encoding="utf-8"))
     assert payload == existing_payload


### PR DESCRIPTION
## Summary
- extend value-list hydration to preserve optional SPARQL bindings alongside required item/itemLabel
- add metadata.columns to hydrated cache payloads so downstream consumers can discover available fields
- enforce duplicate-item conflict detection for non-core fields to keep value-list artifacts unambiguous
- add regression tests for extended field persistence and conflict failure behavior

## Why
This supports the initial URL interpretation MVP by allowing value-list caches (e.g. Q63) to carry dbname/domain while retaining stable item/itemLabel semantics.

Closes #173

## Validation
- poetry run pytest tests/test_spirit_safe_value_lists.py -q
- poetry run pytest tests/test_fermenter_value_list.py tests/test_wizard_value_list_integration.py -q
- bash scripts/pre-merge-check.sh