### PR TITLE
Add meta-wikibase runtime config and docs

### DIFF
--- a/docs/architecture/DataDistillery-Wikibase.md
+++ b/docs/architecture/DataDistillery-Wikibase.md
@@ -2,9 +2,11 @@
 
 Data Distillery Wikibase (`datadistillery.wikibase.cloud`) is the semantic registry for GKC ontology terms, profile metadata relationships, statement/value-list semantics, and multilingual guidance content that must be queryable and collaboratively maintained.
 
+This page describes the current reference implementation of the generic [meta-wikibase architecture](meta-wikibase.md).
+
 This page focuses on one part of a three-part infrastructure model:
 
-- **Data Distillery Wikibase**: semantic source of truth.
+- **Meta-wikibase**: semantic source of truth.
 - **SpiritSafe repository**: materialized artifact registry.
 - **GKC Python package**: runtime execution layer.
 
@@ -15,11 +17,11 @@ The runtime and collaboration needs are different:
 - SpiritSafe JSON profile artifacts are optimized for offline execution and deterministic profile consumption.
 - Wikibase is optimized for semantic relationships, multilingual fields, and query-oriented discovery.
 
-The Data Distillery uses a hybrid model where both sides are maintained in sync.
+The Data Distillery uses the generic meta-wikibase pattern, with a DD-specific ontology and deployment footprint.
 
 Authoring and execution split:
 
-- DD Wikibase holds foundation semantics.
+- The Data Distillery Wikibase holds foundation semantics.
 - SpiritSafe holds deterministic materialized/actionable artifacts.
 - `gkc` consumes materialized artifacts and runs curation/validation/shipping workflows.
 
@@ -403,7 +405,7 @@ Key behavioral rules:
 
 - **Tombstones and gaps are silently skipped.** Numeric gaps in the ID sequence (e.g., `Q10` does not exist) and deleted entities (missing from `wbgetentities`) are ignored. No placeholder files are written.
 
-- **Batch size is auto-detected from auth capability.** When an authenticated `WikiverseAuth` instance with `apihighlimits` rights is provided, the loader uses batches of 500. Without that right, batches of 50 are used. If a 500-item batch fails at runtime, the sync automatically falls back to 50-item sub-batches for that chunk and records a diagnostic counter.
+- **Mash full-sync defaults to unauthenticated reads.** The CLI runs full-sync with 50-entity batches unless an explicit batch size is provided. The lower-level loader still accepts an authenticated session for capability-sensitive batching when a caller intentionally provides one.
 
 - **Provenance is embedded in every cache file.** Each written file includes `workflow_mode: "full_sync_baseline"` and `extractor: "gkc.mash.full_sync_wikibase_entity_cache"` in its provenance metadata.
 
@@ -441,7 +443,7 @@ This table defines the canonical behavior contract. Deviations should be treated
 
 ### `gkc mash check-wikibase-revisions`
 
-- Reads Data Distillery runtime settings from `DD_WB_*` environment variables.
+- Reads Data Distillery integration settings from the resolved meta-wikibase config (`META_WB_CONFIG`, `META_WB_API_URL`, `META_WB_SPARQL_ENDPOINT`).
 - Checks MediaWiki recentchanges for entity page updates.
 - Produces change summaries and optional JSON report via `--output`.
 
@@ -476,23 +478,22 @@ The following items reflect active architectural exploration and are not yet fin
 
 ## Environment Variables
 
-- `DD_WB_API_URL`
-- `DD_WB_SPARQL_ENDPOINT`
-- `DD_WB_USERNAME`
-- `DD_WB_PASSWORD`
+- `META_WB_CONFIG`
+- `META_WB_API_URL`
+- `META_WB_SPARQL_ENDPOINT`
 
 Recommended baseline:
 
 ```bash
-export DD_WB_API_URL="https://datadistillery.wikibase.cloud/w/api.php"
-export DD_WB_SPARQL_ENDPOINT="https://datadistillery.wikibase.cloud/query/sparql"
-export DD_WB_USERNAME="your_dd_username"
-export DD_WB_PASSWORD="your_dd_password"
+export META_WB_CONFIG="/path/to/SpiritSafe/dd-wikibase.yaml"
+# Optional per-run overrides
+export META_WB_API_URL="https://datadistillery.wikibase.cloud/w/api.php"
+export META_WB_SPARQL_ENDPOINT="https://datadistillery.wikibase.cloud/query/sparql"
 ```
 
 ## Troubleshooting
 
