### PR TITLE
Ignore non-entity pages during Wikibase full sync

### DIFF
--- a/gkc/mash/core.py
+++ b/gkc/mash/core.py
@@ -681,6 +681,10 @@ def discover_wikibase_entity_ids(
     what to fetch.
     """
     entity_ids: list[str] = []
+    namespace_patterns: dict[int, re.Pattern[str]] = {
+        0: re.compile(r"^Q[1-9]\d*$"),
+        120: re.compile(r"^P[1-9]\d*$"),
+    }
 
     # (namespace id, title prefix to strip for ID extraction)
     namespaces: list[tuple[int, str]] = []
@@ -710,7 +714,8 @@ def discover_wikibase_entity_ids(
                 if not isinstance(title, str):
                     continue
                 entity_id = title[len(prefix) :].strip() if prefix else title.strip()
-                if entity_id:
+                pattern = namespace_patterns.get(ns)
+                if entity_id and pattern and pattern.fullmatch(entity_id):
                     entity_ids.append(entity_id)
             continuation = payload.get("continue")
             if not isinstance(continuation, dict):

--- a/tests/test_mash.py
+++ b/tests/test_mash.py
@@ -835,6 +835,7 @@ def test_discover_wikibase_entity_ids_collects_items_and_properties():
             {
                 "query": {
                     "allpages": [
+                        {"title": "Main Page"},
                         {"title": "Q4"},
                         {"title": "Q39"},
                     ]
@@ -851,6 +852,7 @@ def test_discover_wikibase_entity_ids_collects_items_and_properties():
             {
                 "query": {
                     "allpages": [
+                        {"title": "Property:Property proposal"},
                         {"title": "Property:P1"},
                         {"title": "Property:P211"},
                     ]


### PR DESCRIPTION
## Summary
- filter `allpages` discovery results to actual `Q...` and `P...` entity ids
- ignore content pages like `Main Page` that can exist in namespace 0 on Wikibase
- extend mash tests to cover non-entity title filtering

## Context
The SpiritSafe full-sync workflow discovered `Main Page` as the only namespace-0 title and then failed when `wbgetentities` was called with that non-entity title.

## Verification
- `poetry run pytest tests/test_mash.py tests/test_cli.py`
- `poetry run black --check gkc tests`
- `poetry run ruff check gkc tests`
