### PR TITLE
fix: reduce semantic anchors to thin map

### DIFF
--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -2279,13 +2279,9 @@ def _handle_spiritsafe_semantic_anchors_build(
         )
 
         artifact = export_spiritsafe_semantic_anchors(local_root, output_path)
-        config = artifact.get("config", {})
         details = {
             "output_path": str(output_path),
-            "config_path": config.get("path"),
-            "config_id": config.get("id"),
-            "anchor_count": artifact.get("anchor_count", 0),
-            "internal_anchor_count": artifact.get("internal_anchor_count", 0),
+            "anchor_count": len(artifact) if isinstance(artifact, dict) else 0,
         }
         return {
             "command": args.command_path,

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -2903,8 +2903,8 @@ def _build_semantic_anchor_entry(
     name_identifier_property_id: str,
     internal_prefix: str,
 ) -> Optional[dict[str, Any]]:
-    base_entry = _build_entity_index_entry(entity_doc)
-    entity_id = str(base_entry.get("id") or "")
+    entity = entity_doc.get("entity", {})
+    entity_id = str(entity_doc.get("entity_id") or entity.get("id") or "")
     claims = entity_doc.get("entity", {}).get("claims", {})
     name_identifier = next(
         (
@@ -2920,33 +2920,28 @@ def _build_semantic_anchor_entry(
     if not name_identifier:
         return None
 
-    is_internal = bool(internal_prefix and name_identifier.startswith(internal_prefix))
-    anchor_key = (
-        name_identifier[len(internal_prefix) :]
-        if is_internal and len(name_identifier) > len(internal_prefix)
-        else name_identifier
-    )
+    if not (internal_prefix and name_identifier.startswith(internal_prefix)):
+        return None
 
-    return {
+    entry = {
         "id": entity_id,
-        "entity": base_entry.get("entity"),
-        "label": base_entry.get("label"),
-        "name_identifier": name_identifier,
-        "anchor_key": anchor_key,
-        "is_internal": is_internal,
-        "classes": list(base_entry.get("classes", [])),
-        "io_map": list(base_entry.get("io_map", [])),
+        "entity": f"{SPIRITSAFE_ENTITY_URI_PREFIX}{entity_id}",
     }
+
+    if entity.get("type") == "property" and isinstance(entity.get("datatype"), str):
+        entry["datatype"] = entity["datatype"]
+
+    return entry
 
 
 def build_spiritsafe_semantic_anchor_document(
     spiritsafe_root: Union[str, Path],
 ) -> dict[str, Any]:
-    """Build a normalized semantic anchor artifact from cached SpiritSafe entities."""
+    """Build a thin semantic anchor mapping from cached SpiritSafe entities."""
 
     root = Path(spiritsafe_root).expanduser().resolve()
     cache_entities_dir = root / "cache" / "entities"
-    config_path, config_values = _resolve_spiritsafe_meta_wikibase_config(root)
+    _config_path, config_values = _resolve_spiritsafe_meta_wikibase_config(root)
 
     name_identifier_property_id = (
         config_values.get("name_identifier_property_id") or "P214"
@@ -2954,60 +2949,32 @@ def build_spiritsafe_semantic_anchor_document(
     internal_prefix = config_values.get("internal_name_identifier_prefix") or "_"
 
     anchors: dict[str, dict[str, Any]] = {}
-    anchor_key_index: dict[str, list[str]] = {}
-    entity_id_index: dict[str, str] = {}
 
     for entity_path in sorted(cache_entities_dir.glob("*.json")):
         entity_doc = json.loads(entity_path.read_text(encoding="utf-8"))
+        claims = entity_doc.get("entity", {}).get("claims", {})
+        name_identifier = next(
+            (
+                value
+                for value in (
+                    _claim_string_value(claim)
+                    for claim in claims.get(name_identifier_property_id, [])
+                )
+                if value
+            ),
+            None,
+        )
         entry = _build_semantic_anchor_entry(
             entity_doc,
             name_identifier_property_id=name_identifier_property_id,
             internal_prefix=internal_prefix,
         )
-        if not entry:
+        if not entry or not name_identifier:
             continue
 
-        name_identifier = str(entry["name_identifier"])
-        entity_id = str(entry["id"])
-        anchor_key = str(entry["anchor_key"])
         anchors[name_identifier] = entry
-        entity_id_index[entity_id] = name_identifier
-        anchor_key_index.setdefault(anchor_key, []).append(name_identifier)
 
-    for anchor_key, identifiers in anchor_key_index.items():
-        anchor_key_index[anchor_key] = sorted(set(identifiers))
-
-    relative_config_path = None
-    if config_path is not None:
-        try:
-            relative_config_path = str(config_path.relative_to(root))
-        except ValueError:
-            relative_config_path = str(config_path)
-
-    internal_anchor_count = sum(
-        1 for anchor in anchors.values() if anchor.get("is_internal") is True
-    )
-
-    return {
-        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        "source": _manifest_source_url(),
-        "config": {
-            "path": relative_config_path,
-            "id": config_values.get("config_id"),
-            "label": config_values.get("label"),
-            "api_url": config_values.get("api_url"),
-            "sparql_endpoint": config_values.get("sparql_endpoint"),
-            "semantic_conventions": {
-                "name_identifier_property_id": name_identifier_property_id,
-                "internal_name_identifier_prefix": internal_prefix,
-            },
-        },
-        "anchor_count": len(anchors),
-        "internal_anchor_count": internal_anchor_count,
-        "anchors": anchors,
-        "anchor_key_index": anchor_key_index,
-        "entity_id_index": entity_id_index,
-    }
+    return anchors
 
 
 def export_spiritsafe_semantic_anchors(

--- a/tests/test_cli_spiritsafe_semantic_anchors.py
+++ b/tests/test_cli_spiritsafe_semantic_anchors.py
@@ -13,12 +13,12 @@ def test_spiritsafe_semantic_anchors_build_json(monkeypatch, capsys, tmp_path):
         assert str(spiritsafe_root).endswith("SpiritSafe")
         assert str(output_path).endswith("cache/config/semantic_anchors.json")
         return {
-            "config": {
-                "path": "config/dd-wikibase.yaml",
-                "id": "datadistillery-wikibase",
+            "_foo": {"id": "Q1", "entity": "https://example.org/entity/Q1"},
+            "_bar": {
+                "id": "P1",
+                "entity": "https://example.org/entity/P1",
+                "datatype": "string",
             },
-            "anchor_count": 3,
-            "internal_anchor_count": 1,
         }
 
     monkeypatch.setattr(cli, "export_spiritsafe_semantic_anchors", fake_export)
@@ -40,9 +40,7 @@ def test_spiritsafe_semantic_anchors_build_json(monkeypatch, capsys, tmp_path):
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["command"] == "spiritsafe.semantic-anchors.build"
     assert payload["ok"] is True
-    assert payload["details"]["config_path"] == "config/dd-wikibase.yaml"
-    assert payload["details"]["anchor_count"] == 3
-    assert payload["details"]["internal_anchor_count"] == 1
+    assert payload["details"]["anchor_count"] == 2
 
 
 def test_spiritsafe_semantic_anchors_build_requires_local_root(capsys):

--- a/tests/test_spirit_safe_phase3.py
+++ b/tests/test_spirit_safe_phase3.py
@@ -107,7 +107,7 @@ def test_export_spiritsafe_entity_index(fixture_root: Path, tmp_path: Path):
 
 
 def test_build_spiritsafe_semantic_anchor_document(tmp_path: Path, fixture_root: Path):
-    """Semantic anchor builder should normalize named entities and config metadata."""
+    """Semantic anchor builder should emit only underscore-prefixed thin mappings."""
 
     root = tmp_path / "spiritsafe"
     copytree(fixture_root, root)
@@ -134,7 +134,7 @@ meta_wikibase:
                 "snaktype": "value",
                 "property": "P214",
                 "datavalue": {
-                    "value": "TribalGovernmentInTheUnitedStates",
+                    "value": "_TribalGovernmentInTheUnitedStates",
                     "type": "string",
                 },
                 "datatype": "string",
@@ -148,33 +148,78 @@ meta_wikibase:
 
     anchors = build_spiritsafe_semantic_anchor_document(root)
 
-    assert anchors["config"]["path"] == "config/dd-wikibase.yaml"
-    assert anchors["config"]["semantic_conventions"] == {
-        "name_identifier_property_id": "P214",
-        "internal_name_identifier_prefix": "_",
+    assert anchors == {
+        "_TribalGovernmentInTheUnitedStates": {
+            "id": "Q4",
+            "entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+        }
     }
-    assert anchors["anchor_count"] == 1
-    assert anchors["internal_anchor_count"] == 0
-    assert anchors["anchors"]["TribalGovernmentInTheUnitedStates"] == {
-        "id": "Q4",
-        "entity": "https://datadistillery.wikibase.cloud/entity/Q4",
-        "label": "Tribal Government in the United States",
-        "name_identifier": "TribalGovernmentInTheUnitedStates",
-        "anchor_key": "TribalGovernmentInTheUnitedStates",
-        "is_internal": False,
-        "classes": [],
-        "io_map": [],
+
+
+def test_build_spiritsafe_semantic_anchor_document_includes_property_datatype(
+    tmp_path: Path, fixture_root: Path
+):
+    """Semantic anchor builder should include datatype for properties only."""
+
+    root = tmp_path / "spiritsafe"
+    copytree(fixture_root, root)
+    config_dir = root / "config"
+    config_dir.mkdir()
+    (config_dir / "dd-wikibase.yaml").write_text(
+        """
+meta_wikibase:
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    property_path = root / "cache" / "entities" / "P192.json"
+    property_doc = {
+        "entity_id": "P192",
+        "entity": {
+            "type": "property",
+            "datatype": "time",
+            "id": "P192",
+            "claims": {
+                "P214": [
+                    {
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P214",
+                            "datavalue": {
+                                "value": "_time",
+                                "type": "string",
+                            },
+                            "datatype": "string",
+                        },
+                        "type": "statement",
+                        "id": "P192$P214-internal",
+                        "rank": "normal",
+                    }
+                ]
+            },
+        },
     }
-    assert anchors["anchor_key_index"] == {
-        "TribalGovernmentInTheUnitedStates": ["TribalGovernmentInTheUnitedStates"]
+    property_path.write_text(json.dumps(property_doc, indent=2), encoding="utf-8")
+
+    anchors = build_spiritsafe_semantic_anchor_document(root)
+
+    assert anchors == {
+        "_time": {
+            "id": "P192",
+            "entity": "https://datadistillery.wikibase.cloud/entity/P192",
+            "datatype": "time",
+        }
     }
-    assert anchors["entity_id_index"] == {"Q4": "TribalGovernmentInTheUnitedStates"}
 
 
 def test_build_spiritsafe_semantic_anchor_document_marks_internal_entries(
     tmp_path: Path, fixture_root: Path
 ):
-    """Semantic anchor builder should flag underscore-prefixed internal anchors."""
+    """Semantic anchor builder should exclude non-underscore identifiers."""
 
     root = tmp_path / "spiritsafe"
     copytree(fixture_root, root)
@@ -199,7 +244,7 @@ meta_wikibase:
                 "snaktype": "value",
                 "property": "P214",
                 "datavalue": {
-                    "value": "_tribal_government_profile",
+                    "value": "tribal_government_profile",
                     "type": "string",
                 },
                 "datatype": "string",
@@ -213,13 +258,7 @@ meta_wikibase:
 
     anchors = build_spiritsafe_semantic_anchor_document(root)
 
-    entry = anchors["anchors"]["_tribal_government_profile"]
-    assert entry["is_internal"] is True
-    assert entry["anchor_key"] == "tribal_government_profile"
-    assert anchors["internal_anchor_count"] == 1
-    assert anchors["anchor_key_index"] == {
-        "tribal_government_profile": ["_tribal_government_profile"]
-    }
+    assert anchors == {}
 
 
 def test_export_spiritsafe_semantic_anchors(fixture_root: Path, tmp_path: Path):
@@ -248,7 +287,7 @@ meta_wikibase:
                 "snaktype": "value",
                 "property": "P214",
                 "datavalue": {
-                    "value": "TribalGovernmentInTheUnitedStates",
+                    "value": "_TribalGovernmentInTheUnitedStates",
                     "type": "string",
                 },
                 "datatype": "string",
@@ -264,7 +303,12 @@ meta_wikibase:
     anchors = export_spiritsafe_semantic_anchors(root, output_path)
 
     assert output_path.exists()
-    assert anchors["anchor_count"] == 1
+    assert anchors == {
+        "_TribalGovernmentInTheUnitedStates": {
+            "id": "Q4",
+            "entity": "https://datadistillery.wikibase.cloud/entity/Q4",
+        }
+    }
 
 
 def test_load_manifest_reads_new_shape():


### PR DESCRIPTION
## Summary

- reduce semantic anchor generation to a thin underscore-prefixed mapping only
- emit only id plus resolvable entity URI, and datatype only for property anchors
- remove borrowed entity-index metadata and wrapper fields from the artifact shape
- update the CLI reporting and focused tests to match the minimal contract

## Verification

- poetry run pytest tests/test_spirit_safe_phase3.py tests/test_cli_spiritsafe_semantic_anchors.py
- poetry run ruff check gkc/spirit_safe.py gkc/cli.py tests/test_spirit_safe_phase3.py tests/test_cli_spiritsafe_semantic_anchors.py
- poetry run black --check gkc/spirit_safe.py gkc/cli.py tests/test_spirit_safe_phase3.py tests/test_cli_spiritsafe_semantic_anchors.py
- poetry run gkc --json spiritsafe semantic-anchors build --source local --local-root /Users/sky/code/SpiritSafe
- ./scripts/pre-merge-check.sh

Note: pre-merge-check still reports the existing repo-wide non-blocking mypy issues outside this change; lint, formatting, and tests passed.

Part of #210.