-- **Auth group mismatch**: if credentials authenticate but write requests fail, verify Data Distillery account permissions include edit rights.
+- **Auth group mismatch**: if explicit MediaWiki credentials authenticate but write requests fail, verify Data Distillery account permissions include edit rights.
 - **Write summary missing**: shipper write operations and init flows require a non-empty summary.
 - **Property create datatype error**: ensure datatype is embedded in the `data` payload JSON for property creation.
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -13,7 +13,7 @@ GKC architecture is best understood through two coordinated lenses:
 
 Infrastructure components:
 
-1. **Data Distillery Wikibase** — semantic authoring system of record for profiles, statements, value lists, and linkage semantics.
+1. **Meta-wikibase** — semantic authoring system of record for profiles, statements, value lists, and linkage semantics.
 2. **SpiritSafe repository** — materialized artifact registry (JSON profiles, query files, hydrated caches, manifest, entity index).
 3. **GKC Python package** — runtime engine that consumes SpiritSafe artifacts to assemble packets (`still_charger`), validate/coerce (`fermenter`), plan writes, and ship.
 
@@ -24,26 +24,28 @@ Architectural components:
 3. **GKC Value Lists** — curated allowed-item domains used to guide and constrain selection.
 4. **GKC Curation Packets** — actionable packet structures combining metadata rulesets and fillable data slots.
 
-This pairing enables a consistent pattern: **define in DD Wikibase, materialize in SpiritSafe, execute in gkc**.
+This pairing enables a consistent pattern: **define in a meta-wikibase, materialize in SpiritSafe, execute in gkc**.
 
 The JSON Schema layer remains important as a machine-facing contract derived from these components, but it is a representation layer rather than a top-level architectural component.
 
-Entity Statements, Entity Profiles, and Value List semantics are defined and organized within the [Data Distillery Wikibase](https://datadistillery.wikibase.cloud/). These semantics are exported into [SpiritSafe](https://github.com/skybristol/SpiritSafe), which is then consumed by the GKC runtime package.
+Entity Statements, Entity Profiles, and Value List semantics are defined and organized within a meta-wikibase. The current reference implementation is the [Data Distillery Wikibase](DataDistillery-Wikibase.md). These semantics are exported into [SpiritSafe](https://github.com/skybristol/SpiritSafe), which is then consumed by the GKC runtime package.
 
 ---
 
 ## Infrastructure Components
 
-### Data Distillery Wikibase
+### Meta-Wikibase
 
-Data Distillery Wikibase is the semantic source of truth. It is where profile, statement, value-list, and linkage semantics are authored and curated.
+A meta-wikibase is the semantic source of truth. It is where profile, statement, value-list, and linkage semantics are authored and curated.
 
-DD Wikibase defines the **foundation form** of architectural components:
+The meta-wikibase defines the **foundation form** of architectural components:
 
 - Profile composition directives.
 - Reusable statement defaults and scoped overrides.
 - Value-list membership and refresh semantics.
 - Prompt/guidance/error messaging and multilingual metadata.
+
+For the generic contract, see [Meta-Wikibase Architecture](meta-wikibase.md). For the current concrete deployment, see [Data Distillery Wikibase](DataDistillery-Wikibase.md).
 
 ### SpiritSafe Repository
 

--- a/docs/architecture/meta-wikibase.md
+++ b/docs/architecture/meta-wikibase.md
@@ -1,0 +1,102 @@
+# Meta-Wikibase Architecture
+
+A meta-wikibase is the semantic authoring system of record for GKC profile, statement, value-list, and guidance semantics. It is the authoring-side of the SpiritSafe, which stores the materialized artifacts consumed by the runtime.
+
+This document describes the generic contract. The current reference implementation is the [Data Distillery Wikibase](DataDistillery-Wikibase.md).
+
+## Core Role
+
+A meta-wikibase exists to do the parts of the job that a file-only artifact registry does poorly, with an eye toward potential implementation within Wikidata:
+
+- Collaborative semantic authoring.
+
+- Multilingual labels, descriptions, aliases, prompts, and guidance.
+
+- Queryable relationships among profiles, statements, value lists, and reference semantics.
+
+- Discovery of ontology-level conventions that should remain curator-maintained rather than hardcoded in runtime code.
+
+SpiritSafe then materializes those semantics into deterministic artifacts for runtime consumption.
+
+The operating pattern is:
+
+- Define in a meta-wikibase.
+
+- Materialize in SpiritSafe.
+
+- Execute in `gkc`.
+
+## Runtime Integration Contract
+
+The current runtime contract is intentionally narrow.
+
+`gkc.runtime_config` resolves read-oriented meta-wikibase integration settings in this order:
+
+1. `META_WB_CONFIG`, when set explicitly, points to the config file to load.
+
+2. If `META_WB_CONFIG` is not set, `gkc` auto-discovers one of the following filenames from the current working directory upward through parent directories:
+
+   - `meta-wikibase.yaml`
+   - `meta-wikibase.yml`
+   - `dd-wikibase.yaml`
+   - `dd-wikibase.yml`
+
+3. `META_WB_API_URL` overrides the config-file `api_url` value.
+
+4. `META_WB_SPARQL_ENDPOINT` overrides the config-file `sparql_endpoint` value.
+
+5. If no config file or override is present, `gkc` falls back to built-in defaults.
+
+This contract is read-only. It does not define an authentication framework.
+
+## Authentication Boundary
+
+Read-oriented mash operations should remain unauthenticated unless a specific capability requires otherwise.
+
+Authenticated MediaWiki writes remain a separate concern:
+
+- `WikiverseAuth` is the generic MediaWiki authentication client.
+
+- `shipper` and other explicit write flows are the main consumers of authenticated MediaWiki sessions.
+
+- `WIKIVERSE_*` remains the generic environment-based authentication surface when explicit credentials are not passed directly.
+
+This keeps meta-wikibase instance targeting separate from write credentials.
+
+## Config File Shape
+
+The reference YAML shape is:
+
+```yaml
+meta_wikibase:
+  id: datadistillery-wikibase
+  label: Data Distillery Wikibase
+  api_url: https://datadistillery.wikibase.cloud/w/api.php
+  sparql_endpoint: https://datadistillery.wikibase.cloud/query/sparql
+
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+```
+
+Current runtime use is limited to endpoint resolution plus preservation of semantic-convention metadata for downstream consumers.
+
+## What Belongs Here
+
+The meta-wikibase config file is the right place for instance-level facts such as:
+
+- Canonical API URL.
+
+- Canonical SPARQL endpoint.
+
+- Stable semantic bootstrap identifiers that are intrinsic to the instance.
+
+- Explicit semantic conventions such as the internal `name_identifier` prefix contract.
+
+It is not the right place for user credentials.
+
+## Reference Implementation
+
+The checked-in reference implementation lives in the SpiritSafe repository as `dd-wikibase.yaml`.
+
+For the concrete Data Distillery infrastructure details, see [Data Distillery Wikibase](DataDistillery-Wikibase.md).

--- a/docs/gkc/authentication.md
+++ b/docs/gkc/authentication.md
@@ -95,7 +95,7 @@ Use a dedicated Data Distillery service account (or user account) and do not ass
 
 Note: the class name `WikiverseAuth` is historical; in practice it is used as a MediaWiki-compatible auth client when you supply an explicit `api_url`.
 
-For Data Distillery command-line workflows, GKC uses dedicated `DD_WB_*` environment variables and treats this as a separate authentication context from `WIKIVERSE_*`.
+For Data Distillery read workflows, GKC uses `META_WB_CONFIG` and optional `META_WB_*` endpoint overrides as integration settings only. Authentication remains generic MediaWiki authentication via explicit `WikiverseAuth(...)` parameters or the `WIKIVERSE_*` environment variables.
 
 ### Python Usage
 
@@ -117,14 +117,13 @@ except AuthenticationError as exc:
 
 ### CLI Usage (`gkc mash cache-wikibase-revisions`)
 
-`gkc mash cache-wikibase-revisions` reads Data Distillery settings from `DD_WB_*` variables.
+`gkc mash cache-wikibase-revisions` reads Data Distillery integration settings from the tracked config file and optional overrides.
 
-- `DD_WB_API_URL`
-- `DD_WB_USERNAME`
-- `DD_WB_PASSWORD`
-- `DD_WB_SPARQL_ENDPOINT` (for SPARQL-based operations)
+- `META_WB_CONFIG`
+- `META_WB_API_URL`
+- `META_WB_SPARQL_ENDPOINT` (for SPARQL-based operations)
 
-Authentication for revision-check/cache operations is optional by default.
+Authentication for revision-check/cache operations is optional by default and is not configured through `META_WB_*` variables.
 
 ### Validate Authentication and Session Behavior
 
@@ -215,21 +214,20 @@ You can set the following environment variables for automatic authentication:
 
 ### Data Distillery Wikibase
 
-- `DD_WB_API_URL` - Data Distillery API URL (for example `https://datadistillery.wikibase.cloud/w/api.php`)
-- `DD_WB_USERNAME` - Data Distillery account username
-- `DD_WB_PASSWORD` - Data Distillery account password
-- `DD_WB_SPARQL_ENDPOINT` - SPARQL endpoint for Data Distillery profile lookup hydration and related query operations
+- `META_WB_CONFIG` - Path to the meta-wikibase config file (for example `/path/to/SpiritSafe/dd-wikibase.yaml`)
+- `META_WB_API_URL` - Optional API URL override for the configured meta-wikibase
+- `META_WB_SPARQL_ENDPOINT` - Optional SPARQL endpoint override for the configured meta-wikibase
 
-`DD_WB_*` variables are used for Data Distillery flows (for example `gkc mash cache-wikibase-revisions`) and are intentionally separate from `WIKIVERSE_*`.
+`META_WB_*` variables are used to point read-oriented Data Distillery flows at the correct config file and endpoint overrides. They are not a separate authentication framework.
 
-If you do not set `DD_WB_API_URL`, GKC defaults to Data Distillery (`https://datadistillery.wikibase.cloud/w/api.php`).
+If you do not set `META_WB_CONFIG` and no config file is auto-discovered, GKC defaults to the Data Distillery API URL (`https://datadistillery.wikibase.cloud/w/api.php`).
 
-If you do not set `DD_WB_SPARQL_ENDPOINT`, GKC currently falls back to `https://query.wikidata.org/sparql`; for Data Distillery operations you should set this explicitly to the Data Distillery query service endpoint.
+If you do not set `META_WB_SPARQL_ENDPOINT` and the config file does not provide a SPARQL endpoint, GKC currently falls back to `https://query.wikidata.org/sparql`; for Data Distillery operations you should set this explicitly in the config file or override.
 
 ### Data Distillery Authentication Troubleshooting
 
 - **Login fails with valid-looking credentials**: verify you are using a Data Distillery account, not Wikimedia SUL bot-password credentials.
-- **Data Distillery cache commands fail with auth/session errors**: verify `DD_WB_API_URL` and credential values if you intend to run authenticated requests.
+- **Data Distillery cache commands fail with auth/session errors**: verify `META_WB_CONFIG` points at the expected file, confirm the configured API URL is correct, and if you are explicitly supplying `WikiverseAuth` credentials verify those values independently.
 - **Write succeeds in manual UI but fails via API**: confirm account permissions/group membership on Data Distillery include edit rights.
 
 ### OpenStreetMap
@@ -260,10 +258,9 @@ export WIKIVERSE_PASSWORD="abc123def456ghi789"
 export WIKIVERSE_API_URL="https://wiki.mycompany.com/w/api.php"
 
 # Data Distillery Wikibase
-export DD_WB_API_URL="https://datadistillery.wikibase.cloud/w/api.php"
-export DD_WB_USERNAME="my_dd_account"
-export DD_WB_PASSWORD="my_dd_password"
-export DD_WB_SPARQL_ENDPOINT="https://datadistillery.wikibase.cloud/query/sparql"
+export META_WB_CONFIG="/path/to/SpiritSafe/dd-wikibase.yaml"
+export META_WB_API_URL="https://datadistillery.wikibase.cloud/w/api.php"
+export META_WB_SPARQL_ENDPOINT="https://datadistillery.wikibase.cloud/query/sparql"
 
 # OpenStreetMap
 export OPENSTREETMAP_USERNAME="your_osm_username"

--- a/docs/gkc/setup.md
+++ b/docs/gkc/setup.md
@@ -79,14 +79,20 @@ If you intend to publish data to Wikidata, Wikimedia Commons, or OpenStreetMap, 
 
 ### Data Distillery Wikibase Environment
 
-If you are working with processes that interface with the [Data Distillery Wikibase](https://datadistillery.wikibase.cloud/) you may find it useful to set the following additional environment variables:
+If you are working with read-oriented processes that interface with the [Data Distillery Wikibase](https://datadistillery.wikibase.cloud/), point `gkc` at the tracked meta-wikibase config file.
 
 ```bash
-export DD_WB_API_URL="https://datadistillery.wikibase.cloud/w/api.php"
-export DD_WB_SPARQL_ENDPOINT="https://datadistillery.wikibase.cloud/query/sparql"
-export DD_WB_USERNAME="your_dd_username"
-export DD_WB_PASSWORD="your_dd_password"
+export META_WB_CONFIG="/path/to/SpiritSafe/dd-wikibase.yaml"
 ```
+
+When necessary, you can override endpoint values directly:
+
+```bash
+export META_WB_API_URL="https://datadistillery.wikibase.cloud/w/api.php"
+export META_WB_SPARQL_ENDPOINT="https://datadistillery.wikibase.cloud/query/sparql"
+```
+
+These settings configure which Wikibase instance and SPARQL endpoint the mash utilities read from. They are not an authentication namespace.
 
 
 ---

--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -349,7 +349,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     mash_check_wikibase_revisions.add_argument(
         "--api-url",
-        help="Override the Data Distillery API URL (default: DD_WB_API_URL env var)",
+        help="Override the configured Wikibase API URL (default: META_WB_API_URL env var)",
     )
     mash_check_wikibase_revisions.add_argument(
         "--since",
@@ -391,7 +391,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     mash_cache_wikibase_revisions.add_argument(
         "--api-url",
-        help="Override the Data Distillery API URL (default: DD_WB_API_URL env var)",
+        help="Override the configured Wikibase API URL (default: META_WB_API_URL env var)",
     )
     mash_cache_wikibase_revisions.add_argument(
         "--source-endpoint",
@@ -460,7 +460,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--batch-size",
         type=int,
         default=None,
-        help="Override API batch size (default: auto-detected from auth capability)",
+        help="Override API batch size (default: 50 for unauthenticated mash reads)",
     )
     mash_full_sync_wikibase.add_argument(
         "--output",
@@ -623,7 +623,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=runtime_config.api_url,
         help=(
             "Wikibase API URL used for talk-page retrieval "
-            "(default: DD_WB_API_URL or Data Distillery API)"
+            "(default: META_WB_API_URL env var, config file, or Data Distillery API)"
         ),
     )
     profile_value_lists_hydrate.add_argument(
@@ -631,7 +631,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=runtime_config.sparql_endpoint,
         help=(
             "SPARQL endpoint URL used for hydration "
-            "(default: DD_WB_SPARQL_ENDPOINT env var or Wikidata Query Service)"
+            "(default: META_WB_SPARQL_ENDPOINT env var, config file, or Wikidata Query Service)"
         ),
     )
     profile_value_lists_hydrate.add_argument(
@@ -2816,15 +2816,7 @@ def _handle_mash_full_sync_wikibase(args: argparse.Namespace) -> dict[str, Any]:
     runtime_config = get_wikibase_runtime_config()
     api_url = args.api_url or runtime_config.api_url
     api_url_source = "arg" if args.api_url else "runtime_config"
-
-    # Attempt auth for high-volume batch capability; continue unauthenticated if unavailable
     auth: Optional[WikiverseAuth] = None
-    try:
-        candidate = WikiverseAuth(api_url=api_url)
-        if candidate.username and candidate.password:
-            auth = candidate
-    except Exception:
-        pass
 
     if args.items_only and args.properties_only:
         raise CLIError("--items-only and --properties-only are mutually exclusive")

--- a/gkc/runtime_config.py
+++ b/gkc/runtime_config.py
@@ -1,47 +1,180 @@
 """Runtime configuration helpers for GKC integrations.
 
-Plain meaning: Read environment-based defaults in one place.
+Plain meaning: Read read-only integration defaults in one place.
 """
 
 from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Optional
+from pathlib import Path
+from typing import Optional, TypedDict
+
+import yaml
 
 DEFAULT_WIKIBASE_API_URL = "https://datadistillery.wikibase.cloud/w/api.php"
 DEFAULT_SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
 DEFAULT_USER_AGENT = "GKC/1.0 (https://github.com/skybristol/gkc; data integration)"
+META_WB_CONFIG_ENV_VAR = "META_WB_CONFIG"
+META_WB_API_URL_ENV_VAR = "META_WB_API_URL"
+META_WB_SPARQL_ENDPOINT_ENV_VAR = "META_WB_SPARQL_ENDPOINT"
+DEFAULT_META_WB_CONFIG_FILENAMES = (
+    "meta-wikibase.yaml",
+    "meta-wikibase.yml",
+    "dd-wikibase.yaml",
+    "dd-wikibase.yml",
+)
 
 
 @dataclass(frozen=True)
 class WikibaseRuntimeConfig:
-    """Wikibase-related runtime settings resolved from environment."""
+    """Read-only Wikibase integration settings resolved from environment."""
 
     api_url: str
     sparql_endpoint: Optional[str]
-    username: Optional[str]
-    password: Optional[str]
+    config_path: Optional[str] = None
+    config_id: Optional[str] = None
+    label: Optional[str] = None
+    name_identifier_property_id: Optional[str] = None
+    internal_name_identifier_prefix: Optional[str] = None
+
+
+class MetaWikibaseConfigValues(TypedDict):
+    config_id: Optional[str]
+    label: Optional[str]
+    api_url: Optional[str]
+    sparql_endpoint: Optional[str]
+    name_identifier_property_id: Optional[str]
+    internal_name_identifier_prefix: Optional[str]
+
+
+def _read_optional_string(mapping: dict[object, object], key: str) -> Optional[str]:
+    value = mapping.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RuntimeError(f"meta-wikibase config field '{key}' must be a string")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _discover_meta_wikibase_config_path() -> Optional[Path]:
+    explicit_path = os.environ.get(META_WB_CONFIG_ENV_VAR)
+    if explicit_path:
+        candidate = Path(explicit_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = (Path.cwd() / candidate).resolve()
+        if not candidate.is_file():
+            raise RuntimeError(f"META_WB_CONFIG points to a missing file: {candidate}")
+        return candidate
+
+    for directory in (Path.cwd(), *Path.cwd().parents):
+        for filename in DEFAULT_META_WB_CONFIG_FILENAMES:
+            candidate = directory / filename
+            if candidate.is_file():
+                return candidate
+
+    return None
+
+
+def _load_meta_wikibase_config(path: Path) -> MetaWikibaseConfigValues:
+    try:
+        raw_config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to read meta-wikibase config {path}: {exc}"
+        ) from exc
+
+    if raw_config is None:
+        return {
+            "config_id": None,
+            "label": None,
+            "api_url": None,
+            "sparql_endpoint": None,
+            "name_identifier_property_id": None,
+            "internal_name_identifier_prefix": None,
+        }
+    if not isinstance(raw_config, dict):
+        raise RuntimeError(
+            f"Meta-wikibase config {path} must contain a top-level mapping"
+        )
+
+    meta_config = raw_config.get("meta_wikibase", raw_config)
+    if not isinstance(meta_config, dict):
+        raise RuntimeError(
+            f"Meta-wikibase config {path} field 'meta_wikibase' must be a mapping"
+        )
+
+    semantic_conventions = meta_config.get("semantic_conventions")
+    if semantic_conventions is None:
+        semantic_conventions = {}
+    if not isinstance(semantic_conventions, dict):
+        raise RuntimeError(
+            f"Meta-wikibase config {path} field 'semantic_conventions' must be a mapping"
+        )
+
+    return {
+        "config_id": _read_optional_string(meta_config, "id"),
+        "label": _read_optional_string(meta_config, "label"),
+        "api_url": _read_optional_string(meta_config, "api_url"),
+        "sparql_endpoint": _read_optional_string(meta_config, "sparql_endpoint"),
+        "name_identifier_property_id": _read_optional_string(
+            semantic_conventions, "name_identifier_property_id"
+        ),
+        "internal_name_identifier_prefix": _read_optional_string(
+            semantic_conventions, "internal_name_identifier_prefix"
+        ),
+    }
 
 
 def get_wikibase_runtime_config() -> WikibaseRuntimeConfig:
     """Return resolved Wikibase runtime settings.
 
     Resolution order:
-      - API URL: DD_WB_API_URL or default Data Distillery URL
-      - SPARQL endpoint: DD_WB_SPARQL_ENDPOINT or default Wikidata QS endpoint
-            - Username/password: DD_WB_USERNAME/DD_WB_PASSWORD (optional)
+      - Config file path from META_WB_CONFIG, when set explicitly
+      - Auto-discovered config file in current/parent directories
+      - API URL override: META_WB_API_URL or config file value or default
+      - SPARQL endpoint override: META_WB_SPARQL_ENDPOINT or config file value
+        or default Wikidata QS endpoint
+
+    Authentication is intentionally out of scope here. Generic MediaWiki
+    authentication continues to flow through ``WikiverseAuth`` and the
+    ``WIKIVERSE_*`` environment variables or explicit parameters.
     """
 
-    api_url = os.environ.get("DD_WB_API_URL") or DEFAULT_WIKIBASE_API_URL
-    sparql_endpoint = os.environ.get("DD_WB_SPARQL_ENDPOINT") or DEFAULT_SPARQL_ENDPOINT
+    config_path = _discover_meta_wikibase_config_path()
+    config_values: MetaWikibaseConfigValues
+    if config_path:
+        config_values = _load_meta_wikibase_config(config_path)
+    else:
+        config_values = {
+            "config_id": None,
+            "label": None,
+            "api_url": None,
+            "sparql_endpoint": None,
+            "name_identifier_property_id": None,
+            "internal_name_identifier_prefix": None,
+        }
 
-    username = os.environ.get("DD_WB_USERNAME")
-    password = os.environ.get("DD_WB_PASSWORD")
+    api_url = (
+        os.environ.get(META_WB_API_URL_ENV_VAR)
+        or config_values.get("api_url")
+        or DEFAULT_WIKIBASE_API_URL
+    )
+    sparql_endpoint = (
+        os.environ.get(META_WB_SPARQL_ENDPOINT_ENV_VAR)
+        or config_values.get("sparql_endpoint")
+        or DEFAULT_SPARQL_ENDPOINT
+    )
 
     return WikibaseRuntimeConfig(
         api_url=api_url,
         sparql_endpoint=sparql_endpoint,
-        username=username,
-        password=password,
+        config_path=str(config_path) if config_path else None,
+        config_id=config_values.get("config_id"),
+        label=config_values.get("label"),
+        name_identifier_property_id=config_values.get("name_identifier_property_id"),
+        internal_name_identifier_prefix=config_values.get(
+            "internal_name_identifier_prefix"
+        ),
     )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Tribal Governments: tribes.md
   - Architecture:
     - Overview: architecture/index.md
+    - Meta-Wikibase: architecture/meta-wikibase.md
     - Data Distillery Wikibase: architecture/DataDistillery-Wikibase.md
     - Cross-Module Contracts: architecture/module-contracts.md
     - Still Charger: architecture/still_charger.md

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -3,16 +3,18 @@
 from gkc.runtime_config import (
     DEFAULT_SPARQL_ENDPOINT,
     DEFAULT_WIKIBASE_API_URL,
+    META_WB_API_URL_ENV_VAR,
+    META_WB_CONFIG_ENV_VAR,
+    META_WB_SPARQL_ENDPOINT_ENV_VAR,
     get_wikibase_runtime_config,
 )
 
 
 def test_runtime_config_defaults(monkeypatch):
-    """Defaults are used when DD_WB_* vars are absent."""
-    monkeypatch.delenv("DD_WB_API_URL", raising=False)
-    monkeypatch.delenv("DD_WB_SPARQL_ENDPOINT", raising=False)
-    monkeypatch.delenv("DD_WB_USERNAME", raising=False)
-    monkeypatch.delenv("DD_WB_PASSWORD", raising=False)
+    """Defaults are used when META_WB_* vars and config files are absent."""
+    monkeypatch.delenv(META_WB_CONFIG_ENV_VAR, raising=False)
+    monkeypatch.delenv(META_WB_API_URL_ENV_VAR, raising=False)
+    monkeypatch.delenv(META_WB_SPARQL_ENDPOINT_ENV_VAR, raising=False)
     monkeypatch.delenv("WIKIVERSE_USERNAME", raising=False)
     monkeypatch.delenv("WIKIVERSE_PASSWORD", raising=False)
 
@@ -20,33 +22,108 @@ def test_runtime_config_defaults(monkeypatch):
 
     assert config.api_url == DEFAULT_WIKIBASE_API_URL
     assert config.sparql_endpoint == DEFAULT_SPARQL_ENDPOINT
-    assert config.username is None
-    assert config.password is None
+    assert config.config_path is None
 
 
 def test_runtime_config_env_overrides(monkeypatch):
-    """DD_WB_* variables override defaults."""
-    monkeypatch.setenv("DD_WB_API_URL", "https://dd.example/w/api.php")
-    monkeypatch.setenv("DD_WB_SPARQL_ENDPOINT", "https://dd.example/query/sparql")
-    monkeypatch.setenv("DD_WB_USERNAME", "bot-user")
-    monkeypatch.setenv("DD_WB_PASSWORD", "bot-pass")
+    """META_WB_* variables override defaults."""
+    monkeypatch.setenv(META_WB_API_URL_ENV_VAR, "https://dd.example/w/api.php")
+    monkeypatch.setenv(
+        META_WB_SPARQL_ENDPOINT_ENV_VAR, "https://dd.example/query/sparql"
+    )
 
     config = get_wikibase_runtime_config()
 
     assert config.api_url == "https://dd.example/w/api.php"
     assert config.sparql_endpoint == "https://dd.example/query/sparql"
-    assert config.username == "bot-user"
-    assert config.password == "bot-pass"
 
 
 def test_runtime_config_ignores_wikiverse_credentials(monkeypatch):
-    """WIKIVERSE_* credentials are ignored for Data Distillery runtime config."""
-    monkeypatch.delenv("DD_WB_USERNAME", raising=False)
-    monkeypatch.delenv("DD_WB_PASSWORD", raising=False)
+    """WIKIVERSE_* credentials do not affect read-only runtime config."""
+    monkeypatch.delenv(META_WB_CONFIG_ENV_VAR, raising=False)
+    monkeypatch.delenv(META_WB_API_URL_ENV_VAR, raising=False)
+    monkeypatch.delenv(META_WB_SPARQL_ENDPOINT_ENV_VAR, raising=False)
     monkeypatch.setenv("WIKIVERSE_USERNAME", "legacy-user")
     monkeypatch.setenv("WIKIVERSE_PASSWORD", "legacy-pass")
 
     config = get_wikibase_runtime_config()
 
-    assert config.username is None
-    assert config.password is None
+    assert config.api_url == DEFAULT_WIKIBASE_API_URL
+    assert config.sparql_endpoint == DEFAULT_SPARQL_ENDPOINT
+
+
+def test_runtime_config_loads_config_file(monkeypatch, tmp_path):
+    """Runtime config loads endpoint settings from a tracked config file."""
+    config_path = tmp_path / "dd-wikibase.yaml"
+    config_path.write_text(
+        """
+meta_wikibase:
+  id: datadistillery-wikibase
+  label: Data Distillery Wikibase
+  api_url: https://config.example/w/api.php
+  sparql_endpoint: https://config.example/query/sparql
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(META_WB_CONFIG_ENV_VAR, str(config_path))
+    monkeypatch.delenv(META_WB_API_URL_ENV_VAR, raising=False)
+    monkeypatch.delenv(META_WB_SPARQL_ENDPOINT_ENV_VAR, raising=False)
+
+    config = get_wikibase_runtime_config()
+
+    assert config.config_path == str(config_path)
+    assert config.config_id == "datadistillery-wikibase"
+    assert config.label == "Data Distillery Wikibase"
+    assert config.api_url == "https://config.example/w/api.php"
+    assert config.sparql_endpoint == "https://config.example/query/sparql"
+    assert config.name_identifier_property_id == "P214"
+    assert config.internal_name_identifier_prefix == "_"
+
+
+def test_runtime_config_autodiscovers_config_file(monkeypatch, tmp_path):
+    """Runtime config auto-discovers dd-wikibase.yaml from parent directories."""
+    root_dir = tmp_path / "SpiritSafe"
+    nested_dir = root_dir / "cache" / "entities"
+    nested_dir.mkdir(parents=True)
+    config_path = root_dir / "dd-wikibase.yaml"
+    config_path.write_text(
+        "api_url: https://autodiscovery.example/w/api.php\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv(META_WB_CONFIG_ENV_VAR, raising=False)
+    monkeypatch.delenv(META_WB_API_URL_ENV_VAR, raising=False)
+    monkeypatch.delenv(META_WB_SPARQL_ENDPOINT_ENV_VAR, raising=False)
+    monkeypatch.chdir(nested_dir)
+
+    config = get_wikibase_runtime_config()
+
+    assert config.config_path == str(config_path)
+    assert config.api_url == "https://autodiscovery.example/w/api.php"
+    assert config.sparql_endpoint == DEFAULT_SPARQL_ENDPOINT
+
+
+def test_runtime_config_env_overrides_config_file(monkeypatch, tmp_path):
+    """META_WB_* overrides win over config file values."""
+    config_path = tmp_path / "dd-wikibase.yaml"
+    config_path.write_text(
+        """
+api_url: https://config.example/w/api.php
+sparql_endpoint: https://config.example/query/sparql
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(META_WB_CONFIG_ENV_VAR, str(config_path))
+    monkeypatch.setenv(META_WB_API_URL_ENV_VAR, "https://env.example/w/api.php")
+    monkeypatch.setenv(
+        META_WB_SPARQL_ENDPOINT_ENV_VAR, "https://env.example/query/sparql"
+    )
+
+    config = get_wikibase_runtime_config()
+
+    assert config.api_url == "https://env.example/w/api.php"
+    assert config.sparql_endpoint == "https://env.example/query/sparql"


### PR DESCRIPTION
Implements the first meta-wikibase configuration slice.

- makes mash read-side config file-first via META_WB_CONFIG and META_WB_* overrides
- keeps mash full sync unauthenticated by default
- adds the generic meta-wikibase architecture doc
- reframes Data Distillery Wikibase as the current reference implementation
- updates setup/auth/runtime-config tests to match the new contract

Refs #210.