### PR TITLE
Finalize #190/#193 boundary cleanup and docs

### DIFF
--- a/docs/architecture/SpiritSafe-testing.md
+++ b/docs/architecture/SpiritSafe-testing.md
@@ -286,21 +286,13 @@ def test_manifest_loading(spiritsafe_local_source):
 ```python
 def test_profile_graph_traversal(spiritsafe_local_source):
     """Test profile graph construction and traversal."""
-    from gkc.profiles.graph import ProfileGraph
-    
-    graph = ProfileGraph.load_from_manifest()
-    
-    # Get neighbors of TribalGovernmentUS
-    neighbors = graph.get_neighbors("TribalGovernmentUS")
-    assert "OfficeHeldByHeadOfState" in neighbors
-    
-    # Verify bidirectional edge
-    reverse_neighbors = graph.get_neighbors("OfficeHeldByHeadOfState")
-    assert "TribalGovernmentUS" in reverse_neighbors
-    
-    # Check cardinality constraint
-    cardinality = graph.get_cardinality("TribalGovernmentUS", "OfficeHeldByHeadOfState")
-    assert cardinality["max"] == 1
+    from gkc.spirit_safe import load_profile_package
+
+    package = load_profile_package("TribalGovernmentUS", depth=1)
+
+    # Confirm linked profile traversal from embedded metadata.profile_graph
+    assert "TribalGovernmentUS" in package["profiles"]
+    assert "OfficeHeldByHeadOfState" in package["profiles"]
 ```
 
 ### Test Coverage Goals

--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -154,9 +154,9 @@ Current anchor surface:
 - Top-level CLI entry `gkc wizard` (public contract).
 - Streamlit app runtime and wizard step orchestration modules.
 
-Transition note:
+Implementation note:
 
-- Wizard runtime code currently still located under `gkc.profiles.forms` is in active migration to `gkc.wizard` and should not be treated as a stable module boundary.
+- Wizard runtime is implemented under `gkc.wizard`.
 
 ### Bottler (`gkc.bottler`)
 

--- a/docs/gkc/api/profiles.md
+++ b/docs/gkc/api/profiles.md
@@ -15,7 +15,7 @@ Those workflows are owned by:
 
 ## Contract Direction
 
-The YAML-era `gkc.profiles` loader/generator/validator path is superseded and targeted for removal unless an explicit retained consumer is approved.
+The YAML-era `gkc.profiles` loader/generator/validator path has been removed from runtime and CLI surfaces.
 
 This includes:
 

