### PR TITLE
Lock JSON-first module boundary contracts in docs

### DIFF
--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document defines the current architectural contract between `mash`, `spirit_safe`, `still_charger`, `fermenter`, `bottler`, `shipper`, and `wikibase` for Data Distillery and broader GKC workflows.
+This document defines the current architectural contract between `mash`, `spirit_safe`, `still_charger`, `fermenter`, `wizard`, `bottler`, `shipper`, and `wikibase` for Data Distillery and broader GKC workflows.
 
 It is written as a practical anti-reinvention guide for contributors and custom agents.
 
@@ -11,6 +11,14 @@ Infrastructure perspective for these module boundaries:
 - Data Distillery Wikibase defines semantic foundation (profiles, statements, value-list semantics).
 - SpiritSafe materializes those semantics as deterministic artifacts.
 - `gkc` modules execute packet assembly, validation/coercion, planning, and shipping from those artifacts.
+
+Contract clarification (active direction):
+
+- JSON Entity Profiles materialized from DD Wikibase semantics are the only active profile runtime contract.
+- YAML-era profile loading/validation/generation is superseded and retained only as temporary legacy surface pending removal.
+- Runtime validation/coercion ownership is centralized in `fermenter`.
+- Wizard runtime ownership is centralized in `wizard`.
+- No compatibility aliasing should be introduced between `gkc.profiles.forms.*` and `gkc.wizard.*`.
 
 ## Boundary Summary
 
@@ -125,6 +133,30 @@ Current anchor surface:
 - `check_packet_integrity`
 - `validate_packet_inline`
 - `validate_packet_from_file`
+
+### Wizard (`gkc.wizard`)
+
+Responsibility:
+
+- Own interactive wizard runtime and UI orchestration.
+- Render profile-driven curation flows from packet/profile artifacts.
+- Consume `still_charger` packet assembly/charging outputs and `fermenter` conformance outputs.
+- Manage wizard-only state and UX helpers (for example draft persistence and packet-to-view adapters).
+
+Out of scope:
+
+- Runtime validation/coercion rule ownership.
+- Packet scaffold assembly ownership.
+- SpiritSafe artifact translation/materialization ownership.
+
+Current anchor surface:
+
+- Top-level CLI entry `gkc wizard` (public contract).
+- Streamlit app runtime and wizard step orchestration modules.
+
+Transition note:
+
+- Wizard runtime code currently still located under `gkc.profiles.forms` is in active migration to `gkc.wizard` and should not be treated as a stable module boundary.
 
 ### Bottler (`gkc.bottler`)
 
@@ -283,6 +315,8 @@ Current anchor surface:
 - Preserve offline-first behavior: network-backed enhancement must not break cache-only operation.
 - Preserve JSON profile export determinism (stable ordering and artifact path shape).
 - Treat packet type/shape conformance as the primary hard blocker; other conformance failures should default to actionable notices unless policy explicitly escalates them.
+- Do not add bridge/shim module aliases that preserve `gkc.profiles.forms.*` as a shadow wizard API.
+- Do not add new runtime validation/coercion logic under `gkc.profiles.*`.
 
 ## Decision Matrix for New Work
 
@@ -300,11 +334,17 @@ When adding new functionality, assign ownership using this matrix:
 
 ## Current Gaps to Revisit During Critical Analysis
 
-- `gkc.profiles.forms.validation_bridge` still contains overlapping nested qualifier/reference validation semantics. It should converge on fermenter statement-instance primitives to avoid policy drift.
+- `gkc.profiles.forms.validation_bridge` still contains overlapping nested qualifier/reference validation semantics. This logic should be moved into fermenter-owned packet-facing APIs and deleted from the profiles namespace.
 - Still Charger does not yet emit per-entity source provenance (`source_qid`, `lastrevid`, `pulled_at`) in the packet.
 - Boundaries between wikibase write planning and bottler transformation stages still need explicit acceptance criteria per phase.
 - Cross-module tests should identify failure source by layer (read, transform, payload-shape, write, orchestration).
 - Packet compatibility metadata, change classification, and forward-migration rules for long-lived offline packets remain to be implemented.
+
+Additional active boundary cleanup:
+
+- The old YAML-era `gkc.profiles` runtime path (`loaders`, `generators`, `validation`, and related CLI surfaces) is superseded and should be removed unless a concrete retained consumer is explicitly approved.
+- `GKCEntityProfile` should be integrated with fermenter-owned validation/coercion pathways (including Pydantic-backed validation surfaces where applicable).
+- Core architecture classes should remain explicit and aligned with top-level components: `GKCEntityProfile`, `GKCEntityStatement`, `GKCValueList`, and `GKCCurationPacket`.
 
 ## Theoretical Design Notes
 

--- a/docs/architecture/profile-loading.md
+++ b/docs/architecture/profile-loading.md
@@ -4,6 +4,11 @@
 
 This page documents implemented and architecturally committed behavior for profile loading in GKC and SpiritSafe-backed sources.
 
+Contract note:
+
+- The active runtime profile contract is JSON Entity Profiles materialized from DD Wikibase semantics into SpiritSafe artifacts.
+- YAML-era profile loading compatibility is legacy-only migration support and is not a forward architecture target.
+
 ## Resolution Model
 
 GKC resolves a profile reference through `resolve_profile_path()` using the canonical artifact layout:
@@ -43,6 +48,11 @@ then as:
 - Missing profile files raise path resolution errors after fallback attempts.
 - Missing query files raise `FileNotFoundError` with attempted paths.
 - Hydration can either collect failures or fail fast based on `fail_on_query_error`.
+
+## Explicit Non-Goals
+
+- Introducing new runtime dependencies on YAML profile loaders, YAML profile validators, or YAML form schema generators.
+- Preserving legacy module boundaries as compatibility shims when moving wizard runtime code into `gkc.wizard`.
 
 ## Theoretical Design Notes
 

--- a/docs/gkc/api/bottler.md
+++ b/docs/gkc/api/bottler.md
@@ -274,4 +274,4 @@ This ensures profile-only packets have shape-consistent, deterministic Wikibase 
 
 - [Still Charger API](still_charger.md) — Packet assembly and charging
 - [Fermenter API](fermenter.md) — Validation and coercion
-- [Architecture Overview](../architecture/modules.md) — Module boundaries and contracts
+- [Cross-Module Contracts](../../architecture/module-contracts.md) — Module boundaries and contracts

--- a/docs/gkc/api/index.md
+++ b/docs/gkc/api/index.md
@@ -232,12 +232,13 @@ Query Wikidata and other SPARQL endpoints.
 
 ### [Profiles](profiles.md)
 
-Profile loading surfaces for validation and form schema generation.
+Legacy module notice and contract direction for superseded YAML-era profile surfaces.
 
-**Key classes:**
-- `ProfileLoader` - Load profile artifacts
-- `ProfileValidator` - Validate Wikidata items
-- `FormSchemaGenerator` - Build form schemas
+**Current runtime owners:**
+- `spirit_safe` - JSON profile artifacts and loading
+- `still_charger` - packet assembly/charging
+- `fermenter` - validation/coercion/conformance
+- `wizard` - interactive runtime
 
 ---
 

--- a/docs/gkc/api/profiles.md
+++ b/docs/gkc/api/profiles.md
@@ -1,136 +1,44 @@
 # Profiles API
 
-## Overview
+## Status
 
-The profiles module provides entity profile loading and validation surfaces for SpiritSafe-backed runtime workflows.
+The historical `gkc.profiles` package is a legacy surface.
 
-**Current implementations:** JSON profile loading, JSON Schema validation, runtime model generation, form schema generation, Wikidata validation  
-**Future implementations:** profile registry, code generation, broader datatype support
+For current runtime workflows, JSON Entity Profiles materialized from DD Wikibase semantics are the canonical contract.
 
-## Quick Start
+Those workflows are owned by:
 
-```python
-from gkc.profiles import ProfileLoader, ProfileValidator
+- `gkc.spirit_safe` for profile artifact loading/materialization.
+- `gkc.still_charger` for packet scaffold assembly and charging.
+- `gkc.fermenter` for validation/coercion/conformance.
+- `gkc.wizard` for interactive wizard runtime.
 
-profile = ProfileLoader().load_from_file(
-    "/path/to/SpiritSafe/profiles/Q4.json"
-)
-validator = ProfileValidator(profile)
-result = validator.validate_item(item_json, policy="lenient")
-```
+## Contract Direction
 
-## Classes
+The YAML-era `gkc.profiles` loader/generator/validator path is superseded and targeted for removal unless an explicit retained consumer is approved.
 
-### ProfileLoader
+This includes:
 
-::: gkc.profiles.loaders.yaml_loader.ProfileLoader
-    options:
-      show_root_heading: false
-      heading_level: 4
+- YAML profile loaders.
+- YAML form schema generators.
+- YAML-first validation pathways.
 
-### ProfileDefinition
+Do not build new runtime integrations on top of these legacy surfaces.
 
-::: gkc.profiles.models.ProfileDefinition
-    options:
-      show_root_heading: false
-      heading_level: 4
+## Future Scope for a Reimagined Profiles Module
 
-### ProfileValidator
+If a future `profiles` module is reintroduced, it should focus on reverse-engineering and profile design support, not runtime validation ownership.
 
-::: gkc.profiles.validation.validator.ProfileValidator
-    options:
-      show_root_heading: false
-      heading_level: 4
+Example future scope:
 
-### ValidationResult
-
-::: gkc.profiles.validation.validator.ValidationResult
-    options:
-      show_root_heading: false
-      heading_level: 4
-
-### FormSchemaGenerator
-
-::: gkc.profiles.generators.form_generator.FormSchemaGenerator
-    options:
-      show_root_heading: false
-      heading_level: 4
-
-## Examples
-
-### Load a JSON Entity Profile
-
-```python
-from gkc.profiles import ProfileLoader
-
-loader = ProfileLoader()
-profile = loader.load_from_file(
-    "/path/to/SpiritSafe/profiles/Q4.json"
-)
-print(profile.name)
-```
-
-### Generate a Form Schema
-
-```python
-from gkc.profiles import FormSchemaGenerator, ProfileLoader
-
-profile = ProfileLoader().load_from_file(
-    "/path/to/SpiritSafe/profiles/Q4.json"
-)
-form_schema = FormSchemaGenerator(profile).build_schema()
-print(form_schema["statements"][0]["label"])
-```
-
-### Validate a Wikidata Item (Lenient)
-
-```python
-from gkc.profiles import ProfileLoader, ProfileValidator
-
-profile = ProfileLoader().load_from_file(
-    "/path/to/SpiritSafe/profiles/Q4.json"
-)
-validator = ProfileValidator(profile)
-result = validator.validate_item(item_json, policy="lenient")
-
-if result.ok:
-    print("Valid (lenient)")
-    for warning in result.warnings:
-        print(warning.message)
-```
-
-### Validate a Wikidata Item (Strict)
-
-```python
-from gkc.profiles import ProfileLoader, ProfileValidator
-
-profile = ProfileLoader().load_from_file(
-    "/path/to/SpiritSafe/profiles/Q4.json"
-)
-validator = ProfileValidator(profile)
-result = validator.validate_item(item_json, policy="strict")
-
-if not result.ok:
-    for error in result.errors:
-        print(error.message)
-```
-
-## Error Handling
-
-### Profile Schema Validation Errors
-
-```python
-from gkc.profiles import ProfileLoader
-
-loader = ProfileLoader()
-try:
-    loader.load_from_file("bad_profile.json")
-except ValueError as exc:
-    print(f"Schema error: {exc}")
-```
+- Analyze uncovered statements from fermenter outputs.
+- Suggest profile extensions toward `GKCEntityProfile` and `GKCEntityStatement` JSON contracts.
+- Assist DD Wikibase profile authoring workflows.
 
 ## See Also
 
-- [Mash](mash.md) - Load Wikidata items for validation
-- [ShEx](shex.md) - Schema validation against EntitySchemas
-- [CLI Profiles](../cli/profiles.md) - Profile commands
+- [Spirit Safe API](spirit_safe.md)
+- [Still Charger API](still_charger.md)
+- [Fermenter API](fermenter.md)
+- [Wizard Commands](../cli/wizard.md)
+- [Module Contracts](../../architecture/module-contracts.md)

--- a/docs/gkc/entity-json-schema.md
+++ b/docs/gkc/entity-json-schema.md
@@ -14,8 +14,13 @@ This page documents the active packet/profile contract used by:
 
 - `gkc.spirit_safe` for loading JSON Entity Profiles.
 - `gkc.still_charger` for packet scaffold assembly and charging.
-- `gkc.fermenter` and wizard validation bridge for value conformance.
+- `gkc.fermenter` for value validation/coercion and conformance notices.
 - `gkc.wikibase` and `gkc.shipper` for downstream write planning and execution.
+
+Contract clarification:
+
+- Wizard runtime consumes fermenter conformance outputs; it does not own validation semantics.
+- Any transitional wizard-side validation helpers are implementation details pending full fermenter consolidation and are not part of the long-term module contract.
 
 ## Pipeline Overview
 


### PR DESCRIPTION
## Summary
- document JSON Entity Profiles as the active runtime contract
- document fermenter as the validation/coercion owner and wizard as its own runtime boundary
- mark the historical profiles API as legacy direction rather than active YAML-era runtime guidance
- fix the broken Bottler API doc link surfaced by strict MkDocs build

## Validation
- poetry run mkdocs build --strict