### PR TITLE
Fix full pre-merge gate after registry cleanup

### DIFF
--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -2113,8 +2113,8 @@ def _handle_registry_list(args: argparse.Namespace) -> dict[str, Any]:
                 {
                     "qid": profile_id,
                     "entity": profile.get("entity"),
-                        "label": _preferred_profile_text(metadata.get("labels", {})),
-                        "description": _preferred_profile_text(
+                    "label": _preferred_profile_text(metadata.get("labels", {})),
+                    "description": _preferred_profile_text(
                         metadata.get("descriptions", {})
                     ),
                     "statement_count": metadata.get(

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -3174,9 +3174,7 @@ def _normalized_packet_statement(statement: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
-def load_profile(
-    profile_id: str, manifest: Optional[object] = None
-) -> dict[str, Any]:
+def load_profile(profile_id: str, manifest: Optional[object] = None) -> dict[str, Any]:
     """Load a single JSON entity profile by QID or entity URI."""
 
     del manifest

--- a/gkc/wizard/steps.py
+++ b/gkc/wizard/steps.py
@@ -12,7 +12,10 @@ import streamlit as st
 
 import gkc
 from gkc.fermenter import validate_inline_value
-from gkc.runtime_config import resolve_spiritsafe_layout_for_root
+from gkc.runtime_config import (
+    get_wikibase_runtime_config,
+    resolve_spiritsafe_layout_for_root,
+)
 from gkc.wikibase import canonicalize_wikibase_datatype, is_wikibase_item_datatype
 from gkc.wizard.step_base import Step
 from gkc.wizard.widgets import WidgetFactory
@@ -297,7 +300,8 @@ def _materialize_value_list_cache(cache_ref: str) -> tuple[Path | None, str | No
                 )
             )
         else:
-            cache_ref_clean = f"cache/queries/{cache_ref_clean}.json"
+            layout = get_wikibase_runtime_config().spiritsafe_layout
+            cache_ref_clean = f"{layout.value_list_cache_path}/{cache_ref_clean}.json"
 
     local_cache_path = _wizard_value_list_cache_root() / cache_ref_clean
     local_cache_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -561,6 +561,7 @@ def test_mash_eid_basic(monkeypatch, capsys):
     assert result["ok"] is True
     assert data["id"] == "E502"
 
+
 def test_registry_list_json_uses_profile_documents(capsys):
     """registry list should emit QID-based profile entries from JSON profiles."""
 

--- a/tests/test_fermenter_value_list.py
+++ b/tests/test_fermenter_value_list.py
@@ -21,8 +21,9 @@ FIXTURE_PATH = (
     Path(__file__).resolve().parent
     / "fixtures"
     / "spiritsafe"
+    / "still"
+    / "value_lists"
     / "cache"
-    / "queries"
     / "Q28.json"
 )
 

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -29,8 +29,7 @@ def test_runtime_config_defaults(monkeypatch):
     )
     assert config.spiritsafe_layout.logs_path == "still/logs"
     assert (
-        config.spiritsafe_layout.wikimedia_sites_path
-        == "partners/wikimedia_sites.json"
+        config.spiritsafe_layout.wikimedia_sites_path == "partners/wikimedia_sites.json"
     )
 
 

--- a/tests/test_wizard_value_list_integration.py
+++ b/tests/test_wizard_value_list_integration.py
@@ -87,7 +87,7 @@ def test_materialize_value_list_cache_from_local_source(
     monkeypatch, tmp_path: Path
 ) -> None:
     spirit_safe_root = tmp_path / "SpiritSafe"
-    source_file = spirit_safe_root / "cache" / "queries" / "Q28.json"
+    source_file = spirit_safe_root / "still" / "value_lists" / "cache" / "Q28.json"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     source_file.write_text(
         '{"items": [{"item": "http://www.wikidata.org/entity/Q42", "itemLabel": "Douglas Adams"}]}',
@@ -118,7 +118,7 @@ def test_value_list_widget_kwargs_uses_statement_local_value_list_id(
     monkeypatch, tmp_path: Path
 ) -> None:
     spirit_safe_root = tmp_path / "SpiritSafe"
-    source_file = spirit_safe_root / "cache" / "queries" / "Q28.json"
+    source_file = spirit_safe_root / "still" / "value_lists" / "cache" / "Q28.json"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     source_file.write_text(
         '{"items": [{"item": "http://www.wikidata.org/entity/Q1", "itemLabel": "Universe"}]}',
@@ -174,7 +174,7 @@ def test_value_list_widget_kwargs_does_not_fallback_to_route_only(
     monkeypatch, tmp_path: Path
 ) -> None:
     spirit_safe_root = tmp_path / "SpiritSafe"
-    source_file = spirit_safe_root / "cache" / "queries" / "Q28.json"
+    source_file = spirit_safe_root / "still" / "value_lists" / "cache" / "Q28.json"
     source_file.parent.mkdir(parents=True, exist_ok=True)
     source_file.write_text(
         '{"items": [{"item": "http://www.wikidata.org/entity/Q1", "itemLabel": "Universe"}]}',


### PR DESCRIPTION
## Summary
- apply the black formatting that CI flagged after the registry cleanup merge
- update stale value-list fixture paths to the current SpiritSafe layout
- make wizard value-list cache fallback read the configured runtime layout instead of the retired `cache/queries` path

## Validation
- poetry run ruff check gkc tests
- poetry run black --check gkc tests
- poetry run pytest --cov=gkc --cov-report=xml --cov-report=term