--- a/gkc/__init__.py
+++ b/gkc/__init__.py
@@ -49,11 +49,11 @@ from gkc.entity_profile import GKCEntityProfile
 from gkc.fermenter import (
     ConformanceNotice,
     enforce_fixed_value,
-    validate_entity_packet_data,
-    validate_inline_value,
     validate_by_datatype,
     validate_commons_media,
+    validate_entity_packet_data,
     validate_globe_coordinate,
+    validate_inline_value,
     validate_monolingualtext,
     validate_quantity,
     validate_string,
@@ -261,14 +261,6 @@ __all__ = [
     "fetch_schema_specification",
     # Entity Profiles
     "GKCEntityProfile",
-    # YAML-first profiles
-    "FormSchemaGenerator",
-    "ProfileDefinition",
-    "ProfileLoader",
-    "ProfilePydanticGenerator",
-    "ProfileValidator",
-    "ValidationIssue",
-    "ValidationResult",
     # Sitelinks
     "DEFAULT_WIKIMEDIA_SITEMATRIX_URL",
     "SitelinkValidator",

--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -12,8 +12,6 @@ import sys
 from pathlib import Path
 from typing import Any, Optional
 
-import requests
-
 import gkc
 from gkc.auth import AuthenticationError, OpenStreetMapAuth, WikiverseAuth
 from gkc.mash import (
@@ -1840,93 +1838,6 @@ def _extract_validation_error_summary(results: Any) -> str:
             return first_line
 
     return "Validation failed (see --verbose for details)"
-
-
-def _handle_profile_validate(args: argparse.Namespace) -> dict[str, Any]:
-    """Validate a Wikidata item against a YAML profile."""
-    if not args.qid and not args.item_json:
-        raise CLIError("Provide either --qid or --item-json")
-    if args.qid and args.item_json:
-        raise CLIError("Use only one of --qid or --item-json")
-
-    previous_source, source_overridden = _apply_source_override(
-        args,
-        source_attr="profile_source",
-        local_root_attr="profile_local_root",
-        repo_attr="profile_repo",
-        ref_attr="profile_github_ref",
-    )
-
-    try:
-        loader = ProfileLoader()
-        profile, resolved_profile = _load_profile_from_reference(loader, args.profile)
-
-        if args.qid:
-            item = WikibaseLoader().load_item(args.qid)
-            entity_data = item.to_dict()
-            source = args.qid
-        else:
-            with open(args.item_json, "r") as f:
-                entity_data = json.load(f)
-            source = args.item_json
-
-        validator = ProfileValidator(profile)
-        result = validator.validate_item(entity_data, policy=args.policy)
-
-        details = {
-            "profile": profile.name,
-            "profile_ref": resolved_profile,
-            "policy": args.policy,
-            "source": source,
-            "errors": [issue.model_dump() for issue in result.errors],
-            "warnings": [issue.model_dump() for issue in result.warnings],
-        }
-
-        if result.ok:
-            message = "✓ Profile validation passed"
-        else:
-            message = "✗ Profile validation failed"
-
-        return {
-            "command": args.command_path,
-            "ok": result.ok,
-            "message": message,
-            "details": details,
-        }
-    finally:
-        _restore_source_override(previous_source, source_overridden)
-
-
-def _handle_profile_form_schema(args: argparse.Namespace) -> dict[str, Any]:
-    """Generate form schema from a YAML profile."""
-    previous_source, source_overridden = _apply_source_override(args)
-
-    try:
-        loader = ProfileLoader()
-        profile, resolved_profile = _load_profile_from_reference(loader, args.profile)
-
-        schema = FormSchemaGenerator(profile).build_schema()
-
-        if args.output:
-            with open(args.output, "w") as f:
-                json.dump(schema, f, indent=2)
-            message = f"Wrote form schema to {args.output}"
-        else:
-            print(json.dumps(schema))
-            message = "Form schema generated"
-
-        return {
-            "command": args.command_path,
-            "ok": True,
-            "message": message,
-            "details": {
-                "profile": profile.name,
-                "profile_ref": resolved_profile,
-                "output": args.output or "stdout",
-            },
-        }
-    finally:
-        _restore_source_override(previous_source, source_overridden)
 
 
 # New handler for 'wizard' CLI entry

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -24,7 +24,6 @@ from typing import Any, Literal, Optional, Union
 from urllib.parse import urlparse
 
 import requests
-import yaml
 
 from gkc.mash import (
     WikibaseApiClient,

--- a/tests/test_wizard_value_list_integration.py
+++ b/tests/test_wizard_value_list_integration.py
@@ -62,6 +62,7 @@ def test_filter_value_list_candidates_matches_label_qid_and_uri() -> None:
         len(_filter_value_list_candidates(candidates, "wikidata.org/entity/q42")) == 1
     )
 
+
 def test_validate_inline_value_keeps_item_metadata() -> None:
     value = {
         "id": "Q42",


### PR DESCRIPTION
## Summary

Final cleanup pass to complete #190 and #193 module-boundary work and close the remaining stage-F/documentation loose ends.

## What changed

- Removed dead YAML-era profile handlers from `gkc/cli.py`:
  - `_handle_profile_validate`
  - `_handle_profile_form_schema`
- Removed stale YAML-era exports from `gkc/__init__.py` `__all__`.
- Removed unused `yaml` import from `gkc/spirit_safe.py`.
- Updated docs to reflect completed (not in-progress) architecture state:
  - `docs/architecture/module-contracts.md`
  - `docs/gkc/api/profiles.md`
  - `docs/architecture/SpiritSafe-testing.md`
- Applied required Black formatting in `tests/test_wizard_value_list_integration.py`.

## CI failure addressed

This directly fixes the latest failing CI run on main (`Run ruff`) caused by stale dead-code references in `gkc/cli.py`:

- undefined names: `ProfileLoader`, `_load_profile_from_reference`, `ProfileValidator`, `FormSchemaGenerator`
- unused import: `requests`
- plus unused `yaml` import in `gkc/spirit_safe.py`

## Validation

- `poetry run ruff check gkc tests`
- `poetry run pytest tests/test_cli.py tests/test_docs_build.py tests/test_wizard_value_list_integration.py -q`
- `bash scripts/pre-merge-check.sh` (known repo-global mypy baseline remains non-blocking per script behavior)

Closes #190
Closes #193
