### PR TITLE
Add dedicated gkc wizard CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,18 @@ poetry install
 
 ## Quick Start
 
+
 For detailed usage instructions, see the [full documentation](https://skybristol.github.io/gkc).
+
+### Launching the Interactive Wizard
+
+To curate entities using a guided workflow, launch the wizard with:
+
+```bash
+gkc wizard --profile Q4 --local-root /path/to/SpiritSafe
+```
+
+Replace `Q4` with your target profile and adjust the path as needed.
 
 ### Authentication
 

--- a/docs/gkc/cli/index.md
+++ b/docs/gkc/cli/index.md
@@ -89,10 +89,11 @@ Get raw Wikidata JSON output for scripting:
 gkc --json mash qid Q42 --output json
 ```
 
-Launch the profile wizard shell:
+
+Launch the interactive profile wizard:
 
 ```bash
-gkc packet create --profile Q4 --mode bulk --depth 1 --source local --local-root /path/to/SpiritSafe
+gkc wizard --profile Q4 --local-root /path/to/SpiritSafe
 ```
 
 ## Getting Help

--- a/docs/gkc/setup.md
+++ b/docs/gkc/setup.md
@@ -88,6 +88,21 @@ export DD_WB_USERNAME="your_dd_username"
 export DD_WB_PASSWORD="your_dd_password"
 ```
 
+
+---
+
+## 6. Launch the Interactive Wizard
+
+To curate entities using a guided workflow, launch the wizard with:
+
+```bash
+gkc wizard --profile Q4 --local-root /path/to/SpiritSafe
+```
+
+Replace `Q4` with your target profile and adjust the path as needed.
+
+---
+
 Then verify command availability and connectivity:
 
 ```bash

--- a/docs/gkc/wizard.md
+++ b/docs/gkc/wizard.md
@@ -4,6 +4,19 @@
 
 ---
 
+
+## Launching the Wizard
+
+To start the interactive profile wizard, use the dedicated CLI command:
+
+```bash
+gkc wizard --profile Q4 --local-root /path/to/SpiritSafe
+```
+
+Replace `Q4` with the desired profile QID and adjust the path as needed. This launches the Streamlit-based wizard for guided entity curation.
+
+---
+
 ## Overview
 
 GKC Wizards are **profile-driven user interfaces** that transform declarative JSON Entity Profile definitions into guided, step-by-step data entry workflows. Every aspect of the wizard—field labels, validation rules, input widgets, help text, and workflow organization—derives directly from the profile with zero hardcoded entity logic.

--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -388,7 +388,7 @@ def _build_parser() -> argparse.ArgumentParser:
         command_path="shex.validate",
     )
 
-    # Profile commands
+    # Profile commands (minus removed 'form' entry)
     profile_parser = subparsers.add_parser("profile", help="Profile utilities")
     profile_subparsers = profile_parser.add_subparsers(dest="profile_command")
 
@@ -478,32 +478,33 @@ def _build_parser() -> argparse.ArgumentParser:
         command_path="profile.export_json",
     )
 
-    profile_run_form = profile_subparsers.add_parser(
-        "form", help="Launch an interactive Streamlit wizard for a JSON profile"
+    # New top-level 'wizard' command
+    wizard_parser = subparsers.add_parser(
+        "wizard", help="Launch the interactive GKC curation wizard (Streamlit UI)"
     )
-    profile_run_form.add_argument(
+    wizard_parser.add_argument(
         "--profile",
         required=True,
         help="Profile reference (QID or full profile entity URI)",
     )
-    profile_run_form.add_argument(
+    wizard_parser.add_argument(
         "--qid",
         help="Optional Wikidata item ID for editing an existing item",
     )
-    profile_run_form.add_argument(
+    wizard_parser.add_argument(
         "--packet",
         help="Path to curation packet JSON file for multi-entity workflow",
     )
-    profile_run_form.add_argument(
+    wizard_parser.add_argument(
         "--depth",
         type=int,
         default=1,
         help="Related profile depth when creating packet on-the-fly (default: 1)",
     )
-    _add_profile_source_args(profile_run_form)
-    profile_run_form.set_defaults(
-        handler=_handle_profile_form,
-        command_path="profile.form",
+    _add_profile_source_args(wizard_parser)
+    wizard_parser.set_defaults(
+        handler=_handle_wizard,
+        command_path="wizard",
     )
 
     profile_lookups = profile_subparsers.add_parser(
@@ -2104,8 +2105,9 @@ def _handle_profile_form_schema(args: argparse.Namespace) -> dict[str, Any]:
         _restore_source_override(previous_source, source_overridden)
 
 
-def _handle_profile_form(args: argparse.Namespace) -> dict[str, Any]:
-    """Launch an interactive Streamlit wizard from a JSON profile or packet.
+# New handler for 'wizard' CLI entry
+def _handle_wizard(args: argparse.Namespace) -> dict[str, Any]:
+    """Launch the interactive GKC curation wizard (Streamlit UI).
 
     Note: Starts a local Streamlit server at http://localhost:8501
     """
@@ -2130,8 +2132,7 @@ def _handle_profile_form(args: argparse.Namespace) -> dict[str, Any]:
             from gkc.profiles.forms import streamlit_app
         except ImportError as exc:
             raise CLIError(
-                "Streamlit UI dependencies are unavailable. Install `streamlit` to use "
-                "`gkc profile form`."
+                "Streamlit UI dependencies are unavailable. Install `streamlit` to use `gkc wizard`."
             ) from exc
 
         # Get path to streamlit_app.py module

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1301,46 +1301,20 @@ def test_profile_form_schema_resolves_profile_name_local_source(capsys):
             output_path.unlink()
 
 
-def test_profile_form_launches_streamlit_app(monkeypatch):
-    """Profile form command loads JSON profile and runs Streamlit app."""
+def test_wizard_cli_launches_streamlit(monkeypatch):
+    """gkc wizard launches Streamlit wizard app with correct args."""
     local_root = Path(__file__).parent / "fixtures" / "spiritsafe"
 
-    args = argparse.Namespace(
-        profile="Q4",
-        qid="Q123",
-        packet=None,
-        source="local",
-        local_root=str(local_root),
-        repo=None,
-        github_ref=None,
-        depth=1,
-        command_path="profile.form",
-    )
-
     class FakeResult:
         returncode = 0
 
-    def fake_run(*args, **kwargs):
-        return FakeResult()
-
-    monkeypatch.setattr("subprocess.run", fake_run)
-
-    result = cli._handle_profile_form(args)
-    assert result["ok"] is True
-    assert result["details"]["qid"] == "Q123"
-
-
-def test_profile_form_from_profile_name_with_local_source(monkeypatch):
-    """Profile form command resolves QID references via local SpiritSafe source override.
-
-    This test verifies profile resolution with local source while mocking Streamlit launch.
-    """
-    fixtures_root = Path(__file__).parent / "fixtures" / "spiritsafe"
-
-    class FakeResult:
-        returncode = 0
-
-    def fake_run(*args, **kwargs):
+    def fake_run(cmd, env=None, **kwargs):
+        assert cmd[1:3] == ["-m", "streamlit"]
+        assert "run" in cmd
+        assert any("streamlit_app.py" in str(arg) for arg in cmd)
+        assert env["GKC_WIZARD_PROFILE"].endswith("/Q4")
+        assert env["GKC_SPIRIT_SAFE_SOURCE_MODE"] == "local"
+        assert env["GKC_SPIRIT_SAFE_LOCAL_ROOT"] == str(local_root)
         return FakeResult()
 
     monkeypatch.setattr("subprocess.run", fake_run)
@@ -1348,17 +1322,15 @@ def test_profile_form_from_profile_name_with_local_source(monkeypatch):
     exit_code = cli.main(
         [
             "--json",
-            "profile",
-            "form",
+            "wizard",
             "--profile",
             "Q4",
             "--source",
             "local",
             "--local-root",
-            str(fixtures_root),
+            str(local_root),
         ]
     )
-
     assert exit_code == 0
 
 


### PR DESCRIPTION
## Summary
- add a dedicated top-level gkc wizard CLI command for launching the Streamlit curation UI
- remove legacy profile form command wiring and route wizard launch through the new handler
- update docs and quick-start examples to use gkc wizard
- replace legacy profile form CLI tests with wizard CLI coverage

## Validation
- poetry run pytest tests/test_cli.py -k wizard_cli_launches_streamlit -q
- bash scripts/pre-merge-check.sh