### PR TITLE
Add metadata to semantic anchor artifacts

### DIFF
--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -828,7 +828,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--output",
         help=(
             "Optional output path for artifact JSON "
-            "(default: <local_root>/cache/config/semantic_anchors.json)"
+            "(default: <local_root>/cache/config/semantic_anchors.json; "
+            "SpiritSafe workflows may override this)"
         ),
     )
     _add_profile_source_args(spiritsafe_semantic_anchors_build)
@@ -2279,9 +2280,13 @@ def _handle_spiritsafe_semantic_anchors_build(
         )
 
         artifact = export_spiritsafe_semantic_anchors(local_root, output_path)
+        entities = artifact.get("entities", {})
+        metadata = artifact.get("metadata", {})
         details = {
             "output_path": str(output_path),
-            "anchor_count": len(artifact) if isinstance(artifact, dict) else 0,
+            "anchor_count": len(entities) if isinstance(entities, dict) else 0,
+            "property_count": metadata.get("property_count", 0),
+            "item_count": metadata.get("item_count", 0),
         }
         return {
             "command": args.command_path,

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -2937,7 +2937,7 @@ def _build_semantic_anchor_entry(
 def build_spiritsafe_semantic_anchor_document(
     spiritsafe_root: Union[str, Path],
 ) -> dict[str, Any]:
-    """Build a thin semantic anchor mapping from cached SpiritSafe entities."""
+    """Build a thin semantic anchor artifact from cached SpiritSafe entities."""
 
     root = Path(spiritsafe_root).expanduser().resolve()
     cache_entities_dir = root / "cache" / "entities"
@@ -2974,7 +2974,27 @@ def build_spiritsafe_semantic_anchor_document(
 
         anchors[name_identifier] = entry
 
-    return anchors
+    property_count = sum(
+        1
+        for entry in anchors.values()
+        if isinstance(entry.get("id"), str) and entry["id"].startswith("P")
+    )
+    item_count = sum(
+        1
+        for entry in anchors.values()
+        if isinstance(entry.get("id"), str) and entry["id"].startswith("Q")
+    )
+
+    return {
+        "metadata": {
+            "generated_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "property_count": property_count,
+            "item_count": item_count,
+        },
+        "entities": anchors,
+    }
 
 
 def export_spiritsafe_semantic_anchors(

--- a/tests/test_cli_spiritsafe_semantic_anchors.py
+++ b/tests/test_cli_spiritsafe_semantic_anchors.py
@@ -13,11 +13,18 @@ def test_spiritsafe_semantic_anchors_build_json(monkeypatch, capsys, tmp_path):
         assert str(spiritsafe_root).endswith("SpiritSafe")
         assert str(output_path).endswith("cache/config/semantic_anchors.json")
         return {
-            "_foo": {"id": "Q1", "entity": "https://example.org/entity/Q1"},
-            "_bar": {
-                "id": "P1",
-                "entity": "https://example.org/entity/P1",
-                "datatype": "string",
+            "metadata": {
+                "generated_at": "2026-04-03T00:00:00Z",
+                "property_count": 1,
+                "item_count": 1,
+            },
+            "entities": {
+                "_foo": {"id": "Q1", "entity": "https://example.org/entity/Q1"},
+                "_bar": {
+                    "id": "P1",
+                    "entity": "https://example.org/entity/P1",
+                    "datatype": "string",
+                },
             },
         }
 
@@ -41,6 +48,8 @@ def test_spiritsafe_semantic_anchors_build_json(monkeypatch, capsys, tmp_path):
     assert payload["command"] == "spiritsafe.semantic-anchors.build"
     assert payload["ok"] is True
     assert payload["details"]["anchor_count"] == 2
+    assert payload["details"]["property_count"] == 1
+    assert payload["details"]["item_count"] == 1
 
 
 def test_spiritsafe_semantic_anchors_build_requires_local_root(capsys):

--- a/tests/test_spirit_safe_phase3.py
+++ b/tests/test_spirit_safe_phase3.py
@@ -107,7 +107,7 @@ def test_export_spiritsafe_entity_index(fixture_root: Path, tmp_path: Path):
 
 
 def test_build_spiritsafe_semantic_anchor_document(tmp_path: Path, fixture_root: Path):
-    """Semantic anchor builder should emit only underscore-prefixed thin mappings."""
+    """Semantic anchor builder should emit metadata plus underscore mappings."""
 
     root = tmp_path / "spiritsafe"
     copytree(fixture_root, root)
@@ -148,7 +148,10 @@ meta_wikibase:
 
     anchors = build_spiritsafe_semantic_anchor_document(root)
 
-    assert anchors == {
+    assert anchors["metadata"]["property_count"] == 0
+    assert anchors["metadata"]["item_count"] == 1
+    assert isinstance(anchors["metadata"]["generated_at"], str)
+    assert anchors["entities"] == {
         "_TribalGovernmentInTheUnitedStates": {
             "id": "Q4",
             "entity": "https://datadistillery.wikibase.cloud/entity/Q4",
@@ -207,7 +210,9 @@ meta_wikibase:
 
     anchors = build_spiritsafe_semantic_anchor_document(root)
 
-    assert anchors == {
+    assert anchors["metadata"]["property_count"] == 1
+    assert anchors["metadata"]["item_count"] == 0
+    assert anchors["entities"] == {
         "_time": {
             "id": "P192",
             "entity": "https://datadistillery.wikibase.cloud/entity/P192",
@@ -258,7 +263,9 @@ meta_wikibase:
 
     anchors = build_spiritsafe_semantic_anchor_document(root)
 
-    assert anchors == {}
+    assert anchors["metadata"]["property_count"] == 0
+    assert anchors["metadata"]["item_count"] == 0
+    assert anchors["entities"] == {}
 
 
 def test_export_spiritsafe_semantic_anchors(fixture_root: Path, tmp_path: Path):
@@ -303,7 +310,9 @@ meta_wikibase:
     anchors = export_spiritsafe_semantic_anchors(root, output_path)
 
     assert output_path.exists()
-    assert anchors == {
+    assert anchors["metadata"]["property_count"] == 0
+    assert anchors["metadata"]["item_count"] == 1
+    assert anchors["entities"] == {
         "_TribalGovernmentInTheUnitedStates": {
             "id": "Q4",
             "entity": "https://datadistillery.wikibase.cloud/entity/Q4",


### PR DESCRIPTION
## Summary
- return semantic-anchor artifacts with top-level metadata and entities keys
- include generated_at, property_count, and item_count in the artifact metadata
- update CLI reporting and tests to use the new artifact shape

## Validation
- poetry run pytest tests/test_spirit_safe_phase3.py tests/test_cli_spiritsafe_semantic_anchors.py
- ./scripts/pre-merge-check.sh (passes for lint, format, docs, and tests; existing non-blocking mypy baseline remains)