### PR TITLE
Lock still_charger docs and reseal metadata after provenance injection

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -15,7 +15,7 @@ Infrastructure components:
 
 1. **Data Distillery Wikibase** — semantic authoring system of record for profiles, statements, value lists, and linkage semantics.
 2. **SpiritSafe repository** — materialized artifact registry (JSON profiles, query files, hydrated caches, manifest, entity index).
-3. **GKC Python package** — runtime engine that consumes SpiritSafe artifacts to build packets, validate/coerce, plan writes, and ship.
+3. **GKC Python package** — runtime engine that consumes SpiritSafe artifacts to assemble packets (`still_charger`), validate/coerce (`fermenter`), plan writes, and ship.
 
 Architectural components:
 
@@ -154,7 +154,7 @@ Profiles are the *source of truth*; JSON Schemas are the *machine interface*.
 
 - **Primary entity** — The entity being directly curated
 - **Related entities** — Secondary entities linked via profile graph (e.g., offices, organizations)
-- **Packet metadata** — Creation timestamps, curator username, status tracking
+- **Packet metadata** — Profile ruleset, linkage graph, provenance, source context, and integrity sealing
 - **Dual-key identity system** — `name_identifier` is the human-facing key while `id` (URI) remains canonical for joins, provenance, and round-trip mapping
 
 **Packet Lifecycle:**
@@ -185,6 +185,7 @@ This enables dependency ordering (ship entities depth-first), audit trails, and 
 
 - [GKC Entity JSON Schema](../gkc/entity-json-schema.md)
 - [Wizard Multi-Entity Curation](../gkc/wizard.md#multi-entity-curation-sessions)
+- [Still Charger Architecture](still_charger.md)
 
 ### SpiritSafe
 

--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -77,14 +77,16 @@ Transition-only legacy surface (deferred removal):
 Responsibility:
 
 - Assemble curation packet scaffolds from Entity Profile JSON documents.
-- Fill curation packet entity scaffolds with concrete source values.
-- Support charging from Wikidata entities and other source adapters.
-- Emit shared conformance notices and charge summaries.
+- Charge packet entities from source values (Wikidata and other adapters).
+- Inject per-entity source provenance into packet metadata for charged packets.
+- Reseal packet metadata digest after charge-time metadata mutation.
+- Orchestrate packet conformance section assembly from fermenter primitives.
 
 Out of scope:
 
 - Target payload shaping for any specific destination API.
 - API transport execution.
+- Validation semantics and outcome interpretation.
 
 Current anchor surface:
 
@@ -118,7 +120,7 @@ Out of scope:
 Current anchor surface:
 
 - `ConformanceNotice`
-- `ConformanceOutcome` (string enum: `CONFORMANT`, `NON_CONFORMANT_MAPPABLE`, `UNCOVERED`, `MISSING_REQUIRED`)
+- `ConformanceOutcome` (evaluation outcome contract under active refinement; packet-facing record migration tracked in #200)
 - `StatementEvaluation`
 - `EntityEvaluation`
 - `ValidationResult`
@@ -327,10 +329,14 @@ When adding new functionality, assign ownership using this matrix:
 
 ## Current Gaps to Revisit During Critical Analysis
 
-- Still Charger does not yet emit per-entity source provenance (`source_qid`, `lastrevid`, `pulled_at`) in the packet.
 - Boundaries between wikibase write planning and bottler transformation stages still need explicit acceptance criteria per phase.
 - Cross-module tests should identify failure source by layer (read, transform, payload-shape, write, orchestration).
 - Packet compatibility metadata, change classification, and forward-migration rules for long-lived offline packets remain to be implemented.
+
+Additional contract-alignment gaps under active work:
+
+- Packet `data` remains transitional hybrid shape in current runtime implementation and must be normalized per #200 contract direction.
+- Still charger should not patch fermenter record fields post-serialization; missing fields must be addressed in fermenter-owned serializer contracts.
 
 Additional active boundary cleanup:
 

--- a/docs/architecture/still_charger.md
+++ b/docs/architecture/still_charger.md
@@ -1,0 +1,156 @@
+# Still Charger Architecture
+
+## Purpose
+
+`still_charger` is the runtime boundary between profile materialization and packet validation.
+
+It is responsible for:
+
+- Packet scaffold assembly from JSON Entity Profiles.
+- Source charging orchestration for primary and linked entities.
+- Packet mutation sequencing for metadata, data, and conformance sections.
+- Preserving packet metadata integrity by resealing digest after metadata changes.
+
+It is not responsible for validation semantics or notice interpretation. Those belong to `fermenter`.
+
+## Inputs and Outputs
+
+Inputs:
+
+- Primary profile JSON document from `spirit_safe`.
+- Related profile metadata from profile graph traversal.
+- Source entities from `mash` (Wikidata/Wikibase JSON).
+- Optional value-list cache context from SpiritSafe local source metadata.
+
+Outputs:
+
+- Curation packet scaffold (`metadata`, `data`, `conformance`).
+- Charged packet with source payloads and conformance evaluation records.
+- Charging report/notices surface for caller workflows.
+
+## Ownership Boundary
+
+Owns:
+
+- Packet assembly API surface (`create_curation_packet`, `build_curation_packet_from_json_profile`).
+- Charge orchestration API surface (`charge_packet_from_wikidata_items`, legacy `charge_curation_packet`).
+- Linked-entity resolution routing from profile linkage metadata.
+- Source provenance injection into packet metadata.
+- Metadata digest resealing after provenance mutation.
+
+Does not own:
+
+- Datatype validation/coercion semantics.
+- Conformance outcome policy definitions.
+- Destination payload shaping and remote write transport.
+- Wizard-specific view state or adapter structures.
+
+## Packet Lifecycle
+
+### Stage 1. Scaffold Assembly
+
+- Normalize primary profile identity (URI and profile name identifier).
+- Load linked profile documents from profile graph metadata.
+- Build packet metadata section:
+  - `primary_profile`
+  - `profiles`
+  - `graph`
+  - `mint`
+  - `source`
+  - `integrity`
+- Build packet data scaffold entities from profile statements.
+
+### Stage 2. Source Charging
+
+- Resolve primary source QID from caller-provided mapping.
+- Resolve linked entities referenced by linkage routes.
+- Load source entity JSON from `mash`.
+- Inject source provenance in `metadata.profiles[*]`:
+  - `source_qid`
+  - `lastrevid`
+  - `pulled_at`
+- Populate packet data entities with source payloads.
+
+### Stage 3. Conformance Assembly
+
+- Evaluate claim instances via fermenter statement primitives.
+- Serialize statement evaluation records into packet conformance section.
+- Preserve ownership separation: orchestration in `still_charger`, semantics in `fermenter`.
+
+### Stage 4. Integrity Reseal
+
+- Reseal metadata digest after charge-time metadata mutation.
+- Ensure packet re-presentation can verify metadata/actionability together.
+
+## Dependency Contracts
+
+### With SpiritSafe
+
+Consumes:
+
+- JSON profile artifacts.
+- Profile graph and linkage metadata.
+- Source mode/local root metadata for cache context.
+
+Contract note:
+
+- Packet assembly is profile-document driven and does not require manifest-based orchestration.
+
+### With Mash
+
+Consumes:
+
+- Raw entity retrieval for primary and linked QIDs.
+
+Contract note:
+
+- `still_charger` owns retrieval order and mapping to packet entities.
+- `mash` owns API retrieval mechanics and response normalization.
+
+### With Fermenter
+
+Consumes:
+
+- Atomic statement evaluation and packet-facing record serialization.
+
+Contract note:
+
+- `still_charger` should not patch or reinterpret fermenter output semantics.
+- If additional fields are required in packet conformance records, they should be emitted by fermenter serialization contract.
+
+### With Wizard
+
+Provides:
+
+- Packet surfaces consumed by wizard adapters.
+
+Contract note:
+
+- Wizard runtime structures are downstream and must not redefine packet contract shape.
+
+## Current State vs Target Direction
+
+Current state:
+
+- Charged packet data surface is still transitional and hybrid in current runtime implementation (scaffold slots plus embedded raw entity payload).
+- Conformance remains packet-level and is generated during charging.
+
+Target direction under #200:
+
+- Lock strict packet contract with clear section boundaries.
+- Keep source payload in packet data without duplicated evaluation semantics.
+- Keep all evaluation status/outcome semantics in packet conformance.
+- Keep packet metadata as canonical machine contract with integrity and provenance.
+
+## Known Prerequisites and Gaps
+
+- Eliminate residual coupling where still_charger patches fields onto fermenter records.
+- Finalize conformance record shape migration to grouped entity evaluations and current outcome contract.
+- Align tests and fixtures to fail on reintroduction of hybrid packet semantics once contract lock is complete.
+
+## Related Docs
+
+- [Curation Packet Contract](../gkc/entity-json-schema.md)
+- [Cross-Module Contracts](module-contracts.md)
+- [Validation Architecture](validation-architecture.md)
+- [SpiritSafe Registry](SpiritSafe.md)

--- a/docs/gkc/api/still_charger.md
+++ b/docs/gkc/api/still_charger.md
@@ -2,46 +2,56 @@
 
 ## Overview
 
-The `gkc.still_charger` module assembles curation packet scaffolds from JSON Entity Profiles and fills them with concrete source values before Wikibase write planning.
+`gkc.still_charger` is the packet assembly and source charging module.
 
-All packets enforce a strict `metadata` / `data` split. The `metadata` section carries the full profile ruleset, unified graph, mint provenance, and an integrity digest. The `data` section contains fillable entity slots keyed by statement `name_identifier`.
+It owns:
 
-Validation and coercion notices are emitted as `ConformanceNotice` objects (see [Fermenter API](fermenter.md)).
+- Building curation packet scaffolds from JSON Entity Profiles.
+- Charging packet entities from source systems (currently Wikidata via `mash`).
+- Producing packet-level conformance payloads by orchestrating fermenter primitives.
+- Maintaining packet metadata integrity sealing after charge-time metadata mutation.
 
-## Quick Start: Build and Charge a Packet
+It does not own validation semantics. Fermenter owns validation outcomes and notice semantics.
+
+## Contract Shape
+
+Curation packets follow a strict three-section top-level shape:
+
+- `metadata`
+- `data`
+- `conformance`
+
+Source metadata for charged packets is recorded in `metadata.profiles[*]` and includes:
+
+- `source_qid`
+- `lastrevid`
+- `pulled_at`
+
+After source metadata injection, `still_charger` reseals `metadata.integrity.metadata_digest`.
+
+## Quick Start
 
 ```python
-from pathlib import Path
-from gkc.still_charger import (
-    create_curation_packet,
-    charge_packet_from_wikidata_items,
-)
+from gkc.still_charger import create_curation_packet, charge_packet_from_wikidata_items
 from gkc.spirit_safe import set_spirit_safe_source
 
 set_spirit_safe_source(mode="local", local_root="/path/to/SpiritSafe")
 
-# 1. Create uncharged scaffold from profile QID (canonical entrypoint)
 packet = create_curation_packet("Q4", operation_mode="single")
 
-print(packet["packet_id"])
-# Entity slots are keyed by name_identifier in data.entities
-for entity in packet["data"]["entities"]:
-    print(entity["profile"], list(entity["statements"].keys()))
-
-# 2. Charge from Wikidata (Cherokee Nation Q195562)
-# qid_map accepts profile entity URI or name_identifier as keys
 qid_map = {entity["id"]: "Q195562" for entity in packet["data"]["entities"]}
 charged_packet, notices = charge_packet_from_wikidata_items(packet, qid_map)
 
-for notice in notices:
-    print(notice.severity, notice.code, notice.message)
+print(charged_packet["metadata"]["profiles"][0].get("source_qid"))
+print(charged_packet["metadata"]["integrity"]["metadata_digest_algorithm"])
+print(len(notices))
 ```
 
 ## Public API
 
-### `create_curation_packet()`
+### create_curation_packet
 
-Create a packet scaffold from SpiritSafe by profile identifier.
+Create a packet scaffold from SpiritSafe profile JSON.
 
 ```python
 from gkc.still_charger import create_curation_packet
@@ -49,20 +59,20 @@ from gkc.still_charger import create_curation_packet
 packet = create_curation_packet("Q4", operation_mode="single")
 ```
 
-**Arguments:**
+Arguments:
 
-| Argument | Type | Description |
+| Argument | Type | Meaning |
 |---|---|---|
 | `profile_id` | `str` | Profile QID or full profile URI |
-| `operation_mode` | `str` | `single` for primary-only scaffold or `bulk` for profile-graph expansion |
+| `operation_mode` | `str` | `single` for primary profile only, `bulk` for profile-graph expansion |
 
-**Returns:** `dict` — Packet scaffold in the dual-key packet contract (`name_identifier` for human-facing keys and `id` URI for canonical identity).
+Returns:
 
----
+- Packet scaffold with `metadata`, `data`, and empty `conformance` target surface.
 
-### `build_curation_packet_from_json_profile()`
+### build_curation_packet_from_json_profile
 
-Assemble a curation packet scaffold from a JSON Entity Profile document.
+Assemble a packet scaffold from a loaded JSON profile document.
 
 ```python
 from pathlib import Path
@@ -75,232 +85,140 @@ packet = build_curation_packet_from_json_profile(
 )
 ```
 
-**Arguments:**
+Arguments:
 
-| Argument | Type | Description |
+| Argument | Type | Meaning |
 |---|---|---|
-| `profile_entity` | `str` | Full URI for the entity profile (e.g., `https://datadistillery.wikibase.cloud/entity/Q4`) |
-| `json_profile_doc` | `dict` | Parsed JSON Entity Profile document |
-| `source_root` | `Path \| None` | Local SpiritSafe root for value-list route resolution (optional) |
+| `profile_entity` | `str` | Profile URI or QID |
+| `json_profile_doc` | `dict` | Parsed JSON profile document |
+| `source_root` | `Path | None` | Optional SpiritSafe local root for value-list route resolution |
+| `source_config` | `dict | None` | Optional source descriptor stored under `metadata.source` |
 
-**Returns:** `dict` — The assembled packet with the two-section contract:
+Returns:
 
-```json
-{
-  "packet_id": "pkt-...",
-  "operation_mode": "new",
-  "metadata": {
-    "primary_profile": {
-      "name_identifier": "tribal_government_us",
-      "id": "https://datadistillery.wikibase.cloud/entity/Q4"
-    },
-    "profiles": [
-      {
-        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
-        "name_identifier": "tribal_government_us",
-        "identification": {},
-        "statements": [],
-        "metadata": {}
-      }
-    ],
-    "graph": {"nodes": {}, "edges": []},
-    "mint": {"minted_at": "...", "generator": "...", "gkc_version": "..."},
-    "integrity": {"metadata_digest": "..."}
-  },
-  "data": {
-    "entities": [
-      {
-        "profile": "tribal_government_us",
-        "id": "https://datadistillery.wikibase.cloud/entity/Q4",
-        "labels": {"mul": {"data-value": ""}},
-        "descriptions": {"mul": {"data-value": ""}},
-        "aliases": {"mul": {"data-value": ""}},
-        "statements": {
-          "instance_of": {
-            "id": "https://datadistillery.wikibase.cloud/entity/Q16",
-            "data-type": "wikibase-item",
-            "data-value": "https://www.wikidata.org/entity/Q7840353"
-          }
-        }
-      }
-    ]
-  }
-}
-```
+- Uncharged packet scaffold with sealed metadata integrity digest.
 
-### `charge_packet_from_wikidata_items()`
+### charge_packet_from_wikidata_items
 
-Charge a packet scaffold with live data fetched from Wikidata.
+Charge a packet from Wikidata entities and emit conformance payloads.
 
 ```python
 from gkc.still_charger import charge_packet_from_wikidata_items
 
-# Map all packet entities to a single QID
-qid_map = {entity["id"]: "Q195562" for entity in packet["data"]["entities"]}
-
 charged_packet, notices = charge_packet_from_wikidata_items(packet, qid_map)
-
-errors = [n for n in notices if n.severity == "error"]
-warnings = [n for n in notices if n.severity == "warning"]
 ```
 
-**Arguments:**
+Arguments:
 
-| Argument | Type | Description |
+| Argument | Type | Meaning |
 |---|---|---|
-| `packet` | `dict` | Assembled packet from `build_curation_packet_from_json_profile()` |
-| `qid_map` | `dict[str, str]` | Maps profile entity URIs or profile `name_identifier` values to Wikidata QIDs |
-| `mash_client` | `Any \| None` | Optional pre-configured mash client; creates a new one if not supplied |
+| `packet` | `dict` | Packet assembled by `build_curation_packet_from_json_profile` |
+| `qid_map` | `dict[str, str]` | Maps profile URI or profile `name_identifier` to Wikidata QID |
+| `mash_client` | `Any | None` | Optional `WikibaseLoader`-compatible client |
 
-**QID resolution order for entity slots:**
+Returns:
 
-1. Full profile entity URI — exact key match in `qid_map`
-2. Profile `name_identifier` — key match in `qid_map`
-
-The charger does not infer primary entity mappings from DD Wikibase QID tails. Pass an explicit profile URI or `name_identifier` key to avoid namespace ambiguity across Wikibase instances.
-
-**Returns:** `tuple[dict, list[ConformanceNotice]]`
-
-- `dict`: Charged packet with `data-value` fields populated in each entity slot and a `conformance` section added at the top level.
-- `list[ConformanceNotice]`: All conformance notices from the charging pass.
-
-**Charged packet `conformance` section:**
-
-```json
-{
-  "conformance": {
-    "entity_profile_map": {
-      "Q195562": "https://datadistillery.wikibase.cloud/entity/Q4",
-      "tribal_government_us": "https://datadistillery.wikibase.cloud/entity/Q4",
-      "https://datadistillery.wikibase.cloud/entity/Q4": "https://datadistillery.wikibase.cloud/entity/Q4",
-      "Q7245055": "https://datadistillery.wikibase.cloud/entity/Q39"
-    },
-    "statement_evaluations": [
-      {
-        "entity_id": "Q195562",
-        "gkc_entity_statement": {
-          "id": "office_held_by_head_of_government",
-          "uri": "https://datadistillery.wikibase.cloud/entity/Q40"
-        },
-        "json_path": "$.entity.claims.P1313[0]",
-        "statement_uri": "https://datadistillery.wikibase.cloud/entity/Q40",
-        "statement_id": "office_held_by_head_of_government",
-        "status": "conformant",
-        "outcome": "conformant"
-      },
-      {
-        "entity_id": "Q195562",
-        "gkc_entity_statement": {
-          "id": "P31",
-          "uri": "unknown/P31"
-        },
-        "json_path": "$.entity.claims.P31[0]",
-        "statement_uri": "unknown/P31",
-        "status": "uncovered"
-      }
-    ]
-  }
-}
-```
-
-**`entity_profile_map` keys:** Each loaded entity is indexed three ways — by Wikidata QID, by profile `name_identifier`, and by full profile URI — all mapping to the profile URI that governs that entity's conformance.
-
-**`statement_evaluations` fields:**
-
-| Field | Type | Description |
+| Position | Type | Meaning |
 |---|---|---|
-| `entity_id` | `str` | Wikidata QID of the evaluated entity |
-| `gkc_entity_statement` | `dict` | DD Wikibase statement reference with keys `id` and `uri`; placed immediately below `entity_id` |
-| `json_path` | `str` | JSONPath to the evaluated claim (e.g. `$.entity.claims.P31[0]`) |
-| `statement_uri` | `str` | DD Wikibase statement URI if matched; `unknown/<prop>` if unrecognized |
-| `statement_id` | `str` | Profile `name_identifier` for the statement when available |
-| `status` | `str` | `conformant`, `nonconformant`, or `uncovered` |
-| `outcome` | `str` | Fermenter conformance outcome (`conformant`, `non_conformant_mappable`, `missing`, `to_be_defined`) |
-| `notices` | `list[dict]` | Serialized fermenter notices for the statement |
-| `qualifiers` | `list[dict]` | Nested qualifier statement evaluation records (same shape recursively) |
-| `references` | `list[dict]` | Nested reference statement evaluation records (same shape recursively) |
+| `0` | `dict` | Charged packet |
+| `1` | `list[ConformanceNotice]` | Packet notices (currently empty placeholder list for this path) |
 
-**Linked entity loading:** When the primary entity has claims matching a profile-declared linkage (via `metadata.linkage_index`), the linked entity is automatically fetched from Wikidata and evaluated against its target profile. Both primary and linked entities appear in `data.entities` and `conformance.entity_profile_map`.
+Charge behavior:
 
-`still_charger` delegates statement-level conformance evaluation and serialization to fermenter primitives (`evaluate_statement_instance` and `statement_evaluation_to_record`). Charger owns packet orchestration and entity loading; fermenter owns conformance interpretation.
+- Resolves linked entities via profile linkage routes.
+- Loads primary and linked entity JSON from Wikidata.
+- Populates packet data entities with source payloads.
+- Injects source provenance fields into `metadata.profiles[*]`.
+- Builds `conformance` payload from fermenter statement evaluators.
+- Reseals metadata digest after metadata mutation.
 
----
+Current runtime note:
 
-### `charge_curation_packet()` (Legacy)
+- `data.entities` remains a transitional hybrid surface in current implementation (scaffold slots plus embedded raw entity payload).
+- Contract direction in #200 is to eliminate hybrid slot decoration from packet `data` and keep evaluation semantics in `conformance` only.
 
-Charge a packet directly from a source-values dict. This is a legacy path for bulk operations where data has already been fetched and transformed before packet assembly. New workflows should use `charge_packet_from_wikidata_items()` instead.
+### charge_curation_packet (Legacy)
+
+Legacy direct-charge path from caller-provided source values.
 
 ```python
 from gkc.still_charger import charge_curation_packet
 
-source_values = {
-    "https://datadistillery.wikibase.cloud/entity/Q4": {
-        "labels": {"mul": {"data-value": "Cherokee Nation"}},
-        "statements": {
-            "instance_of": [{"data-value": "https://www.wikidata.org/entity/Q7840353"}],
-        },
-    }
-}
-
 charged_packet, report = charge_curation_packet(packet, source_values)
-
-print(report.entities_charged)
-print(report.entities_skipped)
-print([issue.message for issue in report.issues])
 ```
 
----
+New workflows should prefer `charge_packet_from_wikidata_items`.
 
-### `ChargeIssue` and `ChargeReport`
+### ChargeIssue and ChargeReport
 
-```python
-from gkc.still_charger import ChargeIssue, ChargeReport
+`ChargeIssue` captures a non-fatal charging issue.
 
-issue = ChargeIssue(
-    severity="warning",
-  entity_ref="https://datadistillery.wikibase.cloud/entity/Q4",
-    code="specificationless_charge",
-    message="Specificationless charging accepted unknown statements",
-)
+`ChargeReport` summarizes charge results:
 
-report = ChargeReport(entities_charged=1, entities_skipped=0, issues=[issue])
-print(report.entities_charged, report.issues[0].severity)
-```
+- `entities_charged`
+- `entities_skipped`
+- `issues`
 
-`ChargeIssue` is an alias for `ConformanceNotice` (see [Fermenter API](fermenter.md)).
+## Metadata Integrity and Provenance
 
+Metadata digest behavior:
+
+1. Packet scaffolds are sealed at build time.
+2. Charged packets inject source provenance into `metadata.profiles[*]`.
+3. Metadata is resealed after provenance injection.
+
+This supports packet re-presentation checks where metadata integrity and source revision context must be evaluated together.
+
+## Conformance Output Interface
+
+`still_charger` orchestrates conformance payload construction and delegates atomic statement evaluation to fermenter:
+
+- `evaluate_statement_instance`
+- `statement_evaluation_to_record`
+
+Ownership split:
+
+- `still_charger`: packet orchestration, source loading, packet mutation order.
+- `fermenter`: statement-level evaluation semantics and record serialization.
 
 ## API Reference (mkdocstrings)
 
-### `ChargeIssue`
+### ChargeIssue
 
 ::: gkc.still_charger.ChargeIssue
     options:
       show_root_heading: false
       heading_level: 4
 
-### `ChargeReport`
+### ChargeReport
 
 ::: gkc.still_charger.ChargeReport
     options:
       show_root_heading: false
       heading_level: 4
 
-### `create_curation_packet()`
+### create_curation_packet
 
 ::: gkc.still_charger.create_curation_packet
     options:
       show_root_heading: false
       heading_level: 4
 
-### `build_curation_packet_from_json_profile()`
+### build_curation_packet_from_json_profile
 
 ::: gkc.still_charger.build_curation_packet_from_json_profile
     options:
       show_root_heading: false
       heading_level: 4
 
-### `charge_curation_packet()`
+### charge_packet_from_wikidata_items
+
+::: gkc.still_charger.charge_packet_from_wikidata_items
+    options:
+      show_root_heading: false
+      heading_level: 4
+
+### charge_curation_packet
 
 ::: gkc.still_charger.charge_curation_packet
     options:
@@ -309,5 +227,6 @@ print(report.entities_charged, report.issues[0].severity)
 
 ## See Also
 
-- [Shipper API](shipper.md)
+- [Fermenter API](fermenter.md)
 - [SpiritSafe API](spirit_safe.md)
+- [Curation Packet Contract](../entity-json-schema.md)

--- a/docs/gkc/entity-json-schema.md
+++ b/docs/gkc/entity-json-schema.md
@@ -4,9 +4,7 @@
 
 1. Data Distillery Wikibase semantics materialized into SpiritSafe JSON Entity Profiles.
 2. JSON Entity Profiles assembled into curation packet scaffolds.
-3. Curation packets charged with data, validated/coerced, and prepared for shipping.
-
-This document replaces older profile-name and YAML-era schema language where it no longer matches runtime behavior.
+3. Curation packets charged with data, validated/coerced, and prepared for editing and eventual shipping.
 
 ## Current Contract Scope
 
@@ -15,7 +13,7 @@ This page documents the active packet/profile contract used by:
 - `gkc.spirit_safe` for loading JSON Entity Profiles.
 - `gkc.still_charger` for packet scaffold assembly and charging.
 - `gkc.fermenter` for value validation/coercion and conformance notices.
-- `gkc.wikibase` and `gkc.shipper` for downstream write planning and execution.
+- `gkc.shipper` for downstream write planning and execution.
 
 Contract clarification:
 
@@ -26,11 +24,11 @@ Contract clarification:
 
 The current pipeline is:
 
-1. Data Distillery Wikibase semantics are captured in SpiritSafe cache artifacts.
-2. `gkc.spirit_safe` exports JSON Entity Profiles under `profiles/<QID>.json`.
-3. `gkc.still_charger.build_curation_packet_from_json_profile(...)` builds a packet scaffold.
-4. `gkc.still_charger.charge_packet_from_wikidata_items(...)` and related flows fill packet entity data.
-5. Validation/coercion runs on packet values and emits conformance notices.
+1. Data Distillery Wikibase semantics are developed and documented within the working "meta-wikibase".
+2. `gkc.spirit_safe` caches and updates raw Data Distillery Wikibase entity content periodically (currently a manual process while development progresses) within `SpiritSafe/cache/entities`. (reference `SpiritSafe/.github/workflows/cache-from-wikibase.yml` and `SpiritSafe/.github/workflows/cache-wikibase-and-build-profiles.yml`)
+3. `gkc.spirit_safe` generates JSON Entity Profiles under `SpiritSafe/profiles/<QID>.json`. (reference `SpiritSafe/.github/workflows/cache-wikibase-and-build-profiles.yml`)
+4. `gkc.still_charger.build_curation_packet_from_json_profile(...)` generates a Curation Packet scaffold and seeds default/fixed values from profile definitions.
+5. `gkc.still_charger.charge_packet_from_wikidata_items(...)` retrieves data from one or more Wikidata items, builds the `data` structure within the packet with those items verbatim, and runs `fermenter` processing to evaluate the items and produce a `conformance` object with reporting details on alignment with the profiles.
 6. Bottling transforms packet content to destination-specific payloads.
 7. Shipping sends destination-specific payloads to Commons Partners (Wikidata, etc.).
 
@@ -78,10 +76,15 @@ These are consumed by downstream wizard/validation paths and are not UI-only fie
 
 ## Curation Packet Structure
 
-All curation packets enforce a strict two-section top-level structure:
+All curation packets enforce a strict three-section top-level structure:
 
 - `metadata` — the ruleset, provenance, and integrity information for this packet. This section is sealed with a SHA-256 digest at mint time and must not be modified after generation.
-- `data` — the fillable data slots for each entity in the packet.
+- `data` — the source data payload: entity values (labels, descriptions, aliases, statements) indexed by entity slot.
+- `conformance` — fermenter-owned evaluation results: statement-by-statement assessment of alignment with profile rules, mapping of entities to profiles, and any notices/issues encountered during validation.
+
+Implementation note:
+
+- The three-section shape above is the locked contract target for #200. Runtime mutation details in current charging paths remain transitional while contract-correction refactors are completed.
 
 ### Top-Level Packet Shape
 
@@ -127,7 +130,14 @@ All curation packets enforce a strict two-section top-level structure:
   },
   "data": {
     "entities": []
-  }
+  },
+  "conformance": [
+    {
+      "source_item": "http://www.wikidata.org/entity/Q14708404",
+      "source_item_label": "Cherokee Nation",
+      "statement_evaluations": []
+    }
+  ]
 }
 ```
 
@@ -209,7 +219,11 @@ Qualifiers and references are omitted entirely when the profile does not specify
 
 ## Charged Entity Slot Shape
 
-Charging populates each entity slot's `data-value` fields and partitions statements into conformance buckets. The entity slot structure expands from the uncharged shape:
+Charging populates each entity slot's `data-value` fields with values from source data (Wikidata, curated input, defaults). The entity slot structure mirrors the uncharged shape:
+
+Implementation note:
+
+- Current runtime charged packets still include transitional hybrid payload details while #200 contract-correction refactors are in progress.
 
 ```json
 {
@@ -233,73 +247,108 @@ Charging populates each entity slot's `data-value` fields and partitions stateme
     "population": {
       "id": "https://datadistillery.wikibase.cloud/entity/Q21",
       "data-type": "quantity",
-      "data-value": null,
-      "non_conformant": true,
-      "notices": ["datatype_mismatch"]
+      "data-value": null
     }
-  },
-  "uncovered_statements": {
-    "P18": [
-      {
-        "data-type": null,
-        "data-value": "Cherokee_Nation_Capitol.jpg"
-      }
-    ]
   }
 }
 ```
 
-### Statement Evaluation Records
+**Target invariant:** The `data` section preserves the **source payload only**. Evaluation results, notices, and conformance status are never stored in `data`. All such metadata flows into the `conformance` section.
 
-Charged packet conformance is emitted as atomic statement evaluation records under:
+## Conformance Section
 
-- `conformance.statement_evaluations`
+The `conformance` section is produced by `gkc.fermenter` during packet charging and contains all evaluation results. It is an array of per-entity evaluation groups, each covering one source item.
 
-Each record is produced by fermenter statement primitives and includes the DD Wikibase statement reference block.
+Implementation note:
+
+- Current runtime charge output is still transitioning toward this grouped conformance shape as contract work in #200 proceeds.
+
+### Conformance Top-Level Shape
 
 ```json
 {
-  "entity_id": "Q14708404",
-  "gkc_entity_statement": {
-    "id": "official_website",
-    "uri": "https://datadistillery.wikibase.cloud/entity/Q19"
-  },
-  "json_path": "$.entity.claims.P856[0]",
-  "statement_uri": "https://datadistillery.wikibase.cloud/entity/Q19",
-  "statement_id": "official_website",
-  "status": "conformant",
-  "outcome": "conformant",
-  "references": [
+  "conformance": [
     {
-      "entity_id": "Q14708404",
-      "gkc_entity_statement": {
-        "id": "reference_url",
-        "uri": "https://datadistillery.wikibase.cloud/entity/Q29"
-      },
-      "json_path": "$.entity.claims.P856[0].references.P854",
-      "statement_uri": "https://datadistillery.wikibase.cloud/entity/Q29",
-      "statement_id": "reference_url",
-      "status": "conformant",
-      "outcome": "conformant"
+      "source_item": "http://www.wikidata.org/entity/Q14708404",
+      "source_item_label": "Cherokee Nation",
+      "statement_evaluations": [
+        { /* ... */ }
+      ]
     }
   ]
 }
 ```
 
-Outcome values (current):
+`source_item_label` is the best available single-language label for the entity, resolved in preference order: `en` → `mul` → first available language. This matches the active GKC language setting (currently defaulting to `en`).
 
-- `conformant`
-- `non_conformant_mappable`
-- `missing`
-- `to_be_defined`
+### Statement Evaluation Records
 
-Status values used in packet records (current):
+Each entry in `statement_evaluations` covers one claim from the source Wikidata entity. Records are produced by the fermenter primitive `evaluate_statement_instance(profile_statement, raw_claim)` and serialized by `statement_evaluation_to_record()`.
 
-- `conformant`
-- `nonconformant`
-- `uncovered`
+```json
+{
+  "json_path": "$.entity.claims.P856[0]",
+  "gkc_entity_statement": {
+    "id": "official_website",
+    "uri": "https://datadistillery.wikibase.cloud/entity/Q19"
+  },
+  "conformant": true,
+  "outcome": "conformant",
+  "normalized_value": "https://www.cherokee.org",
+  "qualifiers": [],
+  "references": [
+    {
+      "json_path": "$.entity.claims.P856[0].references.P854",
+      "gkc_entity_statement": {
+        "id": "reference_url",
+        "uri": "https://datadistillery.wikibase.cloud/entity/Q29"
+      },
+      "conformant": true,
+      "outcome": "conformant",
+      "normalized_value": "https://www.cherokee.org"
+    }
+  ]
+}
+```
 
-Nested qualifiers and references are serialized recursively with the same record shape.
+**For claims not mapped to any profile statement**, `gkc_entity_statement` is `null` and `outcome` is omitted. The claim still appears in the evaluations so curators can see what source data the profile does not cover.
+
+```json
+{
+  "json_path": "$.entity.claims.P18[0]",
+  "gkc_entity_statement": null,
+  "conformant": false,
+  "normalized_value": "Cherokee_Nation_Capitol.jpg"
+}
+```
+
+### Statement Evaluation Record Fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `json_path` | string | JSONPath to the claim in source Wikidata entity JSON (e.g., `$.entity.claims.P856[0]`) |
+| `gkc_entity_statement` | object or null | Profile statement identity: `id` (name_identifier) and `uri` (canonical DD Wikibase URI). `null` when the claim is not covered by the profile. |
+| `conformant` | boolean | `true` only when this record and all nested qualifiers and references are conformant. `false` for any failure or uncovered claim. |
+| `outcome` | string | Evaluation outcome code (see below). Omitted when `gkc_entity_statement` is null. |
+| `normalized_value` | any | Normalized, curator-facing value. For `wikibase-item` types this is a full resolvable URI (e.g., `http://www.wikidata.org/entity/Q12345`). |
+| `qualifiers` | array | Nested qualifier evaluation records using the same shape. |
+| `references` | array | Nested reference evaluation records using the same shape. |
+
+### Outcome Values
+
+`outcome` is set only when `gkc_entity_statement` is non-null. All outcome messaging for curator display is drawn from `error message` statements in the corresponding DD Wikibase entity profile items (accessible via `metadata.profiles` in the packet), enabling multilingual rendering without embedding text strings in the conformance record.
+
+| Outcome | Meaning | Curator action |
+|---|---|---|
+| `conformant` | Value matches all profile constraints | None |
+| `missing` | Profile expects this statement; none found in source | Add the statement |
+| `value_error` | Value is present but malformed or wrong datatype | Fix the value; see statement-type `error message` in profile |
+| `value_not_in_allowed_set` | Value is the right type but not in the required list or fixed value | Choose from allowed values; see list `error message` in profile |
+
+**Note:** fixed-value constraints are modeled as a list of one item in the profile. `value_not_in_allowed_set` covers both list and fixed-value mismatches.
+
+**Note on nesting:** Qualifiers and references use the same record shape recursively. `conformant` on the parent statement is `true` only when the parent value and all nested records are individually `conformant: true`.
+
 
 ### Source Provenance (per entity, in metadata)
 
@@ -313,16 +362,7 @@ When charging from Wikidata, each entity's source metadata is recorded under `me
 }
 ```
 
-`lastrevid` is used when a charged packet reaches the bottling/shipping stage to detect whether the Wikidata item has changed since the packet was minted.
-
-### Conformance Summary
-
-No separate `metadata.conformance_summary` field is currently guaranteed by the packet contract.
-
-Callers should derive summary metrics from:
-
-- `conformance.statement_evaluations`
-- `conformance.entity_profile_map`
+`lastrevid` is used when a charged packet reaches the bottling/shipping stage to detect whether the Wikidata item has changed since the packet was minted. It is also used when a Curation Packet is re-presented for validation.
 
 ## Conformance and Blocking Policy
 

--- a/gkc/still_charger.py
+++ b/gkc/still_charger.py
@@ -1424,6 +1424,26 @@ def charge_packet_from_wikidata_items(
     # Build charged packet while preserving packet-native scaffold slots.
     charged = deepcopy(packet)
 
+    pulled_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    def _resolve_profile_qid(
+        profile_uri: Optional[str], profile_name: Optional[str]
+    ) -> Optional[str]:
+        resolved_qid: Optional[str] = None
+        if isinstance(profile_uri, str):
+            resolved_qid = qid_map.get(profile_uri)
+        if not resolved_qid and isinstance(profile_name, str):
+            resolved_qid = qid_map.get(profile_name)
+        if resolved_qid:
+            return resolved_qid
+
+        if not isinstance(profile_uri, str):
+            return None
+        for map_key, mapped_profile in entity_profile_map.items():
+            if mapped_profile == profile_uri and _looks_like_qid(map_key):
+                return map_key
+        return None
+
     raw_entity_by_qid: dict[str, dict[str, Any]] = {
         entry.get("id"): entry.get("entity")
         for entry in data_entities
@@ -1433,6 +1453,28 @@ def charge_packet_from_wikidata_items(
     }
 
     scaffold_entities = packet_entities(charged)
+
+    profiles_meta = charged.get("metadata", {}).get("profiles", [])
+    if isinstance(profiles_meta, list):
+        for profile_meta in profiles_meta:
+            if not isinstance(profile_meta, dict):
+                continue
+            profile_uri = profile_meta.get("id")
+            profile_name = profile_meta.get("name_identifier")
+            entity_qid = _resolve_profile_qid(
+                profile_uri if isinstance(profile_uri, str) else None,
+                profile_name if isinstance(profile_name, str) else None,
+            )
+            if not entity_qid:
+                continue
+            raw_entity = raw_entity_by_qid.get(entity_qid)
+            if not isinstance(raw_entity, dict):
+                continue
+
+            profile_meta["source_qid"] = entity_qid
+            profile_meta["lastrevid"] = raw_entity.get("lastrevid")
+            profile_meta["pulled_at"] = pulled_at
+
     if not scaffold_entities:
         charged["data"] = {"entities": data_entities}
         charged["conformance"] = {
@@ -1440,10 +1482,10 @@ def charge_packet_from_wikidata_items(
             "statement_evaluations": statement_evaluations,
         }
         charged["operation_mode"] = "edit"
+        _reseal_packet_metadata(charged)
         notices: list[ConformanceNotice] = []
         return charged, notices
 
-    profiles_meta = charged.get("metadata", {}).get("profiles", [])
     if not isinstance(profiles_meta, list):
         profiles_meta = []
 
@@ -1545,6 +1587,7 @@ def charge_packet_from_wikidata_items(
     }
     charged["conformance"] = conformance
     charged["operation_mode"] = "edit"
+    _reseal_packet_metadata(charged)
 
     # For now, return empty notices (will be populated by fermenter integration)
     notices: list[ConformanceNotice] = []

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
     - Overview: architecture/index.md
     - Data Distillery Wikibase: architecture/DataDistillery-Wikibase.md
     - Cross-Module Contracts: architecture/module-contracts.md
+    - Still Charger: architecture/still_charger.md
     - SpiritSafe Registry: architecture/SpiritSafe.md
     - SpiritSafe Models & API: architecture/spirit_safe_models.md
     - Profile Loading: architecture/profile-loading.md


### PR DESCRIPTION
## Summary

- Document and align packet contract and still_charger boundaries for #200.
- Add explicit still_charger architecture page and nav entry.
- Fix charge flow to inject per-profile source provenance and reseal metadata integrity digest after charge-time metadata mutation.

## Changes

- Updated `gkc/still_charger.py` to:
  - inject `source_qid`, `lastrevid`, and `pulled_at` into `metadata.profiles[*]` during charge
  - reseal metadata digest after provenance injection in both charge return paths
- Reworked docs:
  - `docs/gkc/entity-json-schema.md`
  - `docs/gkc/api/still_charger.md`
  - `docs/architecture/module-contracts.md`
  - `docs/architecture/index.md`
  - `docs/architecture/still_charger.md` (new)
  - `mkdocs.yml` nav update

## Validation

- `poetry run pytest tests/test_still_charger.py tests/test_fermenter_packet_validation.py -q`
- `poetry run mkdocs build -q`
