### PR TITLE
Refactor fermenter statement-instance conformance contract

### DIFF
--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -96,10 +96,11 @@ Responsibility:
 
 - Validate and coerce inbound values using profile-defined directives.
 - Provide atomic datatype validators and coercion primitives.
-- Enforce fixed values, value-list constraints, and reference-level constraints.
+- Enforce fixed values, value-list constraints, and full statement-shape constraints (value + qualifiers + references).
 - Enforce derived-value constraints (for example, reference/qualifier values sourced from parent statement values).
 - Validate packet-level compatibility and lifecycle conformance for long-lived curation packets.
 - Emit shared `ConformanceNotice` records with actionable feedback.
+- Serialize packet-facing statement conformance records from atomic statement evaluations.
 
 Out of scope:
 
@@ -117,7 +118,10 @@ Current anchor surface:
 - `coerce_*` datatype coercers
 - `normalize_claim_value`
 - `evaluate_statement_claim`
+- `evaluate_statement_instance`
 - `evaluate_entity`
+- `statement_evaluation_to_record`
+- `conformance_notice_payloads`
 - `check_packet_integrity`
 - `validate_packet_inline`
 - `validate_packet_from_file`
@@ -206,7 +210,7 @@ Current anchor surface:
 
 1. `spirit_safe` loads and exports JSON Entity Profiles and value-list cache artifacts.
 2. `still_charger` assembles curation packets from profile JSON and charges packet entities with source values.
-3. `fermenter` validates and coerces charged values, emitting shared conformance notices.
+3. `fermenter` evaluates atomic statement instances (including qualifiers/references), coerces values, and serializes packet-facing conformance records.
 4. `wikibase` orchestration transforms charged packet data into `WikibaseShipper.plan_batch` operations.
 5. `wikibase` orchestration coordinates this flow for Data Distillery-specific workflows.
 6. `shipper` computes create/update/no-op diff plans and executes writes when enabled.
@@ -277,7 +281,7 @@ When adding new functionality, assign ownership using this matrix:
 
 ## Current Gaps to Revisit During Critical Analysis
 
-- Still Charger now emits `charged_packet["conformance"]["statement_evaluations"]` with basic `conformant`/`nonconformant` status per claim, using profile `linkage_index` to resolve linked entity traversal. Full fermenter `evaluate_entity` integration for richer buckets (`uncovered`, `missing_required`, coercion notices per claim) is the next step under issue #164.
+- `gkc.profiles.forms.validation_bridge` still contains overlapping nested qualifier/reference validation semantics. It should converge on fermenter statement-instance primitives to avoid policy drift.
 - Still Charger does not yet emit per-entity source provenance (`source_qid`, `lastrevid`, `pulled_at`) in the packet.
 - Boundaries between wikibase write planning and bottler transformation stages still need explicit acceptance criteria per phase.
 - Cross-module tests should identify failure source by layer (read, transform, payload-shape, write, orchestration).

--- a/docs/gkc/api/fermenter.md
+++ b/docs/gkc/api/fermenter.md
@@ -527,6 +527,8 @@ Atomic statement evaluation envelope:
 | `normalized_value` | `Any` | Normalized/coerced value payload |
 | `raw_claims` | `list[dict]` | Original inbound claim objects used for evaluation |
 | `notices` | `list[ConformanceNotice]` | Statement-scoped notices emitted during evaluation |
+| `qualifier_evaluations` | `list[StatementEvaluation]` | Nested evaluations for profile-defined qualifiers on the same source claim |
+| `reference_evaluations` | `list[StatementEvaluation]` | Nested evaluations for profile-defined references on the same source claim |
 
 ### `EntityEvaluation`
 
@@ -608,6 +610,82 @@ claims = [{
 evaluation = evaluate_statement_claim(statement, claims, entity_ref="Q195562")
 print(evaluation.outcome.value)  # "conformant"
 ```
+
+### `evaluate_statement_instance(profile_statement, raw_claim, *, entity_ref="", value_list_root=None)`
+
+Atomic full-shape statement primitive used by packet charging and scenario testing.
+
+This evaluates one raw Wikibase claim against one profile statement including:
+
+- main statement value constraints
+- qualifier statement constraints
+- reference statement constraints
+
+Reference-group behavior for profile statements with multiple defined references:
+
+- parent statement is conformant when at least one defined reference is conformant
+- missing alternate defined references are still reported in nested `reference_evaluations`
+- if no defined reference is conformant, parent statement receives `reference_group_missing`
+
+```python
+from gkc.fermenter import evaluate_statement_instance
+
+statement = {
+    "entity": "https://datadistillery.wikibase.cloud/entity/Q19",
+    "name_identifier": "official_website",
+    "value": {"type": "url"},
+    "io_map": [{"to": "http://www.wikidata.org/entity/P856"}],
+    "references": [
+        {
+            "entity": "https://datadistillery.wikibase.cloud/entity/Q29",
+            "name_identifier": "reference_url",
+            "value": {"type": "url"},
+            "io_map": [{"to": "http://www.wikidata.org/entity/P854"}],
+        },
+        {
+            "entity": "https://datadistillery.wikibase.cloud/entity/Q44",
+            "name_identifier": "stated_in",
+            "value": {"type": "wikibase-item"},
+            "io_map": [{"to": "http://www.wikidata.org/entity/P248"}],
+        },
+    ],
+}
+
+claim = {
+    "mainsnak": {"snaktype": "value", "datavalue": {"value": "https://example.org"}},
+    "references": [
+        {
+            "snaks": {
+                "P854": [
+                    {"snaktype": "value", "datavalue": {"value": "https://example.org/source"}}
+                ]
+            }
+        }
+    ],
+}
+
+evaluation = evaluate_statement_instance(statement, claim, entity_ref="Q14708404")
+print(evaluation.outcome.value)
+print([child.outcome.value for child in evaluation.reference_evaluations])
+```
+
+### `statement_evaluation_to_record(evaluation, profile_statement, *, entity_id, json_path)`
+
+Serialize a `StatementEvaluation` into packet conformance record shape.
+
+The serialized record includes a DD Wikibase statement reference block:
+
+```json
+{
+  "entity_id": "Q14708404",
+  "gkc_entity_statement": {
+    "id": "official_website",
+    "uri": "https://datadistillery.wikibase.cloud/entity/Q19"
+  }
+}
+```
+
+Nested qualifier and reference evaluations are serialized recursively using the same shape.
 
 ### `evaluate_entity(profile_statements, wikidata_item, *, io_map_index, entity_ref="", value_list_root=None)`
 

--- a/docs/gkc/api/still_charger.md
+++ b/docs/gkc/api/still_charger.md
@@ -178,16 +178,25 @@ The charger does not infer primary entity mappings from DD Wikibase QID tails. P
     "statement_evaluations": [
       {
         "entity_id": "Q195562",
+        "gkc_entity_statement": {
+          "id": "office_held_by_head_of_government",
+          "uri": "https://datadistillery.wikibase.cloud/entity/Q40"
+        },
         "json_path": "$.entity.claims.P1313[0]",
         "statement_uri": "https://datadistillery.wikibase.cloud/entity/Q40",
-        "status": "conformant"
+        "statement_id": "office_held_by_head_of_government",
+        "status": "conformant",
+        "outcome": "conformant"
       },
       {
         "entity_id": "Q195562",
+        "gkc_entity_statement": {
+          "id": "P31",
+          "uri": "unknown/P31"
+        },
         "json_path": "$.entity.claims.P31[0]",
         "statement_uri": "unknown/P31",
-        "status": "nonconformant",
-        "issues": ["statement not in profile"]
+        "status": "uncovered"
       }
     ]
   }
@@ -201,14 +210,19 @@ The charger does not infer primary entity mappings from DD Wikibase QID tails. P
 | Field | Type | Description |
 |---|---|---|
 | `entity_id` | `str` | Wikidata QID of the evaluated entity |
+| `gkc_entity_statement` | `dict` | DD Wikibase statement reference with keys `id` and `uri`; placed immediately below `entity_id` |
 | `json_path` | `str` | JSONPath to the evaluated claim (e.g. `$.entity.claims.P31[0]`) |
 | `statement_uri` | `str` | DD Wikibase statement URI if matched; `unknown/<prop>` if unrecognized |
-| `status` | `str` | `conformant` if the property is declared in the profile; `nonconformant` otherwise |
-| `issues` | `list[str]` | Present only on `nonconformant` records; describes the reason |
+| `statement_id` | `str` | Profile `name_identifier` for the statement when available |
+| `status` | `str` | `conformant`, `nonconformant`, or `uncovered` |
+| `outcome` | `str` | Fermenter conformance outcome (`conformant`, `non_conformant_mappable`, `missing`, `to_be_defined`) |
+| `notices` | `list[dict]` | Serialized fermenter notices for the statement |
+| `qualifiers` | `list[dict]` | Nested qualifier statement evaluation records (same shape recursively) |
+| `references` | `list[dict]` | Nested reference statement evaluation records (same shape recursively) |
 
 **Linked entity loading:** When the primary entity has claims matching a profile-declared linkage (via `metadata.linkage_index`), the linked entity is automatically fetched from Wikidata and evaluated against its target profile. Both primary and linked entities appear in `data.entities` and `conformance.entity_profile_map`.
 
-**Note:** Full fermenter integration for richer conformance buckets (`uncovered`, `missing_required`, coercion notices) is the next planned step. See [Fermenter API](fermenter.md).
+`still_charger` delegates statement-level conformance evaluation and serialization to fermenter primitives (`evaluate_statement_instance` and `statement_evaluation_to_record`). Charger owns packet orchestration and entity loading; fermenter owns conformance interpretation.
 
 ---
 

--- a/docs/gkc/entity-json-schema.md
+++ b/docs/gkc/entity-json-schema.md
@@ -244,16 +244,57 @@ Charging populates each entity slot's `data-value` fields and partitions stateme
 }
 ```
 
-### Conformance Buckets
+### Statement Evaluation Records
 
-Charged statements are classified by the fermenter evaluator into four outcomes:
+Charged packet conformance is emitted as atomic statement evaluation records under:
 
-| Outcome | Meaning | Packet location |
-|---|---|---|
-| `CONFORMANT` | Value matched profile data-type, value-list, and fixed-value constraints | `statements[name_identifier].data-value` populated |
-| `NON_CONFORMANT_MAPPABLE` | Value present but failed a constraint; retained for curator review | `statements[name_identifier]` with `non_conformant: true` and `notices` array |
-| `MISSING_REQUIRED` | Profile expected this statement but source had none | `statements[name_identifier].data-value` remains `null`; notice attached |
-| `UNCOVERED` | Source had this property but the profile does not model it | `entity.uncovered_statements` keyed by Wikidata PID |
+- `conformance.statement_evaluations`
+
+Each record is produced by fermenter statement primitives and includes the DD Wikibase statement reference block.
+
+```json
+{
+  "entity_id": "Q14708404",
+  "gkc_entity_statement": {
+    "id": "official_website",
+    "uri": "https://datadistillery.wikibase.cloud/entity/Q19"
+  },
+  "json_path": "$.entity.claims.P856[0]",
+  "statement_uri": "https://datadistillery.wikibase.cloud/entity/Q19",
+  "statement_id": "official_website",
+  "status": "conformant",
+  "outcome": "conformant",
+  "references": [
+    {
+      "entity_id": "Q14708404",
+      "gkc_entity_statement": {
+        "id": "reference_url",
+        "uri": "https://datadistillery.wikibase.cloud/entity/Q29"
+      },
+      "json_path": "$.entity.claims.P856[0].references.P854",
+      "statement_uri": "https://datadistillery.wikibase.cloud/entity/Q29",
+      "statement_id": "reference_url",
+      "status": "conformant",
+      "outcome": "conformant"
+    }
+  ]
+}
+```
+
+Outcome values (current):
+
+- `conformant`
+- `non_conformant_mappable`
+- `missing`
+- `to_be_defined`
+
+Status values used in packet records (current):
+
+- `conformant`
+- `nonconformant`
+- `uncovered`
+
+Nested qualifiers and references are serialized recursively with the same record shape.
 
 ### Source Provenance (per entity, in metadata)
 
@@ -269,23 +310,14 @@ When charging from Wikidata, each entity's source metadata is recorded under `me
 
 `lastrevid` is used when a charged packet reaches the bottling/shipping stage to detect whether the Wikidata item has changed since the packet was minted.
 
-### Conformance Summary (in packet metadata)
+### Conformance Summary
 
-A `conformance_summary` field is added to packet metadata after charging:
+No separate `metadata.conformance_summary` field is currently guaranteed by the packet contract.
 
-```json
-{
-  "conformance_summary": {
-    "conformant": 5,
-    "non_conformant": 1,
-    "uncovered": 2,
-    "missing_required": 0,
-    "notice_codes": ["datatype_mismatch", "statement_uncovered"]
-  }
-}
-```
+Callers should derive summary metrics from:
 
-This allows callers to do a single-field go/no-go check without walking the full notice list.
+- `conformance.statement_evaluations`
+- `conformance.entity_profile_map`
 
 ## Conformance and Blocking Policy
 

--- a/gkc/fermenter.py
+++ b/gkc/fermenter.py
@@ -646,6 +646,133 @@ class StatementEvaluation:
     normalized_value: Any
     raw_claims: list[dict[str, Any]]
     notices: list[ConformanceNotice] = field(default_factory=list)
+    qualifier_evaluations: list["StatementEvaluation"] = field(default_factory=list)
+    reference_evaluations: list["StatementEvaluation"] = field(default_factory=list)
+
+
+def conformance_notice_payloads(
+    notices: list[ConformanceNotice],
+) -> list[dict[str, Any]]:
+    """Serialize fermenter notices for packet/UI consumers."""
+    return [
+        {
+            "severity": notice.severity,
+            "code": notice.code,
+            "message": notice.message,
+            "statement_ref": notice.statement_ref,
+            "normalized_value": notice.normalized_value,
+        }
+        for notice in notices
+    ]
+
+
+def statement_evaluation_to_record(
+    evaluation: StatementEvaluation,
+    profile_statement: dict[str, Any],
+    *,
+    entity_id: str,
+    json_path: str,
+) -> dict[str, Any]:
+    """Serialize one atomic statement evaluation to the packet conformance shape."""
+    status = (
+        "conformant"
+        if evaluation.outcome == ConformanceOutcome.CONFORMANT
+        else "nonconformant"
+    )
+    statement_uri = _statement_ref_from_profile_statement(profile_statement)
+    statement_id = profile_statement.get("name_identifier")
+    if not isinstance(statement_id, str) or not statement_id:
+        statement_id = (
+            statement_uri.rstrip("/").split("/")[-1]
+            if isinstance(statement_uri, str) and statement_uri
+            else None
+        )
+
+    record: dict[str, Any] = {
+        "entity_id": entity_id,
+        "gkc_entity_statement": {
+            "id": statement_id,
+            "uri": statement_uri or f"unknown/{evaluation.property_ref or 'statement'}",
+        },
+        "json_path": json_path,
+        "statement_uri": statement_uri
+        or f"unknown/{evaluation.property_ref or 'statement'}",
+        "status": status,
+        "outcome": evaluation.outcome.value,
+    }
+
+    if isinstance(statement_id, str) and statement_id:
+        record["statement_id"] = statement_id
+
+    if evaluation.normalized_value is not None:
+        record["normalized_value"] = evaluation.normalized_value
+
+    if evaluation.notices:
+        record["notices"] = conformance_notice_payloads(evaluation.notices)
+
+    qualifier_records: list[dict[str, Any]] = []
+    qualifier_defs = profile_statement.get("qualifiers", [])
+    if isinstance(qualifier_defs, list):
+        qualifier_def_by_ref = {
+            _statement_ref_from_profile_statement(q): q
+            for q in qualifier_defs
+            if isinstance(q, dict)
+            and isinstance(_statement_ref_from_profile_statement(q), str)
+        }
+        for child_eval in evaluation.qualifier_evaluations:
+            child_profile = qualifier_def_by_ref.get(child_eval.statement_ref)
+            if not isinstance(child_profile, dict):
+                child_profile = {
+                    "entity": child_eval.statement_ref,
+                    "name_identifier": child_eval.statement_ref,
+                }
+            child_property_ref = (
+                _statement_property_ref(child_profile) or child_eval.property_ref
+            )
+            child_path = f"{json_path}.qualifiers.{child_property_ref or 'unknown'}"
+            qualifier_records.append(
+                statement_evaluation_to_record(
+                    child_eval,
+                    child_profile,
+                    entity_id=entity_id,
+                    json_path=child_path,
+                )
+            )
+    if qualifier_records:
+        record["qualifiers"] = qualifier_records
+
+    reference_records: list[dict[str, Any]] = []
+    reference_defs = profile_statement.get("references", [])
+    if isinstance(reference_defs, list):
+        reference_def_by_ref = {
+            _statement_ref_from_profile_statement(r): r
+            for r in reference_defs
+            if isinstance(r, dict)
+            and isinstance(_statement_ref_from_profile_statement(r), str)
+        }
+        for child_eval in evaluation.reference_evaluations:
+            child_profile = reference_def_by_ref.get(child_eval.statement_ref)
+            if not isinstance(child_profile, dict):
+                child_profile = {
+                    "entity": child_eval.statement_ref,
+                    "name_identifier": child_eval.statement_ref,
+                }
+            child_property_ref = (
+                _statement_property_ref(child_profile) or child_eval.property_ref
+            )
+            child_path = f"{json_path}.references.{child_property_ref or 'unknown'}"
+            reference_records.append(
+                statement_evaluation_to_record(
+                    child_eval,
+                    child_profile,
+                    entity_id=entity_id,
+                    json_path=child_path,
+                )
+            )
+    if reference_records:
+        record["references"] = reference_records
+
+    return record
 
 
 @dataclass
@@ -776,6 +903,259 @@ def _resolve_statement_value_list_path(
     if reference_path.is_absolute():
         return reference_path
     return value_list_root / reference_path
+
+
+def _snak_to_claim(snak: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(snak, dict):
+        return None
+    return {"mainsnak": snak}
+
+
+def _claim_qualifiers_by_property(
+    raw_claim: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    qualifiers = raw_claim.get("qualifiers", {})
+    if not isinstance(qualifiers, dict):
+        return {}
+
+    normalized: dict[str, list[dict[str, Any]]] = {}
+    for property_id, snaks in qualifiers.items():
+        if not isinstance(property_id, str) or not property_id:
+            continue
+        if not isinstance(snaks, list):
+            continue
+        normalized[property_id] = [
+            wrapped
+            for snak in snaks
+            if isinstance((wrapped := _snak_to_claim(snak)), dict)
+        ]
+    return normalized
+
+
+def _claim_references_by_property(
+    raw_claim: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    references = raw_claim.get("references", [])
+    if not isinstance(references, list):
+        return {}
+
+    normalized: dict[str, list[dict[str, Any]]] = {}
+    for reference_block in references:
+        if not isinstance(reference_block, dict):
+            continue
+        snaks = reference_block.get("snaks", {})
+        if not isinstance(snaks, dict):
+            continue
+        for property_id, property_snaks in snaks.items():
+            if not isinstance(property_id, str) or not property_id:
+                continue
+            if not isinstance(property_snaks, list):
+                continue
+            normalized.setdefault(property_id, []).extend(
+                wrapped
+                for snak in property_snaks
+                if isinstance((wrapped := _snak_to_claim(snak)), dict)
+            )
+    return normalized
+
+
+def _missing_nested_statement_evaluation(
+    profile_statement: dict[str, Any],
+    *,
+    entity_ref: str,
+    code: str,
+    message: str,
+) -> StatementEvaluation:
+    statement_ref = _statement_ref_from_profile_statement(profile_statement)
+    property_ref = _statement_property_ref(profile_statement)
+    return StatementEvaluation(
+        outcome=ConformanceOutcome.MISSING,
+        statement_ref=statement_ref,
+        property_ref=property_ref,
+        normalized_value=None,
+        raw_claims=[],
+        notices=[
+            ConformanceNotice(
+                severity="warning",
+                entity_ref=entity_ref,
+                statement_ref=statement_ref,
+                code=code,
+                message=message,
+            )
+        ],
+    )
+
+
+def evaluate_statement_instance(
+    profile_statement: dict[str, Any],
+    raw_claim: dict[str, Any],
+    *,
+    entity_ref: str = "",
+    value_list_root: Optional[Path] = None,
+) -> StatementEvaluation:
+    """Evaluate one raw Wikidata statement claim against the full profile shape.
+
+    This is the atomic fermenter surface used by packet conformance reporting.
+    It validates the statement value itself plus any profile-defined qualifiers and
+    references present on the raw claim.
+    """
+    base_evaluation = evaluate_statement_claim(
+        profile_statement,
+        [raw_claim],
+        entity_ref=entity_ref,
+        value_list_root=value_list_root,
+    )
+    if not isinstance(raw_claim, dict):
+        return base_evaluation
+
+    qualifier_evaluations: list[StatementEvaluation] = []
+    reference_evaluations: list[StatementEvaluation] = []
+    qualifiers_by_property = _claim_qualifiers_by_property(raw_claim)
+    references_by_property = _claim_references_by_property(raw_claim)
+
+    qualifier_defs = profile_statement.get("qualifiers", [])
+    qualifier_property_ids: set[str] = set()
+    if isinstance(qualifier_defs, list):
+        for qualifier_def in qualifier_defs:
+            if not isinstance(qualifier_def, dict):
+                continue
+            qualifier_property = _statement_property_ref(qualifier_def)
+            if not qualifier_property:
+                continue
+            qualifier_property_ids.add(qualifier_property)
+            qualifier_claims = qualifiers_by_property.get(qualifier_property, [])
+            if qualifier_claims:
+                child_eval = evaluate_statement_claim(
+                    qualifier_def,
+                    qualifier_claims,
+                    entity_ref=entity_ref,
+                    value_list_root=value_list_root,
+                )
+            else:
+                child_eval = _missing_nested_statement_evaluation(
+                    qualifier_def,
+                    entity_ref=entity_ref,
+                    code="qualifier_missing",
+                    message="Expected qualifier is missing from this statement value.",
+                )
+            qualifier_evaluations.append(child_eval)
+
+    for property_id, qualifier_claims in qualifiers_by_property.items():
+        if property_id in qualifier_property_ids:
+            continue
+        qualifier_evaluations.append(
+            StatementEvaluation(
+                outcome=ConformanceOutcome.TO_BE_DEFINED,
+                statement_ref=f"unknown/{property_id}",
+                property_ref=property_id,
+                normalized_value=None,
+                raw_claims=qualifier_claims,
+                notices=[
+                    ConformanceNotice(
+                        severity="warning",
+                        entity_ref=entity_ref,
+                        statement_ref=f"unknown/{property_id}",
+                        code="qualifier_unexpected",
+                        message=(
+                            f"Qualifier {property_id} is not defined in profile statement."
+                        ),
+                    )
+                ],
+            )
+        )
+
+    reference_defs = profile_statement.get("references", [])
+    reference_property_ids: set[str] = set()
+    defined_reference_evaluations: list[StatementEvaluation] = []
+    if isinstance(reference_defs, list):
+        for reference_def in reference_defs:
+            if not isinstance(reference_def, dict):
+                continue
+            reference_property = _statement_property_ref(reference_def)
+            if not reference_property:
+                continue
+            reference_property_ids.add(reference_property)
+            reference_claims = references_by_property.get(reference_property, [])
+            if reference_claims:
+                child_eval = evaluate_statement_claim(
+                    reference_def,
+                    reference_claims,
+                    entity_ref=entity_ref,
+                    value_list_root=value_list_root,
+                )
+            else:
+                child_eval = _missing_nested_statement_evaluation(
+                    reference_def,
+                    entity_ref=entity_ref,
+                    code="reference_missing",
+                    message="Expected reference not provided.",
+                )
+            reference_evaluations.append(child_eval)
+            defined_reference_evaluations.append(child_eval)
+
+    for property_id, reference_claims in references_by_property.items():
+        if property_id in reference_property_ids:
+            continue
+        reference_evaluations.append(
+            StatementEvaluation(
+                outcome=ConformanceOutcome.TO_BE_DEFINED,
+                statement_ref=f"unknown/{property_id}",
+                property_ref=property_id,
+                normalized_value=None,
+                raw_claims=reference_claims,
+                notices=[
+                    ConformanceNotice(
+                        severity="warning",
+                        entity_ref=entity_ref,
+                        statement_ref=f"unknown/{property_id}",
+                        code="reference_unexpected",
+                        message=(
+                            f"Reference {property_id} is not defined in profile statement."
+                        ),
+                    )
+                ],
+            )
+        )
+
+    base_evaluation.qualifier_evaluations = qualifier_evaluations
+    base_evaluation.reference_evaluations = reference_evaluations
+
+    qualifier_failure = any(
+        child_eval.outcome != ConformanceOutcome.CONFORMANT
+        for child_eval in qualifier_evaluations
+    )
+
+    reference_group_failure = False
+    if defined_reference_evaluations:
+        has_conformant_reference = any(
+            child_eval.outcome == ConformanceOutcome.CONFORMANT
+            for child_eval in defined_reference_evaluations
+        )
+        reference_group_failure = not has_conformant_reference
+        if reference_group_failure:
+            base_evaluation.notices.append(
+                ConformanceNotice(
+                    severity="error",
+                    entity_ref=entity_ref,
+                    statement_ref=base_evaluation.statement_ref,
+                    code="reference_group_missing",
+                    message=(
+                        "At least one profile-defined reference is required for this statement."
+                    ),
+                )
+            )
+
+    unexpected_nested_failure = any(
+        child_eval.outcome == ConformanceOutcome.TO_BE_DEFINED
+        for child_eval in qualifier_evaluations + reference_evaluations
+    )
+
+    if base_evaluation.outcome == ConformanceOutcome.CONFORMANT and (
+        qualifier_failure or reference_group_failure or unexpected_nested_failure
+    ):
+        base_evaluation.outcome = ConformanceOutcome.NON_CONFORMANT_MAPPABLE
+
+    return base_evaluation
 
 
 def normalize_claim_value(
@@ -2184,6 +2564,14 @@ def _values_equal(val1: Any, val2: Any) -> bool:
     """Check equality between two values, handling Wikibase structures."""
     if val1 == val2:
         return True
+
+    # Normalize Wikibase item-like values to canonical URI when possible.
+    # This aligns profile-side wizard item dicts ({"item": ...}) with
+    # Wikidata claim-side snakvalue dicts ({"id": ...}) and QID/URI strings.
+    uri1 = _normalize_item_to_uri(val1)
+    uri2 = _normalize_item_to_uri(val2)
+    if uri1 is not None and uri2 is not None:
+        return uri1 == uri2
 
     # Special handling for wikibase-item dicts
     if isinstance(val1, dict) and isinstance(val2, dict):

--- a/gkc/still_charger.py
+++ b/gkc/still_charger.py
@@ -16,7 +16,11 @@ from pathlib import Path
 from typing import Any, Optional
 
 import gkc
-from gkc.fermenter import ConformanceNotice
+from gkc.fermenter import (
+    ConformanceNotice,
+    evaluate_statement_instance,
+    statement_evaluation_to_record,
+)
 
 
 @dataclass
@@ -214,6 +218,32 @@ def _profile_statement_map(
             statement_by_property.setdefault(property_id, statement_uri)
 
     return statement_by_property, allowed_properties
+
+
+def _statement_uri_to_name_identifier_map(
+    profile_meta: dict[str, Any],
+) -> dict[str, str]:
+    """Return statement_uri -> name_identifier map for conformance reporting.
+
+    Enables human-readable statement identifiers in conformance output alongside URIs.
+    """
+    uri_to_name: dict[str, str] = {}
+
+    statements = profile_meta.get("statements", [])
+    if not isinstance(statements, list):
+        return uri_to_name
+
+    for stmt in statements:
+        if not isinstance(stmt, dict):
+            continue
+        statement_uri = stmt.get("entity")
+        if not isinstance(statement_uri, str) or not statement_uri:
+            continue
+        name_id = _statement_name_identifier(stmt)
+        if name_id:
+            uri_to_name[statement_uri] = name_id
+
+    return uri_to_name
 
 
 def packet_entities(packet: dict[str, Any]) -> list[dict[str, Any]]:
@@ -541,19 +571,6 @@ def _claims_to_values(raw_claims: list[dict[str, Any]]) -> list[Any]:
     return values
 
 
-def _notice_payloads(notices: list[ConformanceNotice]) -> list[dict[str, Any]]:
-    return [
-        {
-            "severity": notice.severity,
-            "code": notice.code,
-            "message": notice.message,
-            "statement_ref": notice.statement_ref,
-            "normalized_value": notice.normalized_value,
-        }
-        for notice in notices
-    ]
-
-
 def _build_unified_graph(
     profile_docs: dict[str, dict[str, Any]],
     name_by_uri: dict[str, str],
@@ -763,6 +780,7 @@ def build_curation_packet_from_json_profile(
     json_profile_doc: dict,
     *,
     source_root: Optional[Path] = None,
+    source_config: Optional[dict[str, Any]] = None,
 ) -> dict:
     """Build a curation packet from a JSON Entity Profile document.
 
@@ -886,6 +904,7 @@ def build_curation_packet_from_json_profile(
             "generator": "gkc.still_charger.build_curation_packet_from_json_profile",
             "gkc_version": gkc.__version__,
         },
+        "source": source_config or {},
     }
 
     metadata_digest = _canonical_json_digest(metadata)
@@ -940,10 +959,17 @@ def create_curation_packet(
         profile_doc.setdefault("metadata", {})["profile_graph"] = []
 
     source = get_spirit_safe_source()
+    source_config: dict[str, Any] = {"mode": source.mode}
+    if source.mode == "local" and source.local_root is not None:
+        source_config["local_root"] = str(source.local_root)
+    else:
+        source_config["github_repo"] = source.github_repo
+        source_config["github_ref"] = source.github_ref
     packet = build_curation_packet_from_json_profile(
         profile_entity=profile_uri,
         json_profile_doc=profile_doc,
         source_root=source.local_root if source.mode == "local" else None,
+        source_config=source_config,
     )
     packet["operation_mode"] = operation_mode
     return packet
@@ -1174,6 +1200,14 @@ def _load_and_evaluate_linked_entities(
     all_entities = {primary_qid: primary_entity}
     all_entities.update(linked_entities_by_qid)
 
+    # Resolve value_list_root from packet source metadata
+    source_meta = packet.get("metadata", {}).get("source", {})
+    value_list_root: Optional[Path] = None
+    if isinstance(source_meta, dict) and source_meta.get("mode") == "local":
+        local_root_str = source_meta.get("local_root")
+        if isinstance(local_root_str, str) and local_root_str:
+            value_list_root = Path(local_root_str)
+
     for entity_qid, entity_json in all_entities.items():
         profile_uri = entity_profile_map.get(entity_qid)
         if not isinstance(profile_uri, str):
@@ -1187,7 +1221,20 @@ def _load_and_evaluate_linked_entities(
         if not isinstance(profile_statements, list):
             continue
 
-        statement_by_property, profile_props = _profile_statement_map(profile_meta)
+        statement_by_property, _ = _profile_statement_map(profile_meta)
+        uri_to_name_identifier = _statement_uri_to_name_identifier_map(profile_meta)
+
+        # Build property_id -> full profile statement dict for fermenter evaluation
+        stmt_by_prop: dict[str, dict[str, Any]] = {}
+        for stmt in profile_statements:
+            if not isinstance(stmt, dict):
+                continue
+            for mapping in stmt.get("io_map", []):
+                if not isinstance(mapping, dict):
+                    continue
+                prop_id = _extract_wikidata_property_id(mapping.get("to"))
+                if prop_id:
+                    stmt_by_prop.setdefault(prop_id, stmt)
 
         # Evaluate each claim in entity against profile
         entity_claims = entity_json.get("claims", {})
@@ -1195,29 +1242,44 @@ def _load_and_evaluate_linked_entities(
             if not isinstance(claims_list, list):
                 continue
 
+            matching_stmt_uri = statement_by_property.get(prop_key)
+            profile_stmt = stmt_by_prop.get(prop_key)
+
             for claim_idx, claim in enumerate(claims_list):
                 if not isinstance(claim, dict):
                     continue
 
-                # Build JSON path for this claim
                 json_path = f"$.entity.claims.{prop_key}[{claim_idx}]"
 
-                # Check if this property is in the profile
-                is_conformant = prop_key in profile_props
+                if profile_stmt is None:
+                    # Property not covered by any profile statement
+                    statement_evaluations.append(
+                        {
+                            "entity_id": entity_qid,
+                            "json_path": json_path,
+                            "statement_uri": f"unknown/{prop_key}",
+                            "status": "uncovered",
+                        }
+                    )
+                    continue
 
-                matching_stmt_uri = statement_by_property.get(prop_key)
+                stmt_eval = evaluate_statement_instance(
+                    profile_stmt,
+                    claim,
+                    entity_ref=entity_qid,
+                    value_list_root=value_list_root,
+                )
+                evaluation = statement_evaluation_to_record(
+                    stmt_eval,
+                    profile_stmt,
+                    entity_id=entity_qid,
+                    json_path=json_path,
+                )
 
-                status = "conformant" if is_conformant else "nonconformant"
-
-                evaluation = {
-                    "entity_id": entity_qid,
-                    "json_path": json_path,
-                    "statement_uri": matching_stmt_uri or f"unknown/{prop_key}",
-                    "status": status,
-                }
-
-                if not is_conformant:
-                    evaluation["issues"] = ["statement not in profile"]
+                if matching_stmt_uri:
+                    stmt_id = uri_to_name_identifier.get(matching_stmt_uri)
+                    if stmt_id:
+                        evaluation["statement_id"] = stmt_id
 
                 statement_evaluations.append(evaluation)
 

--- a/tests/test_fermenter_evaluator.py
+++ b/tests/test_fermenter_evaluator.py
@@ -7,6 +7,7 @@ from gkc.fermenter import (
     EntityEvaluation,
     evaluate_entity,
     evaluate_statement_claim,
+    evaluate_statement_instance,
     validate_packet_from_file,
     validate_packet_inline,
 )
@@ -152,6 +153,226 @@ def test_evaluate_statement_claim_non_conformant_mappable_value_list(tmp_path: P
 
     assert evaluation.outcome == ConformanceOutcome.NON_CONFORMANT_MAPPABLE
     assert any(notice.code == "value_list_miss" for notice in evaluation.notices)
+
+
+def test_evaluate_statement_claim_conformant_with_single_item_inline_value_list():
+    statement = {
+        "id": "https://datadistillery.wikibase.cloud/entity/Q16",
+        "max_count": 1,
+        "value": {
+            "type": "wikibase-item",
+            "value_list": [{"item": "Q5", "itemLabel": "human"}],
+        },
+        "io_map": [{"to": "http://www.wikidata.org/entity/P31"}],
+    }
+    claim = _claim({"entity-type": "item", "numeric-id": 5, "id": "Q5"})
+
+    evaluation = evaluate_statement_claim(statement, [claim], entity_ref="Q195562")
+
+    assert evaluation.outcome == ConformanceOutcome.CONFORMANT
+    assert not any(
+        notice.code == "fixed_value_violation" for notice in evaluation.notices
+    )
+
+
+def test_evaluate_statement_instance_reference_group_conformant_with_one_present():
+    statement = {
+        "entity": "https://datadistillery.wikibase.cloud/entity/Q19",
+        "name_identifier": "official_website",
+        "value": {"type": "url"},
+        "io_map": [{"to": "http://www.wikidata.org/entity/P856"}],
+        "references": [
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q29",
+                "name_identifier": "reference_url",
+                "value": {"type": "url"},
+                "io_map": [{"to": "http://www.wikidata.org/entity/P854"}],
+            },
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q44",
+                "name_identifier": "stated_in",
+                "value": {"type": "wikibase-item"},
+                "io_map": [{"to": "http://www.wikidata.org/entity/P248"}],
+            },
+        ],
+    }
+    claim = {
+        "mainsnak": {
+            "snaktype": "value",
+            "datavalue": {"value": "https://example.org"},
+        },
+        "references": [
+            {
+                "snaks": {
+                    "P854": [
+                        {
+                            "snaktype": "value",
+                            "datavalue": {"value": "https://example.org/source"},
+                        }
+                    ]
+                }
+            }
+        ],
+    }
+
+    evaluation = evaluate_statement_instance(statement, claim, entity_ref="Q195562")
+
+    assert evaluation.outcome == ConformanceOutcome.CONFORMANT
+    assert len(evaluation.reference_evaluations) == 2
+    reference_by_ref = {
+        child.statement_ref: child for child in evaluation.reference_evaluations
+    }
+    assert (
+        reference_by_ref["https://datadistillery.wikibase.cloud/entity/Q29"].outcome
+        == ConformanceOutcome.CONFORMANT
+    )
+    assert (
+        reference_by_ref["https://datadistillery.wikibase.cloud/entity/Q44"].outcome
+        == ConformanceOutcome.MISSING
+    )
+
+
+def test_evaluate_statement_instance_reference_group_missing_when_none_present():
+    statement = {
+        "entity": "https://datadistillery.wikibase.cloud/entity/Q19",
+        "name_identifier": "official_website",
+        "value": {"type": "url"},
+        "io_map": [{"to": "http://www.wikidata.org/entity/P856"}],
+        "references": [
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q29",
+                "name_identifier": "reference_url",
+                "value": {"type": "url"},
+                "io_map": [{"to": "http://www.wikidata.org/entity/P854"}],
+            },
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q44",
+                "name_identifier": "stated_in",
+                "value": {"type": "wikibase-item"},
+                "io_map": [{"to": "http://www.wikidata.org/entity/P248"}],
+            },
+        ],
+    }
+    claim = {
+        "mainsnak": {
+            "snaktype": "value",
+            "datavalue": {"value": "https://example.org"},
+        },
+        "references": [],
+    }
+
+    evaluation = evaluate_statement_instance(statement, claim, entity_ref="Q195562")
+
+    assert evaluation.outcome == ConformanceOutcome.NON_CONFORMANT_MAPPABLE
+    assert any(
+        notice.code == "reference_group_missing" for notice in evaluation.notices
+    )
+    assert all(
+        child.outcome == ConformanceOutcome.MISSING
+        for child in evaluation.reference_evaluations
+    )
+
+
+def test_evaluate_statement_instance_reference_group_allows_valid_or_invalid_mix():
+    statement = {
+        "entity": "https://datadistillery.wikibase.cloud/entity/Q19",
+        "name_identifier": "official_website",
+        "value": {"type": "url"},
+        "io_map": [{"to": "http://www.wikidata.org/entity/P856"}],
+        "references": [
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q29",
+                "name_identifier": "reference_url",
+                "value": {"type": "url"},
+                "io_map": [{"to": "http://www.wikidata.org/entity/P854"}],
+            },
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q44",
+                "name_identifier": "stated_in",
+                "value": {"type": "wikibase-item"},
+                "io_map": [{"to": "http://www.wikidata.org/entity/P248"}],
+            },
+        ],
+    }
+    claim = {
+        "mainsnak": {
+            "snaktype": "value",
+            "datavalue": {"value": "https://example.org"},
+        },
+        "references": [
+            {
+                "snaks": {
+                    "P854": [
+                        {
+                            "snaktype": "value",
+                            "datavalue": {"value": "https://example.org/source"},
+                        }
+                    ],
+                    "P248": [
+                        {
+                            "snaktype": "value",
+                            "datavalue": {"value": "not-a-qid"},
+                        }
+                    ],
+                }
+            }
+        ],
+    }
+
+    evaluation = evaluate_statement_instance(statement, claim, entity_ref="Q195562")
+
+    assert evaluation.outcome == ConformanceOutcome.CONFORMANT
+    reference_by_ref = {
+        child.statement_ref: child for child in evaluation.reference_evaluations
+    }
+    assert (
+        reference_by_ref["https://datadistillery.wikibase.cloud/entity/Q29"].outcome
+        == ConformanceOutcome.CONFORMANT
+    )
+    assert (
+        reference_by_ref["https://datadistillery.wikibase.cloud/entity/Q44"].outcome
+        == ConformanceOutcome.NON_CONFORMANT_MAPPABLE
+    )
+
+
+def test_evaluate_statement_instance_qualifier_validation_fails_parent_when_invalid():
+    statement = {
+        "entity": "https://datadistillery.wikibase.cloud/entity/Q19",
+        "name_identifier": "official_website",
+        "value": {"type": "url"},
+        "io_map": [{"to": "http://www.wikidata.org/entity/P856"}],
+        "qualifiers": [
+            {
+                "entity": "https://datadistillery.wikibase.cloud/entity/Q27",
+                "name_identifier": "language_of_work_or_name",
+                "value": {"type": "wikibase-item"},
+                "io_map": [{"to": "http://www.wikidata.org/entity/P407"}],
+            }
+        ],
+    }
+    claim = {
+        "mainsnak": {
+            "snaktype": "value",
+            "datavalue": {"value": "https://example.org"},
+        },
+        "qualifiers": {
+            "P407": [
+                {
+                    "snaktype": "value",
+                    "datavalue": {"value": "not-a-qid"},
+                }
+            ]
+        },
+    }
+
+    evaluation = evaluate_statement_instance(statement, claim, entity_ref="Q195562")
+
+    assert evaluation.outcome == ConformanceOutcome.NON_CONFORMANT_MAPPABLE
+    assert len(evaluation.qualifier_evaluations) == 1
+    assert (
+        evaluation.qualifier_evaluations[0].outcome
+        == ConformanceOutcome.NON_CONFORMANT_MAPPABLE
+    )
 
 
 def test_evaluate_entity_classifies_all_buckets():

--- a/tests/test_still_charger.py
+++ b/tests/test_still_charger.py
@@ -81,6 +81,10 @@ def test_create_curation_packet_single_mode_is_primary_only():
     assert len(packet["data"]["entities"]) == 1
     graph_edges = packet["metadata"]["graph"]["edges"]
     assert all(edge.get("relationship_type") != "P161" for edge in graph_edges)
+    assert packet["metadata"]["source"]["mode"] == "local"
+    assert packet["metadata"]["source"]["local_root"].endswith(
+        "tests/fixtures/spiritsafe"
+    )
 
 
 def test_create_curation_packet_bulk_mode_expands_profile_graph():
@@ -415,6 +419,232 @@ def test_create_and_charge_packet_single_call_api():
     )
     assert "conformance" in charged
     assert "entity_profile_map" in charged["conformance"]
+
+
+def test_charge_wikidata_evaluates_claim_values_per_claim_with_fermenter() -> None:
+    packet = {
+        "packet_id": "pkt-eval-test",
+        "operation_mode": "single",
+        "metadata": {
+            "primary_profile": {
+                "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+                "name_identifier": "Q4",
+            },
+            "profiles": [
+                {
+                    "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+                    "name_identifier": "Q4",
+                    "statements": [
+                        {
+                            "entity": "https://datadistillery.wikibase.cloud/entity/Q16",
+                            "name_identifier": "instance_of",
+                            "io_map": [{"to": "http://www.wikidata.org/entity/P31"}],
+                            "value": {
+                                "type": "wikibase-item",
+                                "value_list": [{"item": "Q7840353"}],
+                            },
+                        }
+                    ],
+                    "metadata": {},
+                }
+            ],
+            "graph": {"nodes": [], "edges": []},
+            "mint": {},
+            "source": {
+                "mode": "local",
+                "local_root": str(
+                    Path(__file__).resolve().parent / "fixtures" / "spiritsafe"
+                ),
+            },
+            "integrity": {},
+        },
+        "data": {"entities": []},
+    }
+
+    class _FakeMashClient:
+        def load_entity_data(self, qid: str) -> dict:
+            _ = qid
+            return {
+                "id": "Q14708404",
+                "labels": {},
+                "descriptions": {},
+                "aliases": {},
+                "claims": {
+                    "P31": [
+                        {
+                            "mainsnak": {
+                                "datavalue": {
+                                    "value": {
+                                        "id": "Q5982983",
+                                        "entity-type": "item",
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "mainsnak": {
+                                "datavalue": {
+                                    "value": {
+                                        "id": "Q7840353",
+                                        "entity-type": "item",
+                                    }
+                                }
+                            }
+                        },
+                    ]
+                },
+            }
+
+    charged, notices = charge_packet_from_wikidata_items(
+        packet,
+        {"https://datadistillery.wikibase.cloud/entity/Q4": "Q14708404"},
+        mash_client=_FakeMashClient(),
+    )
+
+    assert notices == []
+
+    p31_evaluations = [
+        evaluation
+        for evaluation in charged["conformance"]["statement_evaluations"]
+        if evaluation["entity_id"] == "Q14708404"
+        and evaluation["statement_uri"]
+        == "https://datadistillery.wikibase.cloud/entity/Q16"
+    ]
+    assert len(p31_evaluations) == 2
+
+    first_eval = next(
+        evaluation
+        for evaluation in p31_evaluations
+        if evaluation["json_path"] == "$.entity.claims.P31[0]"
+    )
+    assert first_eval["status"] == "nonconformant"
+    assert first_eval["gkc_entity_statement"] == {
+        "id": "instance_of",
+        "uri": "https://datadistillery.wikibase.cloud/entity/Q16",
+    }
+    assert first_eval["statement_id"] == "instance_of"
+
+    second_eval = next(
+        evaluation
+        for evaluation in p31_evaluations
+        if evaluation["json_path"] == "$.entity.claims.P31[1]"
+    )
+    assert second_eval["status"] == "conformant"
+    assert second_eval["statement_id"] == "instance_of"
+
+
+def test_charge_wikidata_includes_nested_reference_conformance_records() -> None:
+    packet = {
+        "packet_id": "pkt-ref-test",
+        "operation_mode": "single",
+        "metadata": {
+            "primary_profile": {
+                "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+                "name_identifier": "Q4",
+            },
+            "profiles": [
+                {
+                    "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+                    "name_identifier": "Q4",
+                    "statements": [
+                        {
+                            "entity": "https://datadistillery.wikibase.cloud/entity/Q19",
+                            "name_identifier": "official_website",
+                            "io_map": [{"to": "http://www.wikidata.org/entity/P856"}],
+                            "value": {"type": "url"},
+                            "references": [
+                                {
+                                    "entity": "https://datadistillery.wikibase.cloud/entity/Q29",
+                                    "name_identifier": "reference_url",
+                                    "io_map": [
+                                        {"to": "http://www.wikidata.org/entity/P854"}
+                                    ],
+                                    "value": {"type": "url"},
+                                },
+                                {
+                                    "entity": "https://datadistillery.wikibase.cloud/entity/Q44",
+                                    "name_identifier": "stated_in",
+                                    "io_map": [
+                                        {"to": "http://www.wikidata.org/entity/P248"}
+                                    ],
+                                    "value": {"type": "wikibase-item"},
+                                },
+                            ],
+                        }
+                    ],
+                    "metadata": {},
+                }
+            ],
+            "graph": {"nodes": [], "edges": []},
+            "mint": {},
+            "source": {},
+            "integrity": {},
+        },
+        "data": {"entities": []},
+    }
+
+    class _FakeMashClient:
+        def load_entity_data(self, qid: str) -> dict:
+            _ = qid
+            return {
+                "id": "Q14708404",
+                "labels": {},
+                "descriptions": {},
+                "aliases": {},
+                "claims": {
+                    "P856": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "datavalue": {"value": "https://example.org"},
+                            },
+                            "references": [
+                                {
+                                    "snaks": {
+                                        "P854": [
+                                            {
+                                                "snaktype": "value",
+                                                "datavalue": {
+                                                    "value": "https://example.org/source"
+                                                },
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+
+    charged, notices = charge_packet_from_wikidata_items(
+        packet,
+        {"https://datadistillery.wikibase.cloud/entity/Q4": "Q14708404"},
+        mash_client=_FakeMashClient(),
+    )
+
+    assert notices == []
+
+    website_eval = next(
+        evaluation
+        for evaluation in charged["conformance"]["statement_evaluations"]
+        if evaluation["statement_uri"]
+        == "https://datadistillery.wikibase.cloud/entity/Q19"
+    )
+    assert website_eval["status"] == "conformant"
+    assert website_eval["gkc_entity_statement"] == {
+        "id": "official_website",
+        "uri": "https://datadistillery.wikibase.cloud/entity/Q19",
+    }
+    assert website_eval["statement_id"] == "official_website"
+    assert len(website_eval["references"]) == 2
+
+    refs_by_id = {
+        reference["statement_id"]: reference for reference in website_eval["references"]
+    }
+    assert refs_by_id["reference_url"]["status"] == "conformant"
+    assert refs_by_id["stated_in"]["status"] == "nonconformant"
+    assert refs_by_id["stated_in"]["outcome"] == "missing"
 
 
 def test_packet_helpers_resolve_entities_and_primary_profile() -> None:


### PR DESCRIPTION
Summary: move packet-facing statement conformance serialization into fermenter primitives; extend atomic statement evaluation for nested qualifiers/references; add gkc_entity_statement reference block under entity_id; update still_charger integration and API/module-contract docs. Validation: poetry run pytest tests/test_fermenter_evaluator.py tests/test_still_charger.py -q. Note: scripts/pre-merge-check.sh currently fails at repo-global mypy baseline unrelated to this change set.