### PR TITLE
Wizard #181: packet-native review staging and charged scaffold preservation

### DIFF
--- a/gkc/profiles/forms/streamlit_app.py
+++ b/gkc/profiles/forms/streamlit_app.py
@@ -114,6 +114,84 @@ def _collect_review_consequences(entity_slot: dict[str, Any]) -> dict[str, str]:
     return consequences
 
 
+def _looks_like_qid(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith("Q") and value[1:].isdigit()
+
+
+def _profile_statement_refs(entity_slot: dict[str, Any]) -> set[str]:
+    refs: set[str] = set()
+    for statement_def in entity_slot.get("statements", []):
+        if not isinstance(statement_def, dict):
+            continue
+        statement_ref = statement_def.get("entity")
+        if isinstance(statement_ref, str) and statement_ref:
+            refs.add(statement_ref)
+    return refs
+
+
+def _conformance_evaluations_for_entity(
+    *,
+    packet: dict[str, Any],
+    entity_slot: dict[str, Any],
+) -> list[dict[str, Any]]:
+    conformance = packet.get("conformance", {})
+    if not isinstance(conformance, dict):
+        return []
+
+    evaluations = conformance.get("statement_evaluations", [])
+    if not isinstance(evaluations, list):
+        return []
+
+    entity_profile_map = conformance.get("entity_profile_map", {})
+    if not isinstance(entity_profile_map, dict):
+        entity_profile_map = {}
+
+    profile_uri = entity_slot.get("profile_entity") or entity_slot.get("id")
+    entity_id = entity_slot.get("id")
+
+    candidate_entity_ids: set[str] = set()
+    if _looks_like_qid(entity_id):
+        candidate_entity_ids.add(entity_id)
+
+    if isinstance(profile_uri, str) and profile_uri:
+        for key, mapped_profile in entity_profile_map.items():
+            if mapped_profile == profile_uri and _looks_like_qid(key):
+                candidate_entity_ids.add(key)
+
+    if not candidate_entity_ids:
+        return []
+
+    filtered: list[dict[str, Any]] = []
+    for evaluation in evaluations:
+        if not isinstance(evaluation, dict):
+            continue
+        evaluation_entity_id = evaluation.get("entity_id")
+        if isinstance(evaluation_entity_id, str) and (
+            evaluation_entity_id in candidate_entity_ids
+        ):
+            filtered.append(evaluation)
+    return filtered
+
+
+def _partition_conformance_evaluations(
+    *,
+    entity_slot: dict[str, Any],
+    evaluations: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    profile_refs = _profile_statement_refs(entity_slot)
+    profile_aligned: list[dict[str, Any]] = []
+    additional: list[dict[str, Any]] = []
+
+    for evaluation in evaluations:
+        statement_uri = evaluation.get("statement_uri")
+        if isinstance(statement_uri, str) and statement_uri in profile_refs:
+            profile_aligned.append(evaluation)
+        else:
+            additional.append(evaluation)
+
+    return profile_aligned, additional
+
+
 def _group_review_items(
     *,
     entity_slot: dict[str, Any],
@@ -621,6 +699,89 @@ def _render_grouped_review_sections(
             _render_conformance_notices(ungrouped_notices)
 
 
+def _render_conformance_statement_sections(
+    *,
+    entity_slot: dict[str, Any],
+    packet: dict[str, Any],
+) -> None:
+    evaluations = _conformance_evaluations_for_entity(
+        packet=packet,
+        entity_slot=entity_slot,
+    )
+    if not evaluations:
+        st.info("No conformance statement evaluations available for this entity yet.")
+        return
+
+    profile_aligned, additional = _partition_conformance_evaluations(
+        entity_slot=entity_slot,
+        evaluations=evaluations,
+    )
+
+    st.write("#### Profile-Aligned Statements")
+    if not profile_aligned:
+        st.caption("No profile-aligned statement evaluations were found.")
+    else:
+        for evaluation in profile_aligned:
+            statement_info = evaluation.get("gkc_entity_statement", {})
+            statement_id = (
+                statement_info.get("id")
+                if isinstance(statement_info, dict)
+                else evaluation.get("statement_id")
+            )
+            status = evaluation.get("status") or "unknown"
+            outcome = evaluation.get("outcome") or "unknown"
+            json_path = evaluation.get("json_path") or ""
+            label = str(statement_id or evaluation.get("statement_uri") or "statement")
+
+            with st.expander(
+                f"{label} | status={status} | outcome={outcome}",
+                expanded=False,
+            ):
+                if json_path:
+                    st.caption(f"path: {json_path}")
+                notices = evaluation.get("notices")
+                if isinstance(notices, list) and notices:
+                    for notice in notices:
+                        if not isinstance(notice, dict):
+                            continue
+                        severity = notice.get("severity", "info")
+                        message = (
+                            f"[{notice.get('code', 'notice')}] "
+                            f"{notice.get('message', '')}"
+                        )
+                        if severity == "error":
+                            st.error(message)
+                        elif severity == "warning":
+                            st.warning(message)
+                        else:
+                            st.info(message)
+
+    st.write("#### Additional Wikibase Statements (Outside Profile)")
+    if not additional:
+        st.caption("No additional outside-profile statements detected.")
+    else:
+        for evaluation in additional:
+            statement_uri = evaluation.get("statement_uri")
+            status = evaluation.get("status") or "unknown"
+            outcome = evaluation.get("outcome") or "unknown"
+            statement_label = str(statement_uri or "unknown statement")
+            with st.expander(
+                f"{_entity_id_from_uri(statement_label)} | status={status} | outcome={outcome}",
+                expanded=False,
+            ):
+                st.caption(f"statement_uri: {statement_label}")
+                json_path = evaluation.get("json_path") or ""
+                if json_path:
+                    st.caption(f"path: {json_path}")
+                notices = evaluation.get("notices")
+                if isinstance(notices, list) and notices:
+                    for notice in notices:
+                        if isinstance(notice, dict):
+                            st.info(
+                                f"[{notice.get('code', 'notice')}] {notice.get('message', '')}"
+                            )
+
+
 def render_entity_sidebar() -> None:
     packet = st.session_state.packet or {}
     entities = _packet_entities(packet)
@@ -823,6 +984,10 @@ def render_review_step() -> None:
             notices=notices,
         )
     _render_grouped_review_sections(sections, ungrouped_notices)
+
+    if entity_slot:
+        st.write("### Conformance Evaluation")
+        _render_conformance_statement_sections(entity_slot=entity_slot, packet=packet)
 
     blocking_errors = [n for n in notices if n.severity == "error"]
     if blocking_errors:

--- a/gkc/still_charger.py
+++ b/gkc/still_charger.py
@@ -97,6 +97,10 @@ def _extract_wikidata_property_id(target: Any) -> Optional[str]:
     return None
 
 
+def _looks_like_qid(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith("Q") and value[1:].isdigit()
+
+
 def _profile_statement_routes(profile_meta: dict[str, Any]) -> list[dict[str, Any]]:
     """Return statement/property/profile routes for one profile.
 
@@ -1417,11 +1421,122 @@ def charge_packet_from_wikidata_items(
         packet, entity_profile_map, primary_entity, primary_qid, mash_client
     )
 
-    # Build charged packet with new structure
+    # Build charged packet while preserving packet-native scaffold slots.
     charged = deepcopy(packet)
 
-    # Populate data section with raw Wikibase JSON
-    charged["data"] = {"entities": data_entities}
+    raw_entity_by_qid: dict[str, dict[str, Any]] = {
+        entry.get("id"): entry.get("entity")
+        for entry in data_entities
+        if isinstance(entry, dict)
+        and isinstance(entry.get("id"), str)
+        and isinstance(entry.get("entity"), dict)
+    }
+
+    scaffold_entities = packet_entities(charged)
+    if not scaffold_entities:
+        charged["data"] = {"entities": data_entities}
+        charged["conformance"] = {
+            "entity_profile_map": entity_profile_map,
+            "statement_evaluations": statement_evaluations,
+        }
+        charged["operation_mode"] = "edit"
+        notices: list[ConformanceNotice] = []
+        return charged, notices
+
+    profiles_meta = charged.get("metadata", {}).get("profiles", [])
+    if not isinstance(profiles_meta, list):
+        profiles_meta = []
+
+    def _profile_meta_for_entity(
+        entity_slot: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        profile_uri = entity_slot.get("id")
+        profile_name = entity_slot.get("profile")
+        for profile_meta in profiles_meta:
+            if not isinstance(profile_meta, dict):
+                continue
+            if profile_uri and profile_meta.get("id") == profile_uri:
+                return profile_meta
+            if profile_name and profile_meta.get("name_identifier") == profile_name:
+                return profile_meta
+        return None
+
+    for entity_slot in scaffold_entities:
+        profile_uri = entity_slot.get("id")
+        profile_name = entity_slot.get("profile")
+
+        entity_qid = None
+        if isinstance(profile_uri, str):
+            entity_qid = qid_map.get(profile_uri)
+        if not entity_qid and isinstance(profile_name, str):
+            entity_qid = qid_map.get(profile_name)
+        if not entity_qid and isinstance(profile_uri, str):
+            for map_key, mapped_profile in entity_profile_map.items():
+                if mapped_profile == profile_uri and _looks_like_qid(map_key):
+                    entity_qid = map_key
+                    break
+
+        if not entity_qid:
+            continue
+
+        raw_entity = raw_entity_by_qid.get(entity_qid)
+        if not isinstance(raw_entity, dict):
+            continue
+
+        entity_slot["entity"] = raw_entity
+        entity_slot["wikibase_entity"] = raw_entity
+
+        labels_slot = entity_slot.get("labels")
+        if isinstance(labels_slot, dict):
+            _copy_language_values(labels_slot, raw_entity.get("labels"))
+
+        descriptions_slot = entity_slot.get("descriptions")
+        if isinstance(descriptions_slot, dict):
+            _copy_language_values(descriptions_slot, raw_entity.get("descriptions"))
+
+        aliases_slot = entity_slot.get("aliases")
+        if isinstance(aliases_slot, dict):
+            _copy_language_values(aliases_slot, raw_entity.get("aliases"), aliases=True)
+
+        profile_meta = _profile_meta_for_entity(entity_slot)
+        statements_slot = entity_slot.get("statements")
+        claims = (
+            raw_entity.get("claims")
+            if isinstance(raw_entity.get("claims"), dict)
+            else {}
+        )
+        if not isinstance(profile_meta, dict) or not isinstance(statements_slot, dict):
+            continue
+
+        statement_by_property, _ = _profile_statement_map(profile_meta)
+        uri_to_name = _statement_uri_to_name_identifier_map(profile_meta)
+
+        for property_id, statement_uri in statement_by_property.items():
+            property_claims = claims.get(property_id)
+            if not isinstance(property_claims, list):
+                continue
+
+            values = _claims_to_values(property_claims)
+            if not values:
+                continue
+
+            candidates: list[str] = []
+            statement_name = uri_to_name.get(statement_uri)
+            if isinstance(statement_name, str) and statement_name:
+                candidates.append(statement_name)
+            if isinstance(statement_uri, str) and statement_uri:
+                candidates.append(statement_uri.rstrip("/").split("/")[-1])
+                candidates.append(statement_uri)
+
+            slot_payload = None
+            for candidate in candidates:
+                payload = statements_slot.get(candidate)
+                if isinstance(payload, dict):
+                    slot_payload = payload
+                    break
+
+            if isinstance(slot_payload, dict):
+                slot_payload["data-value"] = values[0]
 
     # Populate conformance section
     conformance = {
@@ -1429,6 +1544,7 @@ def charge_packet_from_wikidata_items(
         "statement_evaluations": statement_evaluations,
     }
     charged["conformance"] = conformance
+    charged["operation_mode"] = "edit"
 
     # For now, return empty notices (will be populated by fermenter integration)
     notices: list[ConformanceNotice] = []

--- a/tests/test_still_charger.py
+++ b/tests/test_still_charger.py
@@ -412,7 +412,7 @@ def test_create_and_charge_packet_single_call_api():
         mash_client=_FakeMashClient(),
     )
 
-    assert charged["operation_mode"] == "single"
+    assert charged["operation_mode"] == "edit"
     assert len(charged["data"]["entities"]) == 1
     assert charged["data"]["entities"][0]["entity"]["labels"]["en"]["value"] == (
         "Cherokee Nation"

--- a/tests/test_wizard_review_messages.py
+++ b/tests/test_wizard_review_messages.py
@@ -3,7 +3,9 @@
 from gkc.fermenter import ConformanceNotice
 from gkc.profiles.forms.streamlit_app import (
     _collect_review_consequences,
+    _conformance_evaluations_for_entity,
     _group_review_items,
+    _partition_conformance_evaluations,
 )
 
 
@@ -108,3 +110,82 @@ def test_group_review_items_groups_consequences_and_notices() -> None:
     assert section["notices"][0].code == "datatype_invalid"
     assert len(ungrouped) == 1
     assert ungrouped[0].entity_ref == "ent-999"
+
+
+def test_conformance_evaluations_for_entity_matches_qid_via_profile_map() -> None:
+    entity_slot = {
+        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "statements": [],
+        "data": {"statements": {}},
+    }
+    packet = {
+        "conformance": {
+            "entity_profile_map": {
+                "Q195562": "https://datadistillery.wikibase.cloud/entity/Q4",
+                "Q14708404": "https://datadistillery.wikibase.cloud/entity/Q99",
+            },
+            "statement_evaluations": [
+                {
+                    "entity_id": "Q195562",
+                    "statement_uri": "https://datadistillery.wikibase.cloud/entity/Q19",
+                    "status": "conformant",
+                    "outcome": "conformant",
+                },
+                {
+                    "entity_id": "Q14708404",
+                    "statement_uri": "https://datadistillery.wikibase.cloud/entity/Q19",
+                    "status": "nonconformant",
+                    "outcome": "to_be_defined",
+                },
+            ],
+        }
+    }
+
+    evaluations = _conformance_evaluations_for_entity(
+        packet=packet, entity_slot=entity_slot
+    )
+
+    assert len(evaluations) == 1
+    assert evaluations[0]["entity_id"] == "Q195562"
+
+
+def test_partition_conformance_evaluations_splits_profile_and_additional() -> None:
+    profile_statement = "https://datadistillery.wikibase.cloud/entity/Q19"
+    uncovered_statement = "unknown/P856"
+
+    entity_slot = {
+        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "profile_entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+        "statements": [
+            {
+                "entity": profile_statement,
+                "label": "official website",
+            }
+        ],
+    }
+
+    evaluations = [
+        {
+            "entity_id": "Q195562",
+            "statement_uri": profile_statement,
+            "status": "conformant",
+            "outcome": "conformant",
+        },
+        {
+            "entity_id": "Q195562",
+            "statement_uri": uncovered_statement,
+            "status": "nonconformant",
+            "outcome": "to_be_defined",
+        },
+    ]
+
+    profile_aligned, additional = _partition_conformance_evaluations(
+        entity_slot=entity_slot,
+        evaluations=evaluations,
+    )
+
+    assert len(profile_aligned) == 1
+    assert profile_aligned[0]["statement_uri"] == profile_statement
+    assert len(additional) == 1
+    assert additional[0]["statement_uri"] == uncovered_statement


### PR DESCRIPTION
## Summary
- improve packet-native wizard review output to clearly separate:
  - profile-aligned statement evaluations
  - additional outside-profile Wikibase statements
- keep charged packet scaffolds intact in `still_charger` while attaching raw Wikibase entity payload and pre-filling slot values from claims
- switch charged packet mode to `edit` and align tests to that runtime behavior

## Why
This keeps the wizard operating directly on packet-native structures while making review-stage conformance output curator-readable for both expected and extra statements.

## Additional tracking
- Opened #190 to track module boundary cleanup: move runtime validation logic out of `profiles.validation` / `profiles.validators` and consolidate into `fermenter`.

## Validation
- `poetry run pytest tests/test_still_charger.py tests/test_wizard_review_messages.py tests/test_wizard_packet_alignment.py -q` ✅
- `bash scripts/pre-merge-check.sh` ⚠️ repo mypy baseline currently failing across multiple files (known ongoing state)

Closes #181