### PR TITLE
Implement seed planning and richer semantic anchors

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -17,6 +17,8 @@ Infrastructure components:
 2. **SpiritSafe repository** — materialized artifact registry (JSON profiles, query files, hydrated caches, and supporting generated artifacts).
 3. **GKC Python package** — runtime engine that consumes SpiritSafe artifacts to assemble packets (`still_charger`), validate/coerce (`fermenter`), plan writes, and ship.
 
+For the Commons-specific extension layer built on top of this Wikidata-first foundation, see [Wikimedia Commons Architecture](wikimedia-commons.md).
+
 Architectural components:
 
 1. **GKC Entity Profiles** — declarative definitions of entity structure and context.

--- a/docs/architecture/meta-wikibase/semantic-anchors.md
+++ b/docs/architecture/meta-wikibase/semantic-anchors.md
@@ -38,7 +38,7 @@ At this layer, we are defining concepts and expected datatypes, not binding to a
 
 ### 2. SpiritSafe Semantic-Anchor Artifact
 
-`cache/config/semantic_anchors.json` is the materialized artifact that maps those internal names to the concrete IDs currently present in the Meta-Wikibase-backed cache.
+`config/semantic_anchors.json` is the materialized artifact that maps those internal names to the concrete IDs currently present in the Meta-Wikibase-backed cache.
 
 Typical shape:
 
@@ -46,24 +46,50 @@ Typical shape:
 {
   "metadata": {
     "generated_at": "2026-04-04T00:00:00Z",
+    "contract_digest": "4c9f...",
     "property_count": 12,
     "item_count": 8
   },
+  "validation": {
+    "status": "warning",
+    "checked_at": "2026-04-04T00:00:01Z",
+    "required_anchor_count": 20,
+    "matched_anchor_count": 20,
+    "evaluated_anchor_count": 20,
+    "error_count": 0,
+    "warning_count": 2,
+    "freshness_checked": false,
+    "freshness_match": null
+  },
   "entities": {
     "_has_statement": {
-      "id": "P157",
-      "entity": "https://datadistillery.wikibase.cloud/entity/P157",
-      "datatype": "wikibase-item"
+      "id": "https://datadistillery.wikibase.cloud/entity/P157",
+      "kind": "property",
+      "datatype": "wikibase-item",
+      "required": {"kind": "property"},
+      "resolved": {"kind": "property"},
+      "validation": {
+        "status": "valid",
+        "notices": []
+      }
     },
     "_entity_profile": {
-      "id": "Q3",
-      "entity": "https://datadistillery.wikibase.cloud/entity/Q3"
+      "id": "https://datadistillery.wikibase.cloud/entity/Q3",
+      "kind": "item",
+      "required": {"kind": "item"},
+      "resolved": {"kind": "item"},
+      "validation": {
+        "status": "warning",
+        "notices": [
+          {"severity": "warning", "code": "label_missing"}
+        ]
+      }
     }
   }
 }
 ```
 
-This is the runtime-facing lookup document.
+This is both the runtime-facing lookup document and the operator-facing conformance report.
 
 ### 3. Runtime Resolver
 
@@ -81,7 +107,7 @@ The intended flow is:
 
 3. Materialize cache entities in SpiritSafe.
 
-4. Build `cache/config/semantic_anchors.json` from those cached entities.
+4. Build `config/semantic_anchors.json` from those cached entities.
 
 5. Validate that artifact against the package-owned contract.
 
@@ -95,13 +121,14 @@ Semantic anchors do:
 
 - map internal semantic names to concrete property and item IDs
 - preserve expected property datatypes for runtime checks
+- keep a contract digest and per-entity validation status close to the resolved binding
 - give runtime consumers one stable lookup mechanism
 - let tests and ad hoc callers provide a synthetic anchor document explicitly when they are not operating inside a full SpiritSafe checkout
 
 Semantic anchors do not:
 
 - replace the authored ontology in the Meta-Wikibase
-- validate the full ontology hierarchy or all semantic modeling choices
+- validate every modeling choice in the authored ontology
 - define endpoint URLs, credentials, or other environment configuration
 - eliminate the need for SpiritSafe materialization
 
@@ -110,14 +137,14 @@ Semantic anchors do not:
 Anchor-backed runtime workflows assume two things are present under a local SpiritSafe root:
 
 - `config/dd-wikibase.yaml` or another supported Meta-Wikibase config filename under `config/`
-- `cache/config/semantic_anchors.json`
+- `config/semantic_anchors.json`
 
 The config file supplies the semantic convention needed to interpret internal names:
 
 - `semantic_conventions.name_identifier_property_id`
 - `semantic_conventions.internal_name_identifier_prefix`
 
-The semantic-anchor artifact supplies the actual ID bindings.
+The semantic-anchor artifact supplies the actual ID bindings plus the latest build-time validation state.
 
 When both are available, runtime consumers such as profile export, value-list hydration, and entity-index generation can resolve internal ontology labels consistently.
 
@@ -135,7 +162,7 @@ Use that route when:
 - exercising one runtime helper in isolation
 - running outside the standard SpiritSafe directory layout
 
-Do not treat that override path as the normal production contract. The normal production contract is the validated artifact under `cache/config/semantic_anchors.json`.
+Do not treat that override path as the normal production contract. The normal production contract is the validated artifact under `config/semantic_anchors.json`.
 
 ## Where To Look In The Codebase
 

--- a/docs/architecture/wikimedia-commons.md
+++ b/docs/architecture/wikimedia-commons.md
@@ -1,0 +1,261 @@
+# Wikimedia Commons Architecture
+
+## Purpose
+
+This document defines how `gkc` treats Wikimedia Commons as an extension layer on top of the Wikidata-centered GKC foundation.
+
+The current architecture does not attempt to model Wikimedia Commons as a separate semantic universe. Instead, it treats Commons structured data as a specialized execution context that still relies on Wikibase statements, Wikidata items, and the same profile-driven runtime used elsewhere in `gkc`.
+
+The practical outcome is a single package-owned GKC Entity Profile, `commons_media_object`, that can be attached implicitly whenever a workflow encounters a statement whose datatype points at a Wikimedia Commons-hosted object.
+
+## Architectural Position
+
+Wikidata remains the semantic foundation.
+
+Wikimedia Commons extends that foundation in two complementary ways.
+
+1. File pages can carry structured data through MediaInfo, backed by Wikibase and Wikidata properties and items.
+
+2. Commons-hosted data assets in the `Data:` namespace can carry reusable geographic and tabular resources that are referenced from Wikibase statements.
+
+In `gkc`, these are not modeled as unrelated resource classes. They are treated as Commons-side realizations of the same cross-system entity model.
+
+That keeps the operating pattern consistent:
+
+1. Author semantic contracts in the Meta-Wikibase.
+
+2. Materialize them in SpiritSafe.
+
+3. Execute curation, validation, packet assembly, bottling, and shipping in `gkc`.
+
+## Why An Implicit Profile Exists
+
+The Wikibase datatype alone is not enough to drive a useful Commons workflow.
+
+For example, knowing that a statement has datatype `commonsMedia`, `geo-shape`, or `tabular-data` tells runtime code the primitive value form, but it does not tell the system:
+
+- which additional Commons-facing metadata should be gathered
+
+- which statements commonly travel together on a media object
+
+- which qualifiers are needed for valid Wikibase serialization
+
+- which value lists and format constraints should be offered in the UI
+
+- which downstream destinations are file pages versus `Data:` namespace pages
+
+The `commons_media_object` profile fills that gap.
+
+It acts as the profile-level contract that sits above the primitive datatype and gives `gkc` a stable, reusable semantic bundle for Wikimedia Commons structured content.
+
+## Datatype Trigger Rule
+
+`gkc` treats the following Wikibase datatypes as Commons triggers:
+
+- `commonsMedia`
+
+- `geo-shape`
+
+- `tabular-data`
+
+When any statement in a profile or packet uses one of these datatypes, runtime workflows may resolve an implicit relationship to the `commons_media_object` profile.
+
+The intent of that relationship is architectural, not magical.
+
+It means the runtime can infer that the value being curated is not just an opaque string or file name. It is a Commons-hosted object that should be handled with the Commons-specific semantic contract.
+
+This pattern avoids forcing every profile author to redundantly declare a second explicit profile link every time a Commons value appears, while still letting the runtime load a well-defined profile contract.
+
+## Scope Of The Commons Profile
+
+The current baseline Commons profile covers the metadata needed for Wikimedia Commons structured data on media objects and for closely related Commons-hosted assets.
+
+The seeded statement set is:
+
+1. `depicts`
+
+2. `copyright_status`
+
+3. `copyright_license`
+
+4. `inception`
+
+5. `media_type`
+
+6. `height`
+
+7. `width`
+
+8. `data_size`
+
+9. `checksum`
+
+10. `coordinates_of_the_point_of_view`
+
+These statements provide a practical baseline for describing media files and related Commons resources without overcommitting the ontology before more packet, wizard, and shipper workflows are exercised.
+
+## Statement Design Within The Profile
+
+The ten seeded statements are not arbitrary.
+
+They fall into four functional groups.
+
+### Discovery And Meaning
+
+- `depicts`
+- `inception`
+- `coordinates_of_the_point_of_view`
+
+These statements improve findability, chronological interpretation, and spatial interpretation of Commons-hosted content.
+
+They align closely with how Structured Data on Commons improves search, multilingual reuse, and cross-collection exploration.
+
+### Rights And Reuse
+
+- `copyright_status`
+- `copyright_license`
+
+These statements clarify the legal status of a file or related data object and support safer downstream use.
+
+### Technical Description
+
+- `media_type`
+- `height`
+- `width`
+- `data_size`
+- `checksum`
+
+These statements describe the technical shape of the object being referenced or shipped.
+
+This is especially important for bottling, shipping, and later validation and presentation work because a Commons target is not only semantically meaningful, it is also a concrete file or data artifact with format expectations.
+
+### Modifier Support
+
+Some Commons-oriented statements require helper qualifier or value entities rather than a bare primitive datatype.
+
+The current contract includes support for:
+
+- datetime precision
+- coordinate precision
+- IANA media type format constraints
+- checksum format constraints
+- value lists for rights and measurement units
+
+This keeps the semantic layer explicit and reusable instead of hardcoding every Commons-specific rule into runtime code.
+
+## MediaInfo Relationship
+
+Structured Data on Commons is implemented on Wikimedia Commons through WikibaseMediaInfo.
+
+That matters for `gkc` because Commons file pages are not treated as ad hoc metadata blobs. They are Wikibase-backed entities with:
+
+- multilingual captions
+- statements
+- qualifiers
+- references
+
+From the perspective of `gkc`, this means a Commons file can participate in the same broad statement, qualifier, and reference model used elsewhere in the stack, even though the storage target is a Commons file page rather than a Wikidata item page.
+
+The `commons_media_object` profile is therefore the `gkc` side of that bridge.
+
+It does not replace MediaInfo. It tells `gkc` how to prepare, validate, and later ship data into the MediaInfo-oriented environment.
+
+## Relationship To The Three Commons Datatypes
+
+### `commonsMedia`
+
+This datatype points to a Wikimedia Commons file name.
+
+In isolation, that is only a primitive pointer to a file page. In `gkc`, it is also a signal that a file-centered structured data context may need to be assembled, validated, or shipped.
+
+That is the most direct use of the `commons_media_object` profile.
+
+### `geo-shape`
+
+This datatype points to Commons map data, typically a `.map` page in the `Data:` namespace backed by GeoJSON.
+
+Although the storage format differs from a media file, the object is still Commons-hosted and often participates in the same cross-system pattern: Wikidata anchors meaning, Commons stores reusable media and data artifacts, and downstream presentation layers consume the result.
+
+For `gkc`, `geo-shape` therefore triggers the same Commons-profile context, while later runtime code decides which fields are applicable for a specific object subtype.
+
+### `tabular-data`
+
+This datatype points to Commons tabular datasets, typically `.tab` pages in the `Data:` namespace.
+
+As with `geo-shape`, the Commons-hosted object is not a generic string. It is a structured data artifact with its own Commons-side lifecycle, licensing expectations, and downstream rendering uses.
+
+The same implicit-profile rule lets packet assembly and validation treat the object as part of the Commons architecture instead of as a detached external identifier.
+
+## Packet And Workflow Implications
+
+This architecture is meant to support later runtime work in four places.
+
+### Packet Assembly
+
+When a source profile contains one of the three Commons datatypes, packet assembly can introduce a Commons-side sub-entity or linked entity context without requiring the source profile author to restate the full Commons metadata bundle each time.
+
+### Validation And Coercion
+
+Datatype validation still belongs to `fermenter`, but the Commons profile gives it the higher-order statement set, value lists, and helper constraints needed to validate a Commons object meaningfully.
+
+### Bottling And Shipping
+
+The profile provides the semantic material needed to move from packet content to Commons-facing payload construction, whether that means MediaInfo statements on a file page or later support for `Data:` namespace resources.
+
+### Wizard And Presentation
+
+The wizard layer can use the implicit profile to expose Commons-oriented guidance, grouped metadata prompts, and future specialized widgets without forcing every caller to hand-assemble those fields.
+
+## Deliberate Boundaries
+
+This baseline intentionally does not yet model:
+
+- MediaWiki templates
+- OpenStreetMap entity contracts
+- the full Commons community modeling surface
+- every Structured Data on Commons property in active use
+- every possible distinction between file-page objects and `Data:` namespace objects
+
+Those are deferred until the runtime paths for packet assembly, bottling, shipping, and wizard presentation are exercised through real use cases.
+
+The current decision is to stabilize one clean Commons baseline first.
+
+## Relationship To The Seed Ontology
+
+The package-owned `meta_wb_init.yaml` seed now carries the Commons baseline contract in authored form.
+
+That includes:
+
+- the `commons_media_object` entity profile
+- the ten baseline Commons statements
+- helper items for precision and format specification
+- value-list items for rights and unit selection
+- SPARQL query fixtures for value-list hydration
+
+This is the ontology-level commitment that lets later init, validation, and runtime work proceed from a stable baseline instead of rediscovering the Commons contract in code.
+
+## Upstream References
+
+The current architecture is aligned to Wikimedia’s published model and user-facing behavior, especially the following references:
+
+- [Commons:Structured data](https://commons.wikimedia.org/wiki/Commons:Structured_data) for the overall Structured Data on Commons model, file captions, depicts statements, and Commons-side workflows.
+
+- [Extension:WikibaseMediaInfo](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikibaseMediaInfo) for the MediaInfo entity model used on Commons file pages.
+
+- [Wikibase/DataModel](https://www.mediawiki.org/wiki/Wikibase/DataModel) for the underlying statement, qualifier, reference, datatype, and entity model that Commons structured data still relies on.
+
+- [Help:Map data](https://www.mediawiki.org/wiki/Help:Map_data) for `.map` resources in the Commons `Data:` namespace and their GeoJSON-based structure.
+
+- [Help:Extension:Kartographer](https://www.mediawiki.org/wiki/Help:Extension:Kartographer) for how geoshape-backed Commons data are rendered and combined in Wikimedia map workflows.
+
+- [Help:Tabular data](https://www.mediawiki.org/wiki/Help:Tabular_data) for `.tab` resources in the Commons `Data:` namespace and their JSON-backed table structure.
+
+These references are not a substitute for the `gkc` contract, but they define the upstream execution environment that the `commons_media_object` profile is designed to serve.
+
+## Summary
+
+Wikimedia Commons is currently modeled in `gkc` as a Wikibase-compatible extension layer anchored in Wikidata semantics.
+
+The package baseline is one implicit Commons profile trigger tied to three Commons-oriented datatypes and one seeded profile carrying ten baseline statements.
+
+That is enough to give packet assembly, validation, bottling, shipping, and wizard work a stable architectural target while keeping broader Commons, template, and OSM modeling deliberately out of scope for now.

--- a/gkc/__init__.py
+++ b/gkc/__init__.py
@@ -158,15 +158,20 @@ from gkc.utilities import (
 
 # Wikibase-specific helpers
 from gkc.wikibase import (
+    MetaWikibaseCompiledEntity,
     MetaWikibaseInitEntity,
     MetaWikibaseInitIndex,
     MetaWikibaseInitMetadata,
+    MetaWikibaseSeedCompilation,
+    MetaWikibaseSeedPlan,
+    MetaWikibaseSeedPlanEntry,
     MetaWikibaseSemanticAnchorContract,
     MetaWikibaseSemanticAnchorRequirement,
     WikibaseDatatypeSpec,
     build_meta_wikibase_init_index,
     build_meta_wikibase_semantic_anchor_contract,
     canonicalize_wikibase_datatype,
+    compile_meta_wikibase_seed,
     get_meta_wikibase_init_entity,
     get_wikibase_datatype_spec,
     is_known_wikibase_datatype,
@@ -176,6 +181,7 @@ from gkc.wikibase import (
     load_wikibase_datatype_registry,
     load_wikibase_datatype_registry_json,
     normalize_meta_wikibase_init_document,
+    plan_meta_wikibase_seed_baseline,
 )
 
 # Language Configuration
@@ -219,15 +225,20 @@ __all__ = [
     # Runtime Configuration
     "DEFAULT_USER_AGENT",
     # Wikibase-specific helpers
+    "MetaWikibaseCompiledEntity",
     "MetaWikibaseInitEntity",
     "MetaWikibaseInitIndex",
     "MetaWikibaseInitMetadata",
     "MetaWikibaseSemanticAnchorContract",
     "MetaWikibaseSemanticAnchorRequirement",
+    "MetaWikibaseSeedCompilation",
+    "MetaWikibaseSeedPlan",
+    "MetaWikibaseSeedPlanEntry",
     "WikibaseDatatypeSpec",
     "build_meta_wikibase_init_index",
     "build_meta_wikibase_semantic_anchor_contract",
     "canonicalize_wikibase_datatype",
+    "compile_meta_wikibase_seed",
     "get_meta_wikibase_init_entity",
     "get_wikibase_datatype_spec",
     "is_known_wikibase_datatype",
@@ -237,6 +248,7 @@ __all__ = [
     "load_wikibase_datatype_registry",
     "load_wikibase_datatype_registry_json",
     "normalize_meta_wikibase_init_document",
+    "plan_meta_wikibase_seed_baseline",
     # Language Configuration
     "get_languages",
     "set_languages",

--- a/gkc/bottler.py
+++ b/gkc/bottler.py
@@ -22,13 +22,52 @@ class DataTypeTransformer:
     @staticmethod
     def to_wikibase_item(qid: str) -> dict:
         """Convert a QID string to wikibase-entityid datavalue."""
-        numeric_id = int(qid[1:])  # Remove 'Q' prefix
+        return DataTypeTransformer.to_wikibase_entity_reference(
+            qid,
+            entity_type="item",
+        )
+
+    @staticmethod
+    def to_wikibase_entity_reference(
+        entity_id: str,
+        *,
+        entity_type: Optional[str] = None,
+    ) -> dict:
+        """Convert a resolved or symbolic entity identifier to a datavalue.
+
+        Real Wikibase IDs such as ``Q5`` and ``P31`` include ``numeric-id``.
+        Symbolic pre-resolution identifiers such as ``_instance_of`` omit it.
+        """
+        normalized_entity_id = str(entity_id).strip()
+        if not normalized_entity_id:
+            raise ValueError("entity_id must be a non-empty string")
+
+        inferred_entity_type = entity_type
+        numeric_id: int | None = None
+
+        if normalized_entity_id.startswith("Q") and normalized_entity_id[1:].isdigit():
+            inferred_entity_type = inferred_entity_type or "item"
+            numeric_id = int(normalized_entity_id[1:])
+        elif (
+            normalized_entity_id.startswith("P") and normalized_entity_id[1:].isdigit()
+        ):
+            inferred_entity_type = inferred_entity_type or "property"
+            numeric_id = int(normalized_entity_id[1:])
+
+        if inferred_entity_type not in {"item", "property"}:
+            raise ValueError(
+                "entity_type must be 'item' or 'property' for symbolic entity references"
+            )
+
+        value = {
+            "entity-type": inferred_entity_type,
+            "id": normalized_entity_id,
+        }
+        if numeric_id is not None:
+            value["numeric-id"] = numeric_id
+
         return {
-            "value": {
-                "entity-type": "item",
-                "numeric-id": numeric_id,
-                "id": qid,
-            },
+            "value": value,
             "type": "wikibase-entityid",
         }
 
@@ -196,6 +235,14 @@ class SnakBuilder:
             "datavalue": datavalue,
         }
 
+    def create_snak_from_datavalue(self, property_id: str, datavalue: dict) -> dict:
+        """Create a snak from a prebuilt datavalue structure."""
+        return {
+            "snaktype": "value",
+            "property": property_id,
+            "datavalue": datavalue,
+        }
+
 
 class ClaimBuilder:
     """Builds complete claim structures with qualifiers and references."""
@@ -221,6 +268,46 @@ class ClaimBuilder:
             "type": "statement",
             "rank": rank,
         }
+
+        return self._attach_claim_metadata(
+            claim,
+            qualifiers=qualifiers,
+            references=references,
+        )
+
+    def create_claim_from_datavalue(
+        self,
+        property_id: str,
+        datavalue: dict,
+        *,
+        qualifiers: list[dict] = None,
+        references: list[dict] = None,
+        rank: str = "normal",
+    ) -> dict:
+        """Create a complete claim structure from a prebuilt datavalue."""
+        claim = {
+            "mainsnak": self.snak_builder.create_snak_from_datavalue(
+                property_id,
+                datavalue,
+            ),
+            "type": "statement",
+            "rank": rank,
+        }
+
+        return self._attach_claim_metadata(
+            claim,
+            qualifiers=qualifiers,
+            references=references,
+        )
+
+    def _attach_claim_metadata(
+        self,
+        claim: dict,
+        *,
+        qualifiers: list[dict] = None,
+        references: list[dict] = None,
+    ) -> dict:
+        """Attach qualifier and reference groups to an existing claim."""
 
         # Add qualifiers if provided
         if qualifiers:

--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -36,10 +36,11 @@ from gkc.sitelinks import (
     DEFAULT_WIKIMEDIA_SITEMATRIX_URL,
     export_wikimedia_sites_artifact,
 )
-from gkc.sparql import fetch_entity_labels
+from gkc.sparql import execute_sparql, fetch_entity_labels
 from gkc.spirit_safe import (
     build_entity_profile_json_documents,
     build_spiritsafe_semantic_anchor_document,
+    build_spiritsafe_semantic_anchor_resolver,
     export_entity_profile_json_documents,
     export_spiritsafe_semantic_anchors,
     get_spirit_safe_source,
@@ -749,6 +750,56 @@ def _build_parser() -> argparse.ArgumentParser:
     registry_validate.set_defaults(
         handler=_handle_registry_validate,
         command_path="registry.validate",
+    )
+
+    wikibase_parser = subparsers.add_parser(
+        "wikibase", help="Meta-Wikibase bootstrap and preview operations"
+    )
+    wikibase_subparsers = wikibase_parser.add_subparsers(dest="wikibase_command")
+
+    wikibase_init = wikibase_subparsers.add_parser(
+        "init",
+        help=("Preview the Meta-Wikibase seed compilation and dry-run baseline plan"),
+    )
+    wikibase_init.add_argument(
+        "--api-url",
+        default=runtime_config.api_url,
+        help=(
+            "Override the configured Wikibase API URL when live comparison is used "
+            "(default: META_WB_API_URL env var, config file, or Data Distillery API)"
+        ),
+    )
+    wikibase_init.add_argument(
+        "--local-root",
+        help=(
+            "Optional local SpiritSafe root used to load and validate semantic anchors "
+            "for live comparison"
+        ),
+    )
+    wikibase_init.add_argument(
+        "--artifact-file",
+        help=(
+            "Optional semantic_anchors.json artifact used for live comparison; "
+            "when provided without --local-root it is loaded directly"
+        ),
+    )
+    wikibase_init.add_argument(
+        "--show-entity",
+        help=(
+            "Optional seed entity key or internal name identifier whose compiled payload "
+            "should be included in the output"
+        ),
+    )
+    wikibase_init.add_argument(
+        "--language",
+        help=(
+            "Optional override for the package-level language used for labels, descriptions, "
+            "and aliases in the compiled seed preview"
+        ),
+    )
+    wikibase_init.set_defaults(
+        handler=_handle_wikibase_init,
+        command_path="wikibase.init",
     )
 
     spiritsafe_parser = subparsers.add_parser(
@@ -2304,6 +2355,9 @@ def _handle_spiritsafe_semantic_anchors_build(
             "anchor_count": len(entities) if isinstance(entities, dict) else 0,
             "property_count": metadata.get("property_count", 0),
             "item_count": metadata.get("item_count", 0),
+            "validation_status": artifact.get("validation", {}).get("status"),
+            "error_count": artifact.get("validation", {}).get("error_count", 0),
+            "warning_count": artifact.get("validation", {}).get("warning_count", 0),
         }
         return {
             "command": args.command_path,
@@ -2384,18 +2438,35 @@ def _handle_spiritsafe_semantic_anchors_validate(
         warning_count = sum(
             1 for notice in result.notices if notice.severity == "warning"
         )
-        info_count = sum(1 for notice in result.notices if notice.severity == "info")
+        entity_results_payload = {
+            anchor_name: {
+                "status": entity_result.status,
+                "notices": [
+                    {
+                        "severity": notice.severity,
+                        "entity_ref": notice.entity_ref,
+                        "statement_ref": notice.statement_ref,
+                        "code": notice.code,
+                        "message": notice.message,
+                        "normalized_value": notice.normalized_value,
+                    }
+                    for notice in entity_result.notices
+                ],
+            }
+            for anchor_name, entity_result in result.entity_results.items()
+        }
         details = {
             "artifact_path": str(artifact_path),
+            "status": result.status,
             "required_anchor_count": result.required_anchor_count,
             "matched_anchor_count": result.matched_anchor_count,
             "evaluated_anchor_count": result.evaluated_anchor_count,
             "freshness_checked": result.freshness_checked,
             "freshness_match": result.freshness_match,
-            "notices_error": error_count,
-            "notices_warning": warning_count,
-            "notices_info": info_count,
+            "error_count": error_count,
+            "warning_count": warning_count,
             "notices": notices_payload,
+            "entity_results": entity_results_payload,
         }
         message = (
             f"Validated SpiritSafe semantic anchor artifact at {artifact_path}"
@@ -3109,6 +3180,449 @@ def _handle_mash_full_sync_wikibase(args: argparse.Namespace) -> dict[str, Any]:
         raise
     except Exception as exc:
         raise CLIError(str(exc)) from exc
+
+
+def _handle_wikibase_init(args: argparse.Namespace) -> dict[str, Any]:
+    """Preview Meta-Wikibase seed compilation and dry-run init actions."""
+
+    original_languages = gkc.get_languages()
+    if args.language:
+        gkc.set_languages(args.language)
+
+    try:
+        compilation = gkc.compile_meta_wikibase_seed(
+            label_language=args.language,
+        )
+        current_entities: dict[str, dict[str, Any]] | None = None
+        entity_id_to_internal_name_identifier: dict[str, str] | None = None
+        comparison_source: dict[str, Any] = {"mode": "compiled-only"}
+
+        if args.local_root:
+            (
+                current_entities,
+                entity_id_to_internal_name_identifier,
+                comparison_source,
+            ) = _load_wikibase_init_current_entities_from_local_root(
+                compilation=compilation,
+                local_root=args.local_root,
+                api_url=args.api_url,
+            )
+        elif args.artifact_file:
+            resolver = _load_wikibase_init_anchor_resolver(
+                local_root=None,
+                artifact_file=args.artifact_file,
+            )
+            current_entities, entity_id_to_internal_name_identifier = (
+                _load_wikibase_init_current_entities_from_resolver(
+                    compilation=compilation,
+                    resolver=resolver,
+                    api_url=args.api_url,
+                )
+            )
+            comparison_source = {
+                "mode": "live-compare-anchor-artifact",
+                "api_url": args.api_url,
+                "local_root": None,
+                "artifact_file": resolver.artifact_path,
+                "resolved_entity_count": len(current_entities),
+            }
+
+        plan = gkc.plan_meta_wikibase_seed_baseline(
+            current_entities_by_internal_name_identifier=current_entities,
+            entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+            label_language=args.language,
+            required_value_language="mul",
+        )
+
+        action_rows: list[dict[str, Any]] = []
+        for operation in plan.operations:
+            compiled_entity = compilation.by_internal_name_identifier[
+                operation.internal_name_identifier
+            ]
+            action_rows.append(
+                {
+                    "action": operation.action,
+                    "kind": operation.entity_type,
+                    "label": _wikibase_init_entity_label(compiled_entity.payload),
+                    "entity_id": operation.current_entity_id,
+                    "details": operation.details,
+                    "changed_fields": operation.changed_fields,
+                    "request_payload": operation.payload,
+                    "internal_name_identifier": operation.internal_name_identifier,
+                    "key": operation.key,
+                }
+            )
+
+        summary = {
+            "created": sum(
+                1 for operation in plan.operations if operation.action == "create"
+            ),
+            "updated": sum(
+                1 for operation in plan.operations if operation.action == "update"
+            ),
+            "skipped": sum(
+                1 for operation in plan.operations if operation.action == "skip"
+            ),
+            "dry_run": len(plan.operations),
+        }
+
+        details: dict[str, Any] = {
+            "summary": summary,
+            "seed_entity_count": len(compilation.entities),
+            "label_language": _resolve_command_language(args.language),
+            "value_language": "mul",
+            "comparison_source": comparison_source,
+            "actions": action_rows,
+        }
+
+        if args.show_entity:
+            sample_entity = _select_wikibase_init_sample_entity(
+                compilation, args.show_entity
+            )
+            details["sample_entity"] = {
+                "key": sample_entity.key,
+                "internal_name_identifier": sample_entity.internal_name_identifier,
+                "payload": sample_entity.payload,
+            }
+
+        return {
+            "command": args.command_path,
+            "ok": True,
+            "message": (
+                f"Prepared Meta-Wikibase dry-run plan for {len(plan.operations)} seed entities"
+            ),
+            "details": details,
+        }
+    except CLIError:
+        raise
+    except Exception as exc:
+        raise CLIError(str(exc)) from exc
+    finally:
+        if args.language:
+            gkc.set_languages(original_languages)
+
+
+def _load_wikibase_init_anchor_resolver(
+    *,
+    local_root: str | None,
+    artifact_file: str | None,
+):
+    """Load the semantic-anchor resolver used for live seed comparison."""
+
+    if artifact_file:
+        artifact_path = Path(artifact_file).expanduser().resolve()
+        if not artifact_path.is_file():
+            raise CLIError(f"Semantic anchor artifact not found at {artifact_path}")
+        try:
+            anchor_document = json.loads(artifact_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise CLIError(
+                f"Failed to load semantic anchor artifact {artifact_path}: {exc}"
+            ) from exc
+        return build_spiritsafe_semantic_anchor_resolver(
+            anchor_document,
+            artifact_path=artifact_path,
+        )
+
+    raise CLIError("Anchor-artifact comparison requires --artifact-file")
+
+
+def _load_wikibase_init_current_entities_from_resolver(
+    *,
+    compilation,
+    resolver,
+    api_url: str,
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    """Fetch the current Wikibase entities referenced by the active anchors."""
+
+    api_client = WikibaseApiClient(api_url=api_url)
+    entity_id_to_internal_name_identifier = {
+        anchor.entity_id: anchor_name
+        for anchor_name, anchor in resolver.anchors.items()
+    }
+
+    entity_ids = sorted(
+        {
+            resolver.anchors[internal_name_identifier].entity_id
+            for internal_name_identifier in compilation.by_internal_name_identifier.keys()
+            if internal_name_identifier in resolver.anchors
+        }
+    )
+    fetched_entities = api_client.get_entities(entity_ids)
+
+    current_entities: dict[str, dict[str, Any]] = {}
+    for internal_name_identifier in compilation.by_internal_name_identifier.keys():
+        anchor = resolver.anchors.get(internal_name_identifier)
+        if anchor is None:
+            continue
+        entity_payload = fetched_entities.get(anchor.entity_id)
+        if isinstance(entity_payload, dict):
+            current_entities[internal_name_identifier] = entity_payload
+
+    return current_entities, entity_id_to_internal_name_identifier
+
+
+def _load_wikibase_init_current_entities_from_local_root(
+    *,
+    compilation,
+    local_root: str,
+    api_url: str,
+) -> tuple[dict[str, dict[str, Any]], dict[str, str], dict[str, Any]]:
+    """Fetch current entities by internal name identifier for bootstrap-safe dry runs."""
+
+    resolved_local_root = Path(local_root).expanduser().resolve()
+    _config_path, config_values = resolve_spiritsafe_meta_wikibase_config(
+        resolved_local_root
+    )
+    name_identifier_property_id = config_values.get("name_identifier_property_id")
+    if not name_identifier_property_id:
+        raise CLIError(
+            "Meta-wikibase config is missing semantic_conventions.name_identifier_property_id"
+        )
+
+    sparql_endpoint = config_values.get("sparql_endpoint")
+    if not sparql_endpoint:
+        raise CLIError(
+            "Meta-wikibase config is missing sparql_endpoint, required for bootstrap dry-run comparison"
+        )
+
+    entity_id_to_internal_name_identifier = (
+        _discover_meta_wikibase_entities_by_name_identifier(
+            internal_name_identifiers=sorted(
+                compilation.by_internal_name_identifier.keys()
+            ),
+            name_identifier_property_id=name_identifier_property_id,
+            sparql_endpoint=sparql_endpoint,
+        )
+    )
+    anchor_hint_entity_id_to_internal_name_identifier = (
+        _load_wikibase_init_anchor_hints_from_local_root(
+            local_root=resolved_local_root,
+            compilation=compilation,
+        )
+    )
+
+    api_client = WikibaseApiClient(api_url=api_url)
+    candidate_entity_ids = sorted(
+        set(entity_id_to_internal_name_identifier.keys())
+        | set(anchor_hint_entity_id_to_internal_name_identifier.keys())
+    )
+    fetched_entities = api_client.get_entities(candidate_entity_ids)
+    current_entities: dict[str, dict[str, Any]] = {}
+    validated_entity_id_to_internal_name_identifier: dict[str, str] = {}
+
+    for entity_id, entity_payload in fetched_entities.items():
+        if not isinstance(entity_payload, dict):
+            continue
+        name_identifier_values = _extract_name_identifier_values_from_entity(
+            entity_payload,
+            name_identifier_property_id=name_identifier_property_id,
+        )
+        for internal_name_identifier in name_identifier_values:
+            if internal_name_identifier in compilation.by_internal_name_identifier:
+                current_entities[internal_name_identifier] = entity_payload
+                validated_entity_id_to_internal_name_identifier[entity_id] = (
+                    internal_name_identifier
+                )
+
+    for (
+        entity_id,
+        internal_name_identifier,
+    ) in anchor_hint_entity_id_to_internal_name_identifier.items():
+        if internal_name_identifier in current_entities:
+            continue
+        entity_payload = fetched_entities.get(entity_id)
+        if isinstance(entity_payload, dict):
+            current_entities[internal_name_identifier] = entity_payload
+            validated_entity_id_to_internal_name_identifier[entity_id] = (
+                internal_name_identifier
+            )
+
+    comparison_source = {
+        "mode": "live-compare-name-identifier",
+        "api_url": api_url,
+        "local_root": str(resolved_local_root),
+        "artifact_file": None,
+        "name_identifier_property_id": name_identifier_property_id,
+        "sparql_endpoint": sparql_endpoint,
+        "sparql_candidate_count": len(entity_id_to_internal_name_identifier),
+        "anchor_hint_count": len(anchor_hint_entity_id_to_internal_name_identifier),
+        "resolved_entity_count": len(current_entities),
+    }
+    comparison_entity_id_to_internal_name_identifier = {}
+    if "_name_identifier" in compilation.by_internal_name_identifier:
+        comparison_entity_id_to_internal_name_identifier[
+            name_identifier_property_id
+        ] = "_name_identifier"
+    comparison_entity_id_to_internal_name_identifier.update(
+        anchor_hint_entity_id_to_internal_name_identifier
+    )
+    comparison_entity_id_to_internal_name_identifier.update(
+        entity_id_to_internal_name_identifier
+    )
+    comparison_entity_id_to_internal_name_identifier.update(
+        validated_entity_id_to_internal_name_identifier
+    )
+    return (
+        current_entities,
+        comparison_entity_id_to_internal_name_identifier,
+        comparison_source,
+    )
+
+
+def _load_wikibase_init_anchor_hints_from_local_root(
+    *,
+    local_root: Path,
+    compilation,
+) -> dict[str, str]:
+    """Load non-authoritative entity-id hints from local semantic anchors when present."""
+
+    layout = resolve_spiritsafe_layout(local_root)
+    artifact_path = layout.semantic_anchors_file(local_root)
+    if not artifact_path.is_file():
+        return {}
+
+    try:
+        anchor_document = json.loads(artifact_path.read_text(encoding="utf-8"))
+        resolver = build_spiritsafe_semantic_anchor_resolver(
+            anchor_document,
+            artifact_path=artifact_path,
+        )
+    except Exception:
+        return {}
+
+    hints: dict[str, str] = {}
+    for internal_name_identifier in compilation.by_internal_name_identifier.keys():
+        anchor = resolver.anchors.get(internal_name_identifier)
+        if anchor is None:
+            continue
+        hints[anchor.entity_id] = internal_name_identifier
+    return hints
+
+
+def _discover_meta_wikibase_entities_by_name_identifier(
+    *,
+    internal_name_identifiers: list[str],
+    name_identifier_property_id: str,
+    sparql_endpoint: str,
+) -> dict[str, str]:
+    """Resolve live entity ids by querying the configured name_identifier property."""
+
+    if not internal_name_identifiers:
+        return {}
+
+    results: dict[str, str] = {}
+    batch_size = 25
+    for start in range(0, len(internal_name_identifiers), batch_size):
+        batch = internal_name_identifiers[start : start + batch_size]
+        values = " ".join(json.dumps(value) for value in batch)
+        query = (
+            "SELECT ?entity ?nameIdentifier WHERE { "
+            f"VALUES ?nameIdentifier {{ {values} }} "
+            f"?entity wdt:{name_identifier_property_id} ?nameIdentifier . "
+            "}"
+        )
+        payload = execute_sparql(query, endpoint=sparql_endpoint)
+        bindings = payload.get("results", {}).get("bindings", [])
+        if not isinstance(bindings, list):
+            continue
+        for binding in bindings:
+            if not isinstance(binding, dict):
+                continue
+            entity_value = binding.get("entity", {}).get("value")
+            name_identifier = binding.get("nameIdentifier", {}).get("value")
+            entity_id = _entity_id_from_wikibase_uri(entity_value)
+            if entity_id and isinstance(name_identifier, str) and name_identifier:
+                results[entity_id] = name_identifier
+
+    return results
+
+
+def _entity_id_from_wikibase_uri(entity_uri: Any) -> str | None:
+    """Extract a Q/P identifier from a Wikibase entity URI."""
+
+    if not isinstance(entity_uri, str) or not entity_uri:
+        return None
+    candidate = entity_uri.rstrip("/").split("/")[-1]
+    if candidate[:1] in {"Q", "P"} and candidate[1:].isdigit():
+        return candidate
+    return None
+
+
+def _extract_name_identifier_values_from_entity(
+    entity_payload: dict[str, Any],
+    *,
+    name_identifier_property_id: str,
+) -> set[str]:
+    """Extract string name_identifier values from one fetched Wikibase entity."""
+
+    claims = entity_payload.get("claims")
+    if not isinstance(claims, dict):
+        return set()
+
+    raw_claims = claims.get(name_identifier_property_id)
+    if not isinstance(raw_claims, list):
+        return set()
+
+    values: set[str] = set()
+    for claim in raw_claims:
+        if not isinstance(claim, dict):
+            continue
+        datavalue = claim.get("mainsnak", {}).get("datavalue", {})
+        value = datavalue.get("value")
+        if isinstance(value, str) and value:
+            values.add(value)
+
+    return values
+
+
+def _select_wikibase_init_sample_entity(compilation, selector: str):
+    """Resolve one compiled entity by key or internal name identifier."""
+
+    sample_entity = compilation.entities.get(selector)
+    if sample_entity is not None:
+        return sample_entity
+
+    sample_entity = compilation.by_internal_name_identifier.get(selector)
+    if sample_entity is not None:
+        return sample_entity
+
+    raise CLIError(
+        f"Unknown seed entity '{selector}'. Use a fixture key like 'entity_profile' "
+        "or an internal name identifier like '_entity_profile'."
+    )
+
+
+def _wikibase_init_entity_label(payload: dict[str, Any]) -> str:
+    """Return a human-facing label for one compiled seed payload."""
+
+    labels = payload.get("labels")
+    if isinstance(labels, dict):
+        for language_payload in labels.values():
+            if isinstance(language_payload, dict):
+                value = language_payload.get("value")
+                if isinstance(value, str) and value:
+                    return value
+    return ""
+
+
+def _resolve_command_language(configured_language: str | None) -> str:
+    """Resolve the language used by the command after optional overrides."""
+
+    if isinstance(configured_language, str) and configured_language.strip():
+        return configured_language.strip()
+
+    current_languages = gkc.get_languages()
+    if isinstance(current_languages, str):
+        candidate = current_languages.strip()
+        return candidate if candidate and candidate != "all" else "en"
+    if isinstance(current_languages, list):
+        for candidate in current_languages:
+            if isinstance(candidate, str):
+                candidate = candidate.strip()
+                if candidate and candidate != "all":
+                    return candidate
+    return "en"
 
 
 def _emit_output(output: dict[str, Any], json_output: bool, verbose: bool) -> None:

--- a/gkc/fermenter.py
+++ b/gkc/fermenter.py
@@ -27,8 +27,12 @@ from gkc.runtime_config import resolve_spiritsafe_layout_for_root
 from gkc.wikibase import (
     build_meta_wikibase_semantic_anchor_contract,
     canonicalize_wikibase_datatype,
+    compare_meta_wikibase_entity_views,
+    compile_meta_wikibase_seed,
+    get_meta_wikibase_init_contract_digest,
     get_wikibase_datatype_spec,
     is_wikibase_item_datatype,
+    normalize_meta_wikibase_required_entity_view,
 )
 
 
@@ -98,14 +102,28 @@ class ValidationPolicyConfig:
 
 
 @dataclass
+class SemanticAnchorEntityValidation:
+    """Per-entity semantic-anchor validation outcome."""
+
+    status: str
+    notices: list[ConformanceNotice] = field(default_factory=list)
+
+
+@dataclass
 class SemanticAnchorValidationResult:
     """Validation outcome for a semantic-anchor artifact."""
 
     valid: bool
+    status: str
     required_anchor_count: int
     matched_anchor_count: int
     evaluated_anchor_count: int
     notices: list[ConformanceNotice] = field(default_factory=list)
+    entity_results: dict[str, SemanticAnchorEntityValidation] = field(
+        default_factory=dict
+    )
+    error_count: int = 0
+    warning_count: int = 0
     freshness_checked: bool = False
     freshness_match: Optional[bool] = None
 
@@ -154,24 +172,36 @@ def validate_semantic_anchor_document(
     contract = build_meta_wikibase_semantic_anchor_contract(
         internal_name_identifier_prefix=internal_name_identifier_prefix
     )
+    compilation = compile_meta_wikibase_seed()
+    required_views = {
+        internal_name_identifier: normalize_meta_wikibase_required_entity_view(
+            compiled_entity.payload
+        )
+        for internal_name_identifier, compiled_entity in (
+            compilation.by_internal_name_identifier.items()
+        )
+    }
     notices: list[ConformanceNotice] = []
+    entity_results: dict[str, SemanticAnchorEntityValidation] = {}
     required_anchor_count = len(contract.requirements)
+    contract_digest = get_meta_wikibase_init_contract_digest()
 
     if not isinstance(anchor_document, dict):
         notices.append(
-            ConformanceNotice(
-                severity="error",
-                entity_ref="semantic_anchors",
-                code="artifact_shape_invalid",
-                message="Semantic anchor document must be a JSON object",
+            _semantic_anchor_notice(
+                "error", "semantic_anchors", "artifact_shape_invalid"
             )
         )
         return SemanticAnchorValidationResult(
             valid=False,
+            status="error",
             required_anchor_count=required_anchor_count,
             matched_anchor_count=0,
             evaluated_anchor_count=0,
             notices=notices,
+            entity_results=entity_results,
+            error_count=1,
+            warning_count=0,
             freshness_checked=current_anchor_document is not None,
             freshness_match=None,
         )
@@ -181,29 +211,42 @@ def validate_semantic_anchor_document(
 
     if not isinstance(metadata, dict):
         notices.append(
-            ConformanceNotice(
-                severity="error",
-                entity_ref="semantic_anchors",
-                code="artifact_shape_invalid",
-                message="Semantic anchor document is missing metadata",
+            _semantic_anchor_notice(
+                "error", "semantic_anchors", "artifact_shape_invalid"
             )
         )
+    else:
+        artifact_contract_digest = metadata.get("contract_digest")
+        if isinstance(artifact_contract_digest, str) and artifact_contract_digest:
+            if artifact_contract_digest != contract_digest:
+                notices.append(
+                    _semantic_anchor_notice(
+                        "error",
+                        "semantic_anchors",
+                        "contract_digest_mismatch",
+                        normalized_value={
+                            "expected": contract_digest,
+                            "actual": artifact_contract_digest,
+                        },
+                    )
+                )
 
     if not isinstance(entities, dict):
         notices.append(
-            ConformanceNotice(
-                severity="error",
-                entity_ref="semantic_anchors",
-                code="artifact_shape_invalid",
-                message="Semantic anchor document is missing entities",
+            _semantic_anchor_notice(
+                "error", "semantic_anchors", "artifact_shape_invalid"
             )
         )
         return SemanticAnchorValidationResult(
             valid=False,
+            status="error",
             required_anchor_count=required_anchor_count,
             matched_anchor_count=0,
             evaluated_anchor_count=0,
             notices=notices,
+            entity_results=entity_results,
+            error_count=sum(1 for notice in notices if notice.severity == "error"),
+            warning_count=sum(1 for notice in notices if notice.severity == "warning"),
             freshness_checked=current_anchor_document is not None,
             freshness_match=None,
         )
@@ -215,26 +258,24 @@ def validate_semantic_anchor_document(
     for anchor_name, payload in entities.items():
         if not isinstance(anchor_name, str) or not anchor_name:
             notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref="semantic_anchors",
-                    code="anchor_identifier_invalid",
-                    message="Semantic anchor keys must be non-empty strings",
+                _semantic_anchor_notice(
+                    "error",
+                    "semantic_anchors",
+                    "anchor_identifier_invalid",
                 )
             )
             continue
 
         if not anchor_name.startswith(active_prefix):
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_identifier_invalid",
-                    message=(
-                        f"Internal name identifier '{anchor_name}' must start with "
-                        f"configured prefix '{active_prefix}'"
-                    ),
-                )
+            anchor_notice = _semantic_anchor_notice(
+                "error",
+                anchor_name,
+                "anchor_identifier_invalid",
+            )
+            notices.append(anchor_notice)
+            entity_results[anchor_name] = SemanticAnchorEntityValidation(
+                status="error",
+                notices=[anchor_notice],
             )
             continue
 
@@ -242,134 +283,157 @@ def validate_semantic_anchor_document(
         if not remainder or not _INTERNAL_NAME_IDENTIFIER_BODY_PATTERN.fullmatch(
             remainder
         ):
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_identifier_invalid",
-                    message=(
-                        f"Internal name identifier '{anchor_name}' has an invalid "
-                        "body after the configured prefix"
-                    ),
-                )
+            anchor_notice = _semantic_anchor_notice(
+                "error",
+                anchor_name,
+                "anchor_identifier_invalid",
+            )
+            notices.append(anchor_notice)
+            entity_results[anchor_name] = SemanticAnchorEntityValidation(
+                status="error",
+                notices=[anchor_notice],
             )
 
         if not isinstance(payload, dict):
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_shape_invalid",
-                    message="Semantic anchor entries must be JSON objects",
-                )
+            anchor_notice = _semantic_anchor_notice(
+                "error",
+                anchor_name,
+                "anchor_shape_invalid",
+            )
+            notices.append(anchor_notice)
+            entity_results[anchor_name] = SemanticAnchorEntityValidation(
+                status="error",
+                notices=[anchor_notice],
             )
 
     for anchor_name, requirement in contract.requirements.items():
         payload = entities.get(anchor_name)
+        entity_notices: list[ConformanceNotice] = []
+        required_view = required_views.get(anchor_name, {})
         if not isinstance(payload, dict):
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_missing",
-                    message=f"Required semantic anchor '{anchor_name}' is missing",
-                )
+            entity_notices.append(
+                _semantic_anchor_notice("error", anchor_name, "anchor_missing")
             )
+            entity_results[anchor_name] = SemanticAnchorEntityValidation(
+                status="error",
+                notices=entity_notices,
+            )
+            notices.extend(entity_notices)
             continue
 
         matched_anchor_count += 1
         anchor_id = payload.get("id")
-        if not isinstance(anchor_id, str) or not anchor_id:
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_id_missing",
-                    message=f"Semantic anchor '{anchor_name}' is missing its id",
+        entity_uri, entity_id = _normalize_semantic_anchor_reference(anchor_id)
+        if not entity_uri or not entity_id:
+            entity_notices.append(
+                _semantic_anchor_notice("error", anchor_name, "anchor_id_missing")
+            )
+        else:
+            expected_prefix = "P" if requirement.kind == "property" else "Q"
+            if not entity_id.startswith(expected_prefix):
+                entity_notices.append(
+                    _semantic_anchor_notice(
+                        "error",
+                        anchor_name,
+                        "anchor_kind_mismatch",
+                        normalized_value={
+                            "id": entity_uri,
+                            "expected_kind": requirement.kind,
+                        },
+                    )
+                )
+
+        if requirement.kind == "property":
+            datatype = payload.get("datatype")
+            if not isinstance(datatype, str) or not datatype.strip():
+                entity_notices.append(
+                    _semantic_anchor_notice(
+                        "error",
+                        anchor_name,
+                        "anchor_datatype_missing",
+                    )
+                )
+            else:
+                try:
+                    normalized_datatype = canonicalize_wikibase_datatype(
+                        datatype,
+                        strict=True,
+                    )
+                except KeyError:
+                    entity_notices.append(
+                        _semantic_anchor_notice(
+                            "error",
+                            anchor_name,
+                            "anchor_datatype_invalid",
+                        )
+                    )
+                else:
+                    if normalized_datatype != requirement.datatype:
+                        entity_notices.append(
+                            _semantic_anchor_notice(
+                                "error",
+                                anchor_name,
+                                "anchor_datatype_mismatch",
+                                normalized_value={
+                                    "expected": requirement.datatype,
+                                    "actual": normalized_datatype,
+                                },
+                            )
+                        )
+
+        resolved_view = payload.get("resolved")
+        if isinstance(resolved_view, dict):
+            drift_codes = compare_meta_wikibase_entity_views(
+                required_view,
+                resolved_view,
+            )
+            for code in drift_codes:
+                entity_notices.append(
+                    _semantic_anchor_notice(
+                        _semantic_anchor_drift_severity(
+                            anchor_name, required_view, code
+                        ),
+                        anchor_name,
+                        code,
+                    )
+                )
+        elif isinstance(entity_uri, str) and entity_uri:
+            entity_notices.append(
+                _semantic_anchor_notice(
+                    "warning",
+                    anchor_name,
+                    "resolved_missing",
                 )
             )
-            continue
 
-        expected_prefix = "P" if requirement.kind == "property" else "Q"
-        if not (anchor_id.startswith(expected_prefix) and anchor_id[1:].isdigit()):
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_kind_mismatch",
-                    message=(
-                        f"Semantic anchor '{anchor_name}' must resolve to a "
-                        f"{requirement.kind} id"
-                    ),
-                    normalized_value={
-                        "id": anchor_id,
-                        "expected_kind": requirement.kind,
-                    },
-                )
-            )
-
-        if requirement.kind != "property":
-            continue
-
-        datatype = payload.get("datatype")
-        if not isinstance(datatype, str) or not datatype.strip():
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_datatype_missing",
-                    message=f"Property anchor '{anchor_name}' is missing datatype",
-                )
-            )
-            continue
-
-        try:
-            normalized_datatype = canonicalize_wikibase_datatype(datatype, strict=True)
-        except KeyError:
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_datatype_invalid",
-                    message=(
-                        f"Property anchor '{anchor_name}' uses unknown datatype "
-                        f"'{datatype}'"
-                    ),
-                )
-            )
-            continue
-
-        if normalized_datatype != requirement.datatype:
-            notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref=anchor_name,
-                    code="anchor_datatype_mismatch",
-                    message=(
-                        f"Property anchor '{anchor_name}' must use datatype "
-                        f"'{requirement.datatype}', found '{normalized_datatype}'"
-                    ),
-                    normalized_value={
-                        "expected": requirement.datatype,
-                        "actual": normalized_datatype,
-                    },
-                )
-            )
+        entity_status = _semantic_anchor_status_from_notices(entity_notices)
+        entity_results[anchor_name] = SemanticAnchorEntityValidation(
+            status=entity_status,
+            notices=entity_notices,
+        )
+        notices.extend(entity_notices)
 
     extra_anchors = sorted(set(entities) - set(contract.requirements))
     if extra_anchors:
         notices.append(
-            ConformanceNotice(
-                severity="info",
-                entity_ref="semantic_anchors",
-                code="anchor_extra",
-                message=(
-                    f"Semantic anchor artifact contains {len(extra_anchors)} "
-                    "non-required internal anchors"
-                ),
+            _semantic_anchor_notice(
+                "warning",
+                "semantic_anchors",
+                "anchor_extra",
                 normalized_value=extra_anchors,
             )
         )
+        for anchor_name in extra_anchors:
+            payload = entities.get(anchor_name)
+            extra_notice = _semantic_anchor_notice(
+                "warning",
+                anchor_name,
+                "anchor_extra",
+            )
+            entity_results[anchor_name] = SemanticAnchorEntityValidation(
+                status="warning",
+                notices=[extra_notice],
+            )
 
     freshness_checked = current_anchor_document is not None
     freshness_match: Optional[bool] = None
@@ -377,42 +441,34 @@ def validate_semantic_anchor_document(
         current_entities = current_anchor_document.get("entities")
         if not isinstance(current_entities, dict):
             notices.append(
-                ConformanceNotice(
-                    severity="error",
-                    entity_ref="semantic_anchors",
-                    code="freshness_source_invalid",
-                    message="Current semantic anchor comparison source is missing entities",
+                _semantic_anchor_notice(
+                    "error",
+                    "semantic_anchors",
+                    "freshness_source_invalid",
                 )
             )
             freshness_match = None
         else:
-            freshness_match = entities == current_entities
-            if freshness_match:
-                notices.append(
-                    ConformanceNotice(
-                        severity="info",
-                        entity_ref="semantic_anchors",
-                        code="artifact_current",
-                        message="Semantic anchor artifact matches the current cache-derived document",
-                    )
+            comparable_entities = _semantic_anchor_comparable_entities(entities)
+            comparable_current = _semantic_anchor_comparable_entities(current_entities)
+            freshness_match = comparable_entities == comparable_current
+            if not freshness_match:
+                missing_in_artifact = sorted(
+                    set(comparable_current) - set(comparable_entities)
                 )
-            else:
-                missing_in_artifact = sorted(set(current_entities) - set(entities))
-                extra_in_artifact = sorted(set(entities) - set(current_entities))
+                extra_in_artifact = sorted(
+                    set(comparable_entities) - set(comparable_current)
+                )
                 changed_entries = sorted(
                     key
-                    for key in (set(entities) & set(current_entities))
-                    if entities[key] != current_entities[key]
+                    for key in (set(comparable_entities) & set(comparable_current))
+                    if comparable_entities[key] != comparable_current[key]
                 )
                 notices.append(
-                    ConformanceNotice(
-                        severity="error",
-                        entity_ref="semantic_anchors",
-                        code="artifact_stale",
-                        message=(
-                            "Semantic anchor artifact does not match the current "
-                            "cache-derived document"
-                        ),
+                    _semantic_anchor_notice(
+                        "error",
+                        "semantic_anchors",
+                        "artifact_stale",
                         normalized_value={
                             "missing_in_artifact": missing_in_artifact,
                             "extra_in_artifact": extra_in_artifact,
@@ -421,16 +477,121 @@ def validate_semantic_anchor_document(
                     )
                 )
 
-    valid = not any(notice.severity == "error" for notice in notices)
+    error_count = sum(1 for notice in notices if notice.severity == "error")
+    warning_count = sum(1 for notice in notices if notice.severity == "warning")
+    status = _semantic_anchor_status_from_notices(notices)
+    valid = error_count == 0
     return SemanticAnchorValidationResult(
         valid=valid,
+        status=status,
         required_anchor_count=required_anchor_count,
         matched_anchor_count=matched_anchor_count,
         evaluated_anchor_count=evaluated_anchor_count,
         notices=notices,
+        entity_results=entity_results,
+        error_count=error_count,
+        warning_count=warning_count,
         freshness_checked=freshness_checked,
         freshness_match=freshness_match,
     )
+
+
+def _semantic_anchor_notice(
+    severity: str,
+    entity_ref: str,
+    code: str,
+    *,
+    normalized_value: Any = None,
+) -> ConformanceNotice:
+    return ConformanceNotice(
+        severity=severity,
+        entity_ref=entity_ref,
+        code=code,
+        message=code,
+        normalized_value=normalized_value,
+    )
+
+
+def _semantic_anchor_status_from_notices(notices: list[ConformanceNotice]) -> str:
+    if any(notice.severity == "error" for notice in notices):
+        return "error"
+    if any(notice.severity == "warning" for notice in notices):
+        return "warning"
+    return "valid"
+
+
+def _normalize_semantic_anchor_reference(
+    reference: Any,
+) -> tuple[str | None, str | None]:
+    if not isinstance(reference, str) or not reference.strip():
+        return None, None
+
+    candidate = reference.strip()
+    if candidate.startswith("http://") or candidate.startswith("https://"):
+        entity_uri = candidate.rstrip("/")
+        entity_id = entity_uri.rsplit("/", 1)[-1]
+        if entity_id[:1] in {"P", "Q"} and entity_id[1:].isdigit():
+            return entity_uri, entity_id
+        return None, None
+
+    if candidate[:1] in {"P", "Q"} and candidate[1:].isdigit():
+        return f"https://datadistillery.wikibase.cloud/entity/{candidate}", candidate
+
+    return None, None
+
+
+def _semantic_anchor_requires_structural_integrity(
+    required_view: dict[str, Any],
+) -> bool:
+    claims = required_view.get("claims")
+    if not isinstance(claims, dict):
+        return False
+
+    instance_of_claims = claims.get("_instance_of")
+    if not isinstance(instance_of_claims, list):
+        return False
+
+    for claim in instance_of_claims:
+        if not isinstance(claim, dict):
+            continue
+        value = claim.get("mainsnak", {}).get("datavalue", {}).get("value", {})
+        if not isinstance(value, dict):
+            continue
+        if value.get("id") in {"_entity_profile", "_entity_statement"}:
+            return True
+
+    return False
+
+
+def _semantic_anchor_drift_severity(
+    anchor_name: str,
+    required_view: dict[str, Any],
+    code: str,
+) -> str:
+    if code in {"type", "datatype"}:
+        return "error"
+
+    if code == "claims" and _semantic_anchor_requires_structural_integrity(
+        required_view
+    ):
+        return "error"
+
+    return "warning"
+
+
+def _semantic_anchor_comparable_entities(
+    entities: dict[str, Any],
+) -> dict[str, Any]:
+    comparable: dict[str, Any] = {}
+    for anchor_name, payload in entities.items():
+        if not isinstance(payload, dict):
+            continue
+        comparable[anchor_name] = {
+            key: value
+            for key, value in payload.items()
+            if key in {"id", "kind", "datatype", "required", "resolved"}
+        }
+    return comparable
 
 
 def _coerce_wikibase_item_reference(

--- a/gkc/registry/meta_wb_init.yaml
+++ b/gkc/registry/meta_wb_init.yaml
@@ -62,6 +62,18 @@ entities:
         datatype: wikibase-item
         kind: property
 
+      has_fixed_value:
+        label: has fixed value
+        description: links a statement directly to the canonical external identifier that must be used as its exact value when no local GKC value entity is needed
+        datatype: url
+        kind: property
+
+      has_fixed_value_label:
+        label: has fixed value label
+        description: human-readable label accompanying a fixed external value identifier for profile export and display use
+        datatype: string
+        kind: property
+
       has_qualifier:
         label: has qualifier
         description: links a statement that is required as a qualifier on the subject statement
@@ -164,6 +176,12 @@ entities:
         datatype: wikibase-item
         kind: property
 
+      regex:
+        label: format as a regular expression
+        description: regex describing the format or shape of a value in PCRE syntax
+        datatype: string
+        kind: property
+
     items:
       entity:
         label: entity
@@ -203,7 +221,7 @@ entities:
       manual_refresh_policy:
         label: manual refresh
         description: refresh policy where something is only refreshed manually and not on a schedule
-        instance_of: refresh_policy
+        instance_of: value_list_refresh_policy
         kind: item
 
       wikibase_statement_type:
@@ -301,3 +319,435 @@ entities:
         error_message: Provide a valid Commons Data namespace tabular-data reference.
         instance_of: wikibase_statement_type
         kind: item
+
+      commons_media_object:
+        label: Commons Media Object
+        description: profile laying out the specifications and statements used in documenting media items in Wikimedia Commons with structured data content
+        instance_of: entity_profile
+        kind: item
+        label_prompt: caption used for the media object
+        label_guidance: Provide a short but descriptive caption for the image file or other media object that will be used widely whereve the media is displayed
+        has_statement:
+          - depicts
+          - copyright_status
+          - copyright_license
+          - inception
+          - media_type
+          - height
+          - width
+          - data_size
+          - checksum
+          - coordinates_of_the_point_of_view
+
+      format_specification:
+        label: Format Specification
+        description: items in this class contain specific format constraints or specifications for string values
+        subclass_of: entity
+        kind: item
+
+      depicts:
+        label: depicts
+        description: entity visually depicted in an image, literarily described in a work, or otherwise incorporated into an audiovisual or other medium
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P180
+        statement_type: wikibase-item
+        statement_prompt: enter or choose the Wikidata item that the subject image portrays or depicts
+        statement_guidance: Select the Wikidata item that the subject media object depicts
+        error_message: Failure to identify a Wikidata item that is a subject of the media object will degarade the full functionallity of the information content
+        # null encodes a DD Wikibase novalue claim on max_count, meaning 0-n values are allowed.
+        max_count: null
+
+      copyright_status:
+        label: copyright status
+        description: copyright status for intellectual creations like works of art, publications, software, etc.
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P6216
+        statement_type: wikibase-item
+        has_value: copyright_status_values
+        statement_prompt: enter or select the Wikidata item specifying copyright status for the subject media item
+        statement_guidance: Link to the Wikidata item from a controlled list representing the copyright status for the subject media item to clarify legal use of the media object
+        error_message: Failure to select a valid copyright status value for a media object means the legal uses for the object will be ambiguous or unclear
+        max_count: 1
+
+      copyright_license:
+        label: copyright license
+        description: license under which this copyrighted work is released
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P275
+        statement_type: wikibase-item
+        has_value: copyright_license_values
+        statement_prompt: enter or select the Wikidata item specifying the specific license the subject item is released under
+        statement_guidance: Link to the Wikidata item from a controlled list representing the license governing usage of the subject item
+        error_message: Failure to select a valid license designation for a media object means the legal uses for the object will be ambiguous or unclear
+        max_count: 1
+
+      inception:
+        label: inception
+        description: time when an entity begins to exist
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P571
+        statement_type: time
+        has_qualifier: datetime_precision
+        statement_prompt: enter the date that the subject entity began to exist
+        statement_guidance: Enter the date that the subject item came into existence or was established, citing a reliable reference.
+        error_message: Without a value, the founding or creation date is unknown, making chronological ordering and timeline display impossible.
+        max_count: null
+
+      media_type:
+        label: media type
+        description: IANA-registered identifier for a file type
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P1163
+        statement_type: string
+        has_value: iana_media_type
+        statement_prompt: specify the media type for the subject media object using an approved value from IANA
+        statement_guidance: Provide the official file object type from the Internet Assigned Numbers Authority
+        error_message: Failure to include a media type string may result in an inability for certain applications to use the information in the most efficient way
+        max_count: 1
+
+      height:
+        label: height
+        description: vertical length of an entity
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P2048
+        statement_type: quantity
+        has_qualifier: height_units
+        statement_prompt: enter a value for height of the subject item
+        statement_guidance: Enter a value for the height of the subject and specify an appropriate unit of measure
+        error_message: Failure to provide a height measurement with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
+        max_count: null
+
+      width:
+        label: width
+        description: horizontal length of an object
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P2049
+        statement_type: quantity
+        has_qualifier: width_units
+        statement_prompt: enter a value for width of the subject item
+        statement_guidance: Enter a value for the width of the subject and specify an appropriate unit of measure
+        error_message: Failure to provide a width measurement with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
+        max_count: null
+
+      data_size:
+        label: data size
+        description: size of a software, dataset, neural network, or individual file
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P3575
+        statement_type: quantity
+        has_qualifier: data_size_units
+        statement_prompt: enter a value for total size of the data item
+        statement_guidance: Enter a value for the data size of the subject and specify an appropriate unit of measure
+        error_message: Failure to provide a data size with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
+        max_count: null
+
+      checksum:
+        label: checksum
+        description: small-sized datum derived from a block of digital data for the purpose of detecting errors
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P4092
+        statement_type: string
+        has_value: checksum_format
+        statement_prompt: provide the checksum string for the subject item
+        statement_guidance: Provide the generated checksum and specify the determination method (e.g., sha1) in the associated qualifier
+        error_message: Failure to include the checksum may result in lack of trustworthiness in the veracity of the subject data
+        max_count: 1
+
+      coordinates_of_the_point_of_view:
+        label: coordinates of the point of view
+        description: point from which the scene depicted by the element is seen (element can be a photo, a painting, etc.)
+        instance_of: entity_statement
+        kind: item
+        same_as: http://www.wikidata.org/entity/P1259
+        statement_type: globe-coordinate
+        has_qualifier: coordinate_precision
+        statement_prompt: provide the coordinates from which the subject entity was observed or captured in a media object
+        statement_guidance: Record the coordinates for a point on earth where an image was recorded or created
+        error_message: Failure to provide the point of view location may result in reduced usability for the subject item
+        max_count: 1
+
+      datetime_precision:
+        label: datetime precision
+        description: specialized qualifier/modifier used to set the time precision value for Wikibase data representations; generally set dynamically through coercion code
+        instance_of: entity_statement
+        additional_instance_of:
+          - wikibase_statement_modifier
+        kind: item
+        has_value: time_precision_values
+        statement_prompt: set the time precision value for the datetime statement
+        statement_guidance: Time precision values will be computed dynamically in most cases
+        error_message: Statements with time values must include a precision value or they will be rejected when submitted to a Wikibase instance
+        max_count: 1
+
+      coordinate_precision:
+        label: coordinate precision
+        description: specialized qualifier/modifier used to set the globe-coordinate precision value for Wikibase data representations; generally set dynamically through coercion code
+        instance_of: entity_statement
+        additional_instance_of:
+          - wikibase_statement_modifier
+        kind: item
+        has_value: coordinate_precision_values
+        statement_prompt: set the coordinate precision value for the globe-coordinate statement
+        statement_guidance: Coordinate precision values will be computed dynamically in most cases
+        error_message: Statements with globe-coordinate values must include a precision value or they will be rejected when submitted to a Wikibase instance
+        max_count: 1
+
+      iana_media_type:
+        label: IANA media type value
+        description: format specification containing a regular expression that controls values applied to media type statements
+        instance_of: format_specification
+        kind: item
+        regex: '(application|audio|chemical|example|font|image|message|model|multipart|text|video)/[a-zA-Z0-9+.-]+'
+
+      checksum_format:
+        label: checksum string format
+        description: regex formatter for checksum values pulled from Wikidata property constraints
+        instance_of: format_specification
+        kind: item
+        regex: '[a-z\d]{128}|[a-z\d]{64}|[a-z\d]{40}|[a-z\d]{32}|[a-z\d]{16}|[a-z\d]{8}(-[a-z\d]{4}){3}-[a-z\d]{12}'
+
+      copyright_status_values:
+        label: List of Copyright Status Values
+        description: value list of valid copyright status values from Wikidata
+        instance_of: value_list
+        kind: item
+        refresh_policy: manual_refresh_policy
+        query_fixture: copyright_status_values
+
+      copyright_license_values:
+        label: List of Copyright Licenses
+        description: list of copyright license values from Wikidata for use in copyright license statements
+        instance_of: value_list
+        kind: item
+        refresh_policy: manual_refresh_policy
+        query_fixture: copyright_license_values
+
+      height_units:
+        label: List of Units for Height
+        description: list of units for height statements pulled from property constraints
+        instance_of: value_list
+        kind: item
+        refresh_policy: manual_refresh_policy
+        query_fixture: height_units
+
+      width_units:
+        label: List of Units for Width
+        description: list of units for width statements pulled from Wikidata property constraints
+        instance_of: value_list
+        kind: item
+        refresh_policy: manual_refresh_policy
+        query_fixture: width_units
+
+      data_size_units:
+        label: List of Units for Data Size
+        description: list of units for data size statements pulled from Wikidata property constraint
+        instance_of: value_list
+        kind: item
+        refresh_policy: manual_refresh_policy
+        query_fixture: data_size_units
+
+      time_precision_values:
+        label: Time Precision Values
+        description: value list of time precision numerical values and labels for use in setting time precision qualifiers/modifiers
+        instance_of: value_list
+        kind: item
+        error_message: The time value provided requires a qualifier specifying the precision (e.g., year, month, day, etc.). Please select from the list provided or consult the query source for more context.
+        query_fixture: time_precision_values
+
+      coordinate_precision_values:
+        label: Coordinate Precision Values
+        description: value list of time precision values and labels for use in setting globe-coordinate precision qualifiers/modifiers
+        instance_of: value_list
+        kind: item
+        error_message: The geographic coordinates provided require a precision qualifier. Please select from the list provided or consult the query source for more context.
+        query_fixture: coordinate_precision_values
+
+value_list_query_fixtures:
+  copyright_status_values:
+    value_list: copyright_status_values
+    storage_mode: item_talk_page
+    content_type: application/sparql-query
+    endpoint: https://query.wikidata.org/sparql
+    expected_vars:
+      - item
+      - itemLabel
+    query: |
+      # Purpose: value list for copyright status statements
+      # Expected vars: ?item ?itemLabel
+
+      PREFIX wd: <http://www.wikidata.org/entity/>
+      PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?item ?itemLabel
+      WHERE {
+        ?item wdt:P31 wd:Q50424085 ;
+              rdfs:label ?itemLabel .
+        FILTER(LANG(?itemLabel) = "en")
+        FILTER NOT EXISTS {
+          ?item wdt:P31 wd:Q21286738 .
+        }
+      }
+
+  copyright_license_values:
+    value_list: copyright_license_values
+    storage_mode: item_talk_page
+    content_type: application/sparql-query
+    endpoint: https://query.wikidata.org/sparql
+    expected_vars:
+      - item
+      - itemLabel
+    query: |
+      # Purpose: value list for copyright license statements
+      # Expected vars: ?item ?itemLabel
+
+      PREFIX wd: <http://www.wikidata.org/entity/>
+      PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?item ?itemLabel
+      WHERE {
+        ?item wdt:P31/wdt:P279 wd:Q77205602 ; # instance or subclass of copyright license
+              rdfs:label ?itemLabel .
+        FILTER(LANG(?itemLabel) = "en")
+        FILTER NOT EXISTS {
+          ?item wdt:P31 wd:Q21286738 .
+        }
+      }
+
+  height_units:
+    value_list: height_units
+    storage_mode: item_talk_page
+    content_type: application/sparql-query
+    endpoint: https://query.wikidata.org/sparql
+    expected_vars:
+      - item
+      - itemLabel
+    query: |
+      # Purpose: value list from height property constraint allowed items
+      # Expected vars: ?item ?itemLabel
+
+      PREFIX wd: <http://www.wikidata.org/entity/>
+      PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+
+      SELECT ?item ?itemLabel WHERE {
+        VALUES ?property { wd:P2048 }   # height
+        ?property p:P2302 ?constraintStatement .
+        ?constraintStatement ps:P2302 wd:Q21514353 .   # allowed units constraint
+        ?constraintStatement pq:P2305 ?item . # item of property constraint
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      }
+
+  width_units:
+    value_list: width_units
+    storage_mode: item_talk_page
+    content_type: application/sparql-query
+    endpoint: https://query.wikidata.org/sparql
+    expected_vars:
+      - item
+      - itemLabel
+    query: |
+      # Purpose: value list from width property constraint allowed items
+      # Expected vars: ?item ?itemLabel
+
+      PREFIX wd: <http://www.wikidata.org/entity/>
+      PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+
+      SELECT ?item ?itemLabel WHERE {
+        VALUES ?property { wd:P2049 }   # width
+        ?property p:P2302 ?constraintStatement .
+        ?constraintStatement ps:P2302 wd:Q21514353 .   # allowed units constraint
+        ?constraintStatement pq:P2305 ?item . # item of property constraint
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      }
+
+  data_size_units:
+    value_list: data_size_units
+    storage_mode: item_talk_page
+    content_type: application/sparql-query
+    endpoint: https://query.wikidata.org/sparql
+    expected_vars:
+      - item
+      - itemLabel
+    query: |
+      # Purpose: value list from data size property constraint allowed items
+      # Expected vars: ?item ?itemLabel
+
+      PREFIX wd: <http://www.wikidata.org/entity/>
+      PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+
+      SELECT ?item ?itemLabel WHERE {
+        VALUES ?property { wd:P3575 }   # data size
+        ?property p:P2302 ?constraintStatement .
+        ?constraintStatement ps:P2302 wd:Q21514353 .   # allowed units constraint
+        ?constraintStatement pq:P2305 ?item . # item of property constraint
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      }
+
+  time_precision_values:
+    value_list: time_precision_values
+    storage_mode: item_talk_page
+    content_type: application/sparql-query
+    expected_vars:
+      - item
+      - itemLabel
+    result_cast: integer
+    query: |
+      # Time Precision value list
+      # Static enumeration of Wikibase time precision codes (integer 0-14).
+      # Fermenter should cast selected item to integer for time.precision.
+
+      SELECT ?item ?itemLabel WHERE {
+        VALUES (?item ?itemLabel) {
+          ("0"  "Gigayear (10^9 years)"@en)
+          ("1"  "100 Megayears (10^8 years)"@en)
+          ("2"  "10 Megayears (10^7 years)"@en)
+          ("3"  "Megayear (10^6 years)"@en)
+          ("4"  "100 Kiloyears (10^5 years)"@en)
+          ("5"  "10 Kiloyears (10^4 years)"@en)
+          ("6"  "millennium"@en)
+          ("7"  "century"@en)
+          ("8"  "decade"@en)
+          ("9"  "year"@en)
+          ("10" "month"@en)
+          ("11" "day"@en)
+          ("12" "hour"@en)
+          ("13" "minute"@en)
+          ("14" "second"@en)
+        }
+      }
+
+  coordinate_precision_values:
+    value_list: coordinate_precision_values
+    storage_mode: item_talk_page
+    content_type: application/sparql-query
+    expected_vars:
+      - item
+      - itemLabel
+    result_cast: float
+    query: |
+      # Globe-Coordinate Precision value list
+      # Static enumeration of coordinate precision levels in decimal degrees.
+      # Fermenter should cast selected item to float for coordinate.precision.
+
+      SELECT ?item ?itemLabel WHERE {
+        VALUES (?item ?itemLabel) {
+          ("10"       "10 degrees"@en)
+          ("1"        "1 degree (~111 km)"@en)
+          ("0.1"      "0.1 degree (~11 km)"@en)
+          ("0.01667"  "1 arcminute (~1.85 km)"@en)
+          ("0.00278"  "10 arcseconds (~300 m)"@en)
+          ("0.000278" "1 arcsecond (~30 m)"@en)
+          ("0.0001"   "0.0001 degree (~11 m)"@en)
+          ("0.00001"  "0.00001 degree (~1 m)"@en)
+        }
+      }

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -43,6 +43,14 @@ from gkc.runtime_config import (
     resolve_spiritsafe_layout_for_root,
 )
 from gkc.sparql import SPARQLQuery, paginate_query, read_sparql_query_file
+from gkc.wikibase import (
+    build_meta_wikibase_init_index,
+    build_meta_wikibase_semantic_anchor_contract,
+    compile_meta_wikibase_seed,
+    get_meta_wikibase_init_contract_digest,
+    normalize_meta_wikibase_current_entity_view,
+    normalize_meta_wikibase_required_entity_view,
+)
 
 RefreshPolicy = Literal["manual", "daily", "weekly", "on_release"]
 SpiritSafeSourceMode = Literal["github", "local"]
@@ -1307,44 +1315,12 @@ class EntityProfileJsonBuilder:
         identification = profile_doc.get("identification", {})
 
         labels = metadata.get("labels", {}) if isinstance(metadata, dict) else {}
-        descriptions = (
-            metadata.get("descriptions", {}) if isinstance(metadata, dict) else {}
-        )
-        aliases = metadata.get("aliases", {}) if isinstance(metadata, dict) else {}
 
         if not self._metadata_has_label(labels, language):
             missing.append(f"metadata.labels.{language}")
 
-        if not self._metadata_has_description(descriptions, language):
-            if language == "mul":
-                missing.append("metadata.descriptions.mul_or_en")
-            else:
-                missing.append(f"metadata.descriptions.{language}")
-
-        if aliases and not self._metadata_has_alias(aliases, language):
-            missing.append(f"metadata.aliases.{language}")
-
         if not self._identification_has_prompt(identification, "labels", language):
             missing.append(f"identification.labels.{language}.prompt")
-
-        if not self._identification_has_prompt(
-            identification, "descriptions", language
-        ):
-            missing.append(f"identification.descriptions.{language}.prompt")
-
-        if not self._identification_has_prompt(identification, "aliases", language):
-            missing.append(f"identification.aliases.{language}.prompt")
-
-        statements = profile_doc.get("statements", [])
-        for statement in self._iter_statement_nodes(statements):
-            entity = statement.get("entity", "<unknown>")
-            messages = statement.get("messages", {})
-            if not isinstance(messages, dict):
-                missing.append(f"statement:{entity}.messages.{language}.prompt")
-                continue
-            prompt = messages.get(language, {}).get("prompt")
-            if not isinstance(prompt, str) or not prompt.strip():
-                missing.append(f"statement:{entity}.messages.{language}.prompt")
 
         return sorted(set(missing))
 
@@ -2781,22 +2757,22 @@ def build_spiritsafe_semantic_anchor_resolver(
                 f"Semantic anchor '{anchor_name}' must map to an object payload"
             )
 
-        entity_id = str(payload.get("id") or "").strip()
-        if not entity_id:
+        entity_reference = str(payload.get("id") or "").strip()
+        if not entity_reference:
             raise RuntimeError(
                 f"Semantic anchor '{anchor_name}' is missing required field 'id'"
             )
-        if not (entity_id[0] in {"P", "Q"} and entity_id[1:].isdigit()):
+
+        entity_uri = _entity_uri_from_reference(entity_reference)
+        entity_id = _entity_id_from_reference(entity_reference)
+        if not entity_uri or not entity_id:
             raise RuntimeError(
-                f"Semantic anchor '{anchor_name}' has invalid entity id '{entity_id}'"
+                f"Semantic anchor '{anchor_name}' has invalid entity id '{entity_reference}'"
             )
 
         kind: Literal["property", "item"] = (
             "property" if entity_id.startswith("P") else "item"
         )
-        entity_uri = payload.get("entity")
-        if not isinstance(entity_uri, str) or not entity_uri:
-            entity_uri = f"{SPIRITSAFE_ENTITY_URI_PREFIX}{entity_id}"
 
         datatype = payload.get("datatype")
         if datatype is not None and not isinstance(datatype, str):
@@ -3026,6 +3002,11 @@ def _build_semantic_anchor_entry(
     *,
     name_identifier_property_id: str,
     internal_prefix: str,
+    required_view: dict[str, Any],
+    entity_id_to_internal_name_identifier: dict[str, str],
+    label_language: str,
+    required_value_language: str,
+    required_monolingualtext_properties: set[str],
 ) -> Optional[dict[str, Any]]:
     entity = entity_doc.get("entity", {})
     entity_id = str(entity_doc.get("entity_id") or entity.get("id") or "")
@@ -3047,9 +3028,22 @@ def _build_semantic_anchor_entry(
     if not (internal_prefix and name_identifier.startswith(internal_prefix)):
         return None
 
+    expected_property_ids = set(required_view.get("claims", {}).keys())
+    resolved_view, _issues = normalize_meta_wikibase_current_entity_view(
+        entity,
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+        label_language=label_language,
+        required_value_language=required_value_language,
+        required_monolingualtext_properties=required_monolingualtext_properties,
+        expected_property_ids=expected_property_ids,
+    )
+
     entry = {
-        "id": entity_id,
-        "entity": f"{SPIRITSAFE_ENTITY_URI_PREFIX}{entity_id}",
+        "id": f"{SPIRITSAFE_ENTITY_URI_PREFIX}{entity_id}",
+        "kind": entity.get("type")
+        or ("property" if entity_id.startswith("P") else "item"),
+        "required": required_view,
+        "resolved": resolved_view,
     }
 
     if entity.get("type") == "property" and isinstance(entity.get("datatype"), str):
@@ -3061,7 +3055,7 @@ def _build_semantic_anchor_entry(
 def build_spiritsafe_semantic_anchor_document(
     spiritsafe_root: Union[str, Path],
 ) -> dict[str, Any]:
-    """Build a thin semantic anchor artifact from cached SpiritSafe entities."""
+    """Build a semantic-anchor artifact from cached SpiritSafe entities."""
 
     root = Path(spiritsafe_root).expanduser().resolve()
     layout = resolve_spiritsafe_layout(root)
@@ -3069,12 +3063,27 @@ def build_spiritsafe_semantic_anchor_document(
     _config_path, name_identifier_property_id, internal_prefix = (
         _require_spiritsafe_meta_wikibase_semantics(root)
     )
+    label_language = "en"
+    required_value_language = "mul"
+    contract = build_meta_wikibase_semantic_anchor_contract(
+        internal_name_identifier_prefix=internal_prefix
+    )
+    compilation = compile_meta_wikibase_seed(label_language=label_language)
+    contract_digest = get_meta_wikibase_init_contract_digest()
+    required_monolingualtext_properties: set[str] = {
+        entity.internal_name_identifier
+        for entity in build_meta_wikibase_init_index().properties.values()
+        if entity.datatype == "monolingualtext"
+    }
 
-    anchors: dict[str, dict[str, Any]] = {}
+    current_entities_by_internal_name_identifier: dict[str, dict[str, Any]] = {}
+    entity_id_to_internal_name_identifier: dict[str, str] = {}
 
     for entity_path in sorted(cache_entities_dir.glob("*.json")):
         entity_doc = json.loads(entity_path.read_text(encoding="utf-8"))
         claims = entity_doc.get("entity", {}).get("claims", {})
+        entity = entity_doc.get("entity", {})
+        entity_id = str(entity_doc.get("entity_id") or entity.get("id") or "")
         name_identifier = next(
             (
                 value
@@ -3086,37 +3095,121 @@ def build_spiritsafe_semantic_anchor_document(
             ),
             None,
         )
-        entry = _build_semantic_anchor_entry(
-            entity_doc,
-            name_identifier_property_id=name_identifier_property_id,
-            internal_prefix=internal_prefix,
+        if not name_identifier:
+            continue
+        if not (internal_prefix and name_identifier.startswith(internal_prefix)):
+            continue
+        current_entities_by_internal_name_identifier[name_identifier] = entity_doc
+        if entity_id:
+            entity_id_to_internal_name_identifier[entity_id] = name_identifier
+
+    anchors: dict[str, dict[str, Any]] = {}
+    for anchor_name, requirement in sorted(contract.requirements.items()):
+        compiled_entity = compilation.by_internal_name_identifier[anchor_name]
+        required_view = normalize_meta_wikibase_required_entity_view(
+            compiled_entity.payload
         )
-        if not entry or not name_identifier:
+        current_entity_doc = current_entities_by_internal_name_identifier.get(
+            anchor_name
+        )
+        if current_entity_doc is None:
+            anchors[anchor_name] = {
+                "id": None,
+                "kind": requirement.kind,
+                **(
+                    {"datatype": requirement.datatype}
+                    if requirement.kind == "property"
+                    and requirement.datatype is not None
+                    else {}
+                ),
+                "required": required_view,
+                "resolved": None,
+            }
             continue
 
-        anchors[name_identifier] = entry
+        entry = _build_semantic_anchor_entry(
+            current_entity_doc,
+            name_identifier_property_id=name_identifier_property_id,
+            internal_prefix=internal_prefix,
+            required_view=required_view,
+            entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+            label_language=label_language,
+            required_value_language=required_value_language,
+            required_monolingualtext_properties=required_monolingualtext_properties,
+        )
+        if entry is None:
+            anchors[anchor_name] = {
+                "id": None,
+                "kind": requirement.kind,
+                **(
+                    {"datatype": requirement.datatype}
+                    if requirement.kind == "property"
+                    and requirement.datatype is not None
+                    else {}
+                ),
+                "required": required_view,
+                "resolved": None,
+            }
+            continue
+        anchors[anchor_name] = entry
 
     property_count = sum(
         1
         for entry in anchors.values()
-        if isinstance(entry.get("id"), str) and entry["id"].startswith("P")
+        if _entity_id_from_reference(entry.get("id") or "")
+        and _entity_id_from_reference(entry.get("id") or "").startswith("P")
     )
     item_count = sum(
         1
         for entry in anchors.values()
-        if isinstance(entry.get("id"), str) and entry["id"].startswith("Q")
+        if _entity_id_from_reference(entry.get("id") or "")
+        and _entity_id_from_reference(entry.get("id") or "").startswith("Q")
     )
 
-    return {
+    semantic_anchor_document = {
         "metadata": {
             "generated_at": datetime.now(timezone.utc)
             .isoformat()
             .replace("+00:00", "Z"),
+            "contract_digest": contract_digest,
             "property_count": property_count,
             "item_count": item_count,
         },
         "entities": anchors,
     }
+
+    validation_result = validate_semantic_anchor_document(
+        semantic_anchor_document,
+        internal_name_identifier_prefix=internal_prefix,
+    )
+    semantic_anchor_document["validation"] = {
+        "status": validation_result.status,
+        "checked_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "required_anchor_count": validation_result.required_anchor_count,
+        "matched_anchor_count": validation_result.matched_anchor_count,
+        "evaluated_anchor_count": validation_result.evaluated_anchor_count,
+        "error_count": validation_result.error_count,
+        "warning_count": validation_result.warning_count,
+        "freshness_checked": validation_result.freshness_checked,
+        "freshness_match": validation_result.freshness_match,
+    }
+
+    for anchor_name, entity_result in validation_result.entity_results.items():
+        entry = semantic_anchor_document["entities"].get(anchor_name)
+        if not isinstance(entry, dict):
+            continue
+        entry["validation"] = {
+            "status": entity_result.status,
+            "notices": [
+                {
+                    "severity": notice.severity,
+                    "code": notice.code,
+                }
+                for notice in entity_result.notices
+            ],
+        }
+
+    return semantic_anchor_document
 
 
 def export_spiritsafe_semantic_anchors(

--- a/gkc/wikibase.py
+++ b/gkc/wikibase.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from functools import lru_cache
@@ -69,6 +70,51 @@ class MetaWikibaseSemanticAnchorContract:
 
     internal_name_identifier_prefix: str
     requirements: dict[str, MetaWikibaseSemanticAnchorRequirement]
+
+
+@dataclass(frozen=True)
+class MetaWikibaseCompiledEntity:
+    """Compiled symbolic Wikibase payload for one init-fixture entity."""
+
+    key: str
+    kind: str
+    internal_name_identifier: str
+    entity_type: str
+    datatype: str | None
+    claims: dict[str, list[dict[str, Any]]]
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class MetaWikibaseSeedCompilation:
+    """Compiled symbolic Wikibase payload set derived from the init fixture."""
+
+    metadata: MetaWikibaseInitMetadata
+    entities: dict[str, MetaWikibaseCompiledEntity]
+    by_internal_name_identifier: dict[str, MetaWikibaseCompiledEntity]
+
+
+@dataclass(frozen=True)
+class MetaWikibaseSeedPlanEntry:
+    """One dry-run baseline action derived from the compiled init fixture."""
+
+    action: str
+    key: str
+    internal_name_identifier: str
+    entity_type: str
+    datatype: str | None
+    payload: dict[str, Any]
+    current_entity_id: str | None = None
+    changed_fields: list[str] | None = None
+    details: str | None = None
+
+
+@dataclass(frozen=True)
+class MetaWikibaseSeedPlan:
+    """Dry-run baseline plan for the package-owned Meta-Wikibase seed."""
+
+    metadata: MetaWikibaseInitMetadata
+    operations: list[MetaWikibaseSeedPlanEntry]
 
 
 @dataclass(frozen=True)
@@ -403,17 +449,766 @@ def build_meta_wikibase_semantic_anchor_contract(
     )
 
 
+def get_meta_wikibase_init_contract_digest(
+    document: dict[str, Any] | None = None,
+) -> str:
+    """Return a stable digest for the normalized Meta-Wikibase init contract."""
+
+    normalized_document = (
+        load_meta_wikibase_init_document()
+        if document is None
+        else normalize_meta_wikibase_init_document(document)
+    )
+    serialized = json.dumps(
+        normalized_document,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def compile_meta_wikibase_seed(
+    document: dict[str, Any] | None = None,
+    *,
+    label_language: str | None = None,
+) -> MetaWikibaseSeedCompilation:
+    """Compile the init fixture into symbolic Wikibase JSON payloads.
+
+    The compiled payloads use internal name identifiers such as ``_instance_of``
+    as unresolved placeholders for entity references. This keeps the output in a
+    deterministic dry-run form that can be inspected before any live baseline
+    orchestration resolves or writes entities.
+    """
+
+    from gkc.bottler import (
+        ClaimBuilder,
+        DataTypeTransformer,
+        EntityShellBuilder,
+        SnakBuilder,
+    )
+
+    index = build_meta_wikibase_init_index(document)
+    entity_shell_builder = EntityShellBuilder()
+    claim_builder = ClaimBuilder(SnakBuilder(DataTypeTransformer()))
+    resolved_label_language = _resolve_meta_wikibase_label_language(label_language)
+
+    compiled_entities: dict[str, MetaWikibaseCompiledEntity] = {}
+    compiled_by_internal_name_identifier: dict[str, MetaWikibaseCompiledEntity] = {}
+
+    for entity in index.entities.values():
+        symbolic_claims = _compile_meta_wikibase_entity_claims(
+            entity,
+            index=index,
+            claim_builder=claim_builder,
+        )
+
+        shell = entity_shell_builder.build_entity_shell(
+            {
+                "labels": {resolved_label_language: entity.label},
+                "descriptions": {resolved_label_language: entity.description},
+                "statement_pids": sorted(symbolic_claims.keys()),
+            }
+        )
+        payload = dict(shell)
+        payload["type"] = entity.kind
+        if entity.kind == "property" and entity.datatype is not None:
+            payload["datatype"] = entity.datatype
+
+        if symbolic_claims:
+            payload_claims = payload.setdefault("claims", {})
+            for property_id in sorted(symbolic_claims.keys()):
+                payload_claims[property_id] = list(symbolic_claims[property_id])
+
+        compiled_entity = MetaWikibaseCompiledEntity(
+            key=entity.key,
+            kind=entity.kind,
+            internal_name_identifier=entity.internal_name_identifier,
+            entity_type=entity.kind,
+            datatype=entity.datatype,
+            claims=symbolic_claims,
+            payload=payload,
+        )
+        compiled_entities[entity.key] = compiled_entity
+        compiled_by_internal_name_identifier[entity.internal_name_identifier] = (
+            compiled_entity
+        )
+
+    return MetaWikibaseSeedCompilation(
+        metadata=index.metadata,
+        entities=compiled_entities,
+        by_internal_name_identifier=compiled_by_internal_name_identifier,
+    )
+
+
+def plan_meta_wikibase_seed_baseline(
+    document: dict[str, Any] | None = None,
+    *,
+    current_entities_by_internal_name_identifier: (
+        dict[str, dict[str, Any]] | None
+    ) = None,
+    entity_id_to_internal_name_identifier: dict[str, str] | None = None,
+    label_language: str | None = None,
+    required_value_language: str = "mul",
+) -> MetaWikibaseSeedPlan:
+    """Return a dry-run baseline plan for the package-owned init fixture."""
+
+    compilation = compile_meta_wikibase_seed(
+        document,
+        label_language=label_language,
+    )
+    operations: list[MetaWikibaseSeedPlanEntry] = []
+    resolved_label_language = _resolve_meta_wikibase_label_language(label_language)
+    required_monolingualtext_properties = {
+        entity.internal_name_identifier
+        for entity in build_meta_wikibase_init_index(document).properties.values()
+        if entity.datatype == "monolingualtext"
+    }
+
+    for entity in compilation.entities.values():
+        current_entity = None
+        if current_entities_by_internal_name_identifier is not None:
+            current_entity = current_entities_by_internal_name_identifier.get(
+                entity.internal_name_identifier
+            )
+
+        if current_entity is None:
+            operations.append(
+                MetaWikibaseSeedPlanEntry(
+                    action="create",
+                    key=entity.key,
+                    internal_name_identifier=entity.internal_name_identifier,
+                    entity_type=entity.entity_type,
+                    datatype=entity.datatype,
+                    current_entity_id=None,
+                    changed_fields=None,
+                    details="missing from current state",
+                    payload=entity.payload,
+                )
+            )
+            continue
+
+        comparison = _compare_meta_wikibase_compiled_to_current(
+            entity.payload,
+            current_entity=current_entity,
+            entity_id_to_internal_name_identifier=(
+                entity_id_to_internal_name_identifier or {}
+            ),
+            label_language=resolved_label_language,
+            required_value_language=required_value_language,
+            required_monolingualtext_properties=required_monolingualtext_properties,
+        )
+        operations.append(
+            MetaWikibaseSeedPlanEntry(
+                action="skip" if comparison["matches"] else "update",
+                key=entity.key,
+                internal_name_identifier=entity.internal_name_identifier,
+                entity_type=entity.entity_type,
+                datatype=entity.datatype,
+                current_entity_id=str(current_entity.get("id") or "").strip() or None,
+                changed_fields=comparison["changed_fields"] or None,
+                details=comparison["details"],
+                payload=entity.payload,
+            )
+        )
+
+    operations.sort(key=lambda operation: operation.internal_name_identifier)
+    return MetaWikibaseSeedPlan(
+        metadata=compilation.metadata,
+        operations=operations,
+    )
+
+
+def normalize_meta_wikibase_required_entity_view(
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the canonical comparable view for one compiled seed payload."""
+
+    return _normalize_meta_wikibase_compiled_payload(payload)
+
+
+def normalize_meta_wikibase_current_entity_view(
+    entity: dict[str, Any],
+    *,
+    entity_id_to_internal_name_identifier: dict[str, str],
+    label_language: str,
+    required_value_language: str,
+    required_monolingualtext_properties: set[str],
+    expected_property_ids: set[str],
+) -> tuple[dict[str, Any], list[str]]:
+    """Return the canonical comparable view for one current Wikibase entity."""
+
+    return _normalize_meta_wikibase_live_entity(
+        entity,
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+        label_language=label_language,
+        required_value_language=required_value_language,
+        required_monolingualtext_properties=required_monolingualtext_properties,
+        expected_property_ids=expected_property_ids,
+    )
+
+
+def compare_meta_wikibase_entity_views(
+    required_view: dict[str, Any],
+    current_view: dict[str, Any],
+    *,
+    issues: list[str] | None = None,
+) -> list[str]:
+    """Compare canonical required and current views and return changed-field codes."""
+
+    changed_fields: list[str] = []
+    for field_name in (
+        "type",
+        "datatype",
+        "labels",
+        "descriptions",
+        "aliases",
+        "claims",
+    ):
+        if required_view.get(field_name) != current_view.get(field_name):
+            changed_fields.append(field_name)
+
+    for issue in issues or []:
+        if issue not in changed_fields:
+            changed_fields.append(issue)
+
+    return changed_fields
+
+
+def _compare_meta_wikibase_compiled_to_current(
+    compiled_payload: dict[str, Any],
+    *,
+    current_entity: dict[str, Any],
+    entity_id_to_internal_name_identifier: dict[str, str],
+    label_language: str,
+    required_value_language: str,
+    required_monolingualtext_properties: set[str],
+) -> dict[str, Any]:
+    """Compare one compiled symbolic payload against one live Wikibase entity."""
+
+    expected = _normalize_meta_wikibase_compiled_payload(compiled_payload)
+    current, issues = _normalize_meta_wikibase_live_entity(
+        current_entity,
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+        label_language=label_language,
+        required_value_language=required_value_language,
+        required_monolingualtext_properties=required_monolingualtext_properties,
+        expected_property_ids=set(expected.get("claims", {}).keys()),
+    )
+
+    changed_fields: list[str] = []
+    for field_name in (
+        "type",
+        "datatype",
+        "labels",
+        "descriptions",
+        "aliases",
+        "claims",
+    ):
+        if expected.get(field_name) != current.get(field_name):
+            changed_fields.append(field_name)
+
+    if issues:
+        changed_fields.extend(issue for issue in issues if issue not in changed_fields)
+
+    details = "matches current state"
+    if changed_fields:
+        details = "fields changed: " + ", ".join(changed_fields)
+
+    return {
+        "matches": not changed_fields,
+        "changed_fields": changed_fields,
+        "details": details,
+    }
+
+
+def _normalize_meta_wikibase_compiled_payload(
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Normalize a compiled symbolic payload to a comparable canonical form."""
+
+    normalized: dict[str, Any] = {
+        "type": payload.get("type"),
+    }
+    if "datatype" in payload:
+        normalized["datatype"] = payload.get("datatype")
+
+    labels = payload.get("labels")
+    descriptions = payload.get("descriptions")
+    aliases = payload.get("aliases")
+    claims = payload.get("claims")
+
+    if isinstance(labels, dict) and labels:
+        normalized["labels"] = _normalize_meta_wikibase_language_block(labels)
+    if isinstance(descriptions, dict) and descriptions:
+        normalized["descriptions"] = _normalize_meta_wikibase_language_block(
+            descriptions
+        )
+    if isinstance(aliases, dict) and aliases:
+        normalized["aliases"] = _normalize_meta_wikibase_alias_block(aliases)
+    if isinstance(claims, dict) and claims:
+        normalized["claims"] = _normalize_meta_wikibase_claims(claims)
+
+    return normalized
+
+
+def _normalize_meta_wikibase_live_entity(
+    entity: dict[str, Any],
+    *,
+    entity_id_to_internal_name_identifier: dict[str, str],
+    label_language: str,
+    required_value_language: str,
+    required_monolingualtext_properties: set[str],
+    expected_property_ids: set[str],
+) -> tuple[dict[str, Any], list[str]]:
+    """Normalize one fetched Wikibase entity into comparable symbolic form."""
+
+    normalized: dict[str, Any] = {
+        "type": entity.get("type"),
+    }
+    datatype = entity.get("datatype")
+    if isinstance(datatype, str) and datatype:
+        normalized["datatype"] = canonicalize_wikibase_datatype(datatype)
+
+    labels = _normalize_meta_wikibase_language_block(
+        entity.get("labels"),
+        allowed_languages={label_language},
+    )
+    descriptions = _normalize_meta_wikibase_language_block(
+        entity.get("descriptions"),
+        allowed_languages={label_language},
+    )
+    aliases = _normalize_meta_wikibase_alias_block(
+        entity.get("aliases"),
+        allowed_languages={label_language},
+    )
+    claims, issues = _normalize_meta_wikibase_claims(
+        entity.get("claims"),
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+        expected_property_ids=expected_property_ids,
+        required_monolingualtext_properties=required_monolingualtext_properties,
+        required_value_language=required_value_language,
+    )
+
+    if labels:
+        normalized["labels"] = labels
+    if descriptions:
+        normalized["descriptions"] = descriptions
+    if aliases:
+        normalized["aliases"] = aliases
+    if claims:
+        normalized["claims"] = claims
+
+    return normalized, issues
+
+
+def _normalize_meta_wikibase_language_block(
+    block: Any,
+    *,
+    allowed_languages: set[str] | None = None,
+) -> dict[str, dict[str, str]]:
+    """Normalize a labels/descriptions block to comparable minimal form."""
+
+    if not isinstance(block, dict):
+        return {}
+
+    normalized: dict[str, dict[str, str]] = {}
+    for language in sorted(block.keys()):
+        if allowed_languages is not None and language not in allowed_languages:
+            continue
+        payload = block.get(language)
+        if not isinstance(payload, dict):
+            continue
+        value = payload.get("value")
+        if isinstance(language, str) and language and isinstance(value, str) and value:
+            normalized[language] = {"language": language, "value": value}
+    return normalized
+
+
+def _normalize_meta_wikibase_alias_block(
+    block: Any,
+    *,
+    allowed_languages: set[str] | None = None,
+) -> dict[str, list[dict[str, str]]]:
+    """Normalize an aliases block to comparable minimal form."""
+
+    if not isinstance(block, dict):
+        return {}
+
+    normalized: dict[str, list[dict[str, str]]] = {}
+    for language in sorted(block.keys()):
+        if allowed_languages is not None and language not in allowed_languages:
+            continue
+        payloads = block.get(language)
+        if not isinstance(payloads, list):
+            continue
+        values: list[dict[str, str]] = []
+        for payload in payloads:
+            if not isinstance(payload, dict):
+                continue
+            value = payload.get("value")
+            if isinstance(value, str) and value:
+                values.append({"language": language, "value": value})
+        if values:
+            values.sort(key=lambda payload: payload["value"])
+            normalized[language] = values
+    return normalized
+
+
+def _normalize_meta_wikibase_claims(
+    claims: Any,
+    *,
+    entity_id_to_internal_name_identifier: dict[str, str] | None = None,
+    expected_property_ids: set[str] | None = None,
+    required_monolingualtext_properties: set[str] | None = None,
+    required_value_language: str = "mul",
+) -> Any:
+    """Normalize claims to a comparable deterministic symbolic form."""
+
+    if not isinstance(claims, dict):
+        return ({}, []) if entity_id_to_internal_name_identifier is not None else {}
+
+    issues: list[str] = []
+    normalized: dict[str, list[dict[str, Any]]] = {}
+
+    for property_id in sorted(claims.keys()):
+        symbolic_property_id = (
+            entity_id_to_internal_name_identifier.get(property_id, property_id)
+            if entity_id_to_internal_name_identifier is not None
+            else property_id
+        )
+        if (
+            expected_property_ids is not None
+            and symbolic_property_id not in expected_property_ids
+        ):
+            continue
+
+        raw_claims = claims.get(property_id)
+        if not isinstance(raw_claims, list):
+            continue
+
+        normalized_claims: list[dict[str, Any]] = []
+        for claim in raw_claims:
+            normalized_claim = _normalize_meta_wikibase_claim(
+                claim,
+                symbolic_property_id=symbolic_property_id,
+                entity_id_to_internal_name_identifier=(
+                    entity_id_to_internal_name_identifier or {}
+                ),
+                required_value_language=required_value_language,
+                require_mul=symbolic_property_id
+                in (required_monolingualtext_properties or set()),
+            )
+            if normalized_claim is None:
+                continue
+            if "issue" in normalized_claim:
+                issues.append(str(normalized_claim.pop("issue")))
+            normalized_claims.append(normalized_claim)
+
+        if normalized_claims:
+            normalized_claims.sort(key=lambda claim: json.dumps(claim, sort_keys=True))
+            normalized[symbolic_property_id] = normalized_claims
+
+    if entity_id_to_internal_name_identifier is not None:
+        return normalized, issues
+    return normalized
+
+
+def _normalize_meta_wikibase_claim(
+    claim: Any,
+    *,
+    symbolic_property_id: str,
+    entity_id_to_internal_name_identifier: dict[str, str],
+    required_value_language: str,
+    require_mul: bool,
+) -> dict[str, Any] | None:
+    """Normalize one claim to comparable canonical form."""
+
+    if not isinstance(claim, dict):
+        return None
+    mainsnak = claim.get("mainsnak")
+    if not isinstance(mainsnak, dict) or mainsnak.get("snaktype") != "value":
+        return None
+    datavalue = mainsnak.get("datavalue")
+    if not isinstance(datavalue, dict):
+        return None
+
+    normalized_datavalue, issue = _normalize_meta_wikibase_datavalue(
+        datavalue,
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+        required_value_language=required_value_language,
+        require_mul=require_mul,
+        property_id=symbolic_property_id,
+    )
+    normalized_claim = {
+        "mainsnak": {
+            "snaktype": "value",
+            "property": symbolic_property_id,
+            "datavalue": normalized_datavalue,
+        },
+        "type": claim.get("type", "statement"),
+        "rank": claim.get("rank", "normal"),
+    }
+    if issue is not None:
+        normalized_claim["issue"] = issue
+    return normalized_claim
+
+
+def _normalize_meta_wikibase_datavalue(
+    datavalue: dict[str, Any],
+    *,
+    entity_id_to_internal_name_identifier: dict[str, str],
+    required_value_language: str,
+    require_mul: bool,
+    property_id: str,
+) -> tuple[dict[str, Any], str | None]:
+    """Normalize one datavalue block to symbolic comparable form."""
+
+    datavalue_type = datavalue.get("type")
+    value = datavalue.get("value")
+
+    if datavalue_type == "wikibase-entityid" and isinstance(value, dict):
+        entity_id = value.get("id")
+        if isinstance(entity_id, str) and entity_id:
+            entity_id = entity_id_to_internal_name_identifier.get(entity_id, entity_id)
+        return (
+            {
+                "type": "wikibase-entityid",
+                "value": {
+                    "entity-type": value.get("entity-type"),
+                    "id": entity_id,
+                },
+            },
+            None,
+        )
+
+    if datavalue_type == "monolingualtext":
+        normalized_value = _normalize_meta_wikibase_monolingualtext(value)
+        if normalized_value is None:
+            return datavalue, f"{property_id}.invalid_monolingualtext"
+        issue = None
+        if require_mul and normalized_value["language"] != required_value_language:
+            issue = f"{property_id}.language"
+        return (
+            {"type": "monolingualtext", "value": normalized_value},
+            issue,
+        )
+
+    return ({"type": datavalue_type, "value": value}, None)
+
+
+def _resolve_meta_wikibase_label_language(
+    configured_language: str | None = None,
+) -> str:
+    """Resolve the display language for labels, descriptions, and aliases."""
+
+    if isinstance(configured_language, str) and configured_language.strip():
+        return configured_language.strip()
+
+    try:
+        from gkc import get_languages
+
+        languages = get_languages()
+    except Exception:
+        return "en"
+
+    if isinstance(languages, str):
+        candidate = languages.strip()
+        return candidate if candidate and candidate != "all" else "en"
+
+    if isinstance(languages, list):
+        for candidate in languages:
+            if isinstance(candidate, str):
+                candidate = candidate.strip()
+                if candidate and candidate != "all":
+                    return candidate
+
+    return "en"
+
+
+def _compile_meta_wikibase_entity_claims(
+    entity: MetaWikibaseInitEntity,
+    *,
+    index: MetaWikibaseInitIndex,
+    claim_builder: Any,
+) -> dict[str, list[dict[str, Any]]]:
+    """Compile the symbolic claim set for one init-fixture entity."""
+
+    claims: dict[str, list[dict[str, Any]]] = {}
+
+    _append_meta_wikibase_claim(
+        claims,
+        index.properties["name_identifier"].internal_name_identifier,
+        claim_builder.create_claim(
+            index.properties["name_identifier"].internal_name_identifier,
+            entity.internal_name_identifier,
+            "string",
+        ),
+    )
+
+    if isinstance(entity.instance_of, str) and entity.instance_of:
+        _append_meta_wikibase_claim(
+            claims,
+            index.properties["instance_of"].internal_name_identifier,
+            _build_symbolic_entity_reference_claim(
+                claim_builder,
+                property_id=index.properties["instance_of"].internal_name_identifier,
+                value_internal_name_identifier=(
+                    index.entities[entity.instance_of].internal_name_identifier
+                ),
+                entity_type="item",
+            ),
+        )
+
+    if isinstance(entity.subclass_of, str) and entity.subclass_of:
+        _append_meta_wikibase_claim(
+            claims,
+            index.properties["subclass_of"].internal_name_identifier,
+            _build_symbolic_entity_reference_claim(
+                claim_builder,
+                property_id=index.properties["subclass_of"].internal_name_identifier,
+                value_internal_name_identifier=(
+                    index.entities[entity.subclass_of].internal_name_identifier
+                ),
+                entity_type="item",
+            ),
+        )
+
+    for attribute_key, attribute_value in sorted((entity.attributes or {}).items()):
+        property_entity = index.properties.get(attribute_key)
+        if property_entity is None:
+            continue
+        claim = _build_meta_wikibase_attribute_claim(
+            claim_builder,
+            property_entity=property_entity,
+            attribute_value=attribute_value,
+            index=index,
+        )
+        if claim is None:
+            continue
+        _append_meta_wikibase_claim(
+            claims,
+            property_entity.internal_name_identifier,
+            claim,
+        )
+
+    return {property_id: claims[property_id] for property_id in sorted(claims.keys())}
+
+
+def _build_meta_wikibase_attribute_claim(
+    claim_builder: Any,
+    *,
+    property_entity: MetaWikibaseInitEntity,
+    attribute_value: Any,
+    index: MetaWikibaseInitIndex,
+) -> dict[str, Any] | None:
+    """Compile one authored attribute into a symbolic claim when supported."""
+
+    if property_entity.datatype == "wikibase-item":
+        if (
+            not isinstance(attribute_value, str)
+            or attribute_value not in index.entities
+        ):
+            return None
+        return _build_symbolic_entity_reference_claim(
+            claim_builder,
+            property_id=property_entity.internal_name_identifier,
+            value_internal_name_identifier=(
+                index.entities[attribute_value].internal_name_identifier
+            ),
+            entity_type="item",
+        )
+
+    if property_entity.datatype == "monolingualtext":
+        normalized_value = _normalize_meta_wikibase_monolingualtext(attribute_value)
+        if normalized_value is None:
+            return None
+        return claim_builder.create_claim(
+            property_entity.internal_name_identifier,
+            normalized_value["text"],
+            "monolingualtext",
+            {"language": normalized_value["language"]},
+        )
+
+    if property_entity.datatype in {"string", "url", "quantity", "time"}:
+        return claim_builder.create_claim(
+            property_entity.internal_name_identifier,
+            attribute_value,
+            property_entity.datatype,
+        )
+
+    return None
+
+
+def _build_symbolic_entity_reference_claim(
+    claim_builder: Any,
+    *,
+    property_id: str,
+    value_internal_name_identifier: str,
+    entity_type: str,
+) -> dict[str, Any]:
+    """Build a symbolic entity-reference claim using bottler primitives."""
+
+    from gkc.bottler import DataTypeTransformer
+
+    datavalue = DataTypeTransformer.to_wikibase_entity_reference(
+        value_internal_name_identifier,
+        entity_type=entity_type,
+    )
+    return claim_builder.create_claim_from_datavalue(
+        property_id,
+        datavalue,
+    )
+
+
+def _append_meta_wikibase_claim(
+    claims: dict[str, list[dict[str, Any]]],
+    property_id: str,
+    claim: dict[str, Any],
+) -> None:
+    """Append one compiled claim to the per-property claim bucket."""
+
+    claims.setdefault(property_id, []).append(claim)
+
+
+def _normalize_meta_wikibase_monolingualtext(
+    value: Any,
+) -> dict[str, str] | None:
+    """Normalize authored monolingualtext fixture values to text/language pairs."""
+
+    from gkc.fermenter import validate_monolingualtext
+
+    validation = validate_monolingualtext(value)
+    if not validation.valid or not isinstance(validation.value, dict):
+        return None
+
+    language = validation.value.get("language")
+    text = validation.value.get("text")
+    if not isinstance(language, str) or not language:
+        return None
+    if not isinstance(text, str) or not text:
+        return None
+
+    return {"text": text, "language": language}
+
+
 __all__ = [
     "MetaWikibaseInitEntity",
     "MetaWikibaseInitIndex",
     "MetaWikibaseInitMetadata",
+    "MetaWikibaseCompiledEntity",
     "MetaWikibaseSemanticAnchorContract",
     "MetaWikibaseSemanticAnchorRequirement",
+    "MetaWikibaseSeedCompilation",
+    "MetaWikibaseSeedPlan",
+    "MetaWikibaseSeedPlanEntry",
     "WikibaseDatatypeSpec",
     "build_meta_wikibase_init_index",
     "build_meta_wikibase_semantic_anchor_contract",
     "canonicalize_wikibase_datatype",
+    "compare_meta_wikibase_entity_views",
+    "compile_meta_wikibase_seed",
     "get_meta_wikibase_init_entity",
+    "get_meta_wikibase_init_contract_digest",
     "get_wikibase_datatype_spec",
     "is_known_wikibase_datatype",
     "is_wikibase_item_datatype",
@@ -421,5 +1216,8 @@ __all__ = [
     "load_meta_wikibase_init_document",
     "load_wikibase_datatype_registry",
     "load_wikibase_datatype_registry_json",
+    "normalize_meta_wikibase_current_entity_view",
     "normalize_meta_wikibase_init_document",
+    "normalize_meta_wikibase_required_entity_view",
+    "plan_meta_wikibase_seed_baseline",
 ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Tribal Governments: tribes.md
   - Architecture:
     - Overview: architecture/index.md
+    - Wikimedia Commons: architecture/wikimedia-commons.md
     - Meta-Wikibase:
       - Overview: architecture/meta-wikibase/index.md
       - Data Distillery Wikibase: architecture/meta-wikibase/DataDistillery-Wikibase.md

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,263 @@ def test_wikiverse_token_redacted(monkeypatch, capsys):
     assert data["details"]["token"] == "<redacted>"
 
 
+def test_wikibase_init_preview_json_uses_language_override(capsys):
+    exit_code = cli.main(
+        [
+            "--json",
+            "wikibase",
+            "init",
+            "--language",
+            "fr",
+            "--show-entity",
+            "entity_profile",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["command"] == "wikibase.init"
+    assert payload["ok"] is True
+    assert payload["details"]["label_language"] == "fr"
+    assert payload["details"]["value_language"] == "mul"
+    assert payload["details"]["summary"]["created"] > 0
+    sample_payload = payload["details"]["sample_entity"]["payload"]
+    assert sample_payload["labels"]["fr"]["value"] == "GKC Entity Profile"
+
+
+def test_wikibase_init_preview_can_compare_live_state(monkeypatch, capsys, tmp_path):
+    class FakeWikibaseApiClient:
+        def __init__(self, api_url):
+            self.api_url = api_url
+
+        def get_entities(self, entity_ids):
+            assert "Q50" in entity_ids
+            return {
+                "Q50": {
+                    "id": "Q50",
+                    "type": "item",
+                    "labels": {"en": {"language": "en", "value": "wikibase-item"}},
+                    "descriptions": {
+                        "en": {
+                            "language": "en",
+                            "value": "wikibase item property template used to set a data type for a statement, reference, or qualifier and any additional specifications",
+                        }
+                    },
+                    "claims": {
+                        "P1": [
+                            {
+                                "mainsnak": {
+                                    "snaktype": "value",
+                                    "property": "P1",
+                                    "datavalue": {
+                                        "type": "wikibase-entityid",
+                                        "value": {
+                                            "entity-type": "item",
+                                            "id": "Q99",
+                                            "numeric-id": 99,
+                                        },
+                                    },
+                                },
+                                "type": "statement",
+                                "rank": "normal",
+                            }
+                        ],
+                        "P214": [
+                            {
+                                "mainsnak": {
+                                    "snaktype": "value",
+                                    "property": "P214",
+                                    "datavalue": {
+                                        "type": "string",
+                                        "value": "_wikibase-item",
+                                    },
+                                },
+                                "type": "statement",
+                                "rank": "normal",
+                            }
+                        ],
+                        "P168": [
+                            {
+                                "mainsnak": {
+                                    "snaktype": "value",
+                                    "property": "P168",
+                                    "datavalue": {
+                                        "type": "monolingualtext",
+                                        "value": {
+                                            "language": "mul",
+                                            "text": "Item must be or resolve to a valid QID identifier.",
+                                        },
+                                    },
+                                },
+                                "type": "statement",
+                                "rank": "normal",
+                            }
+                        ],
+                    },
+                }
+            }
+
+    monkeypatch.setattr(
+        cli,
+        "resolve_spiritsafe_meta_wikibase_config",
+        lambda local_root: (
+            Path(local_root) / "config" / "dd-wikibase.yaml",
+            {
+                "name_identifier_property_id": "P214",
+                "sparql_endpoint": "https://example.org/query/sparql",
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "execute_sparql",
+        lambda query, endpoint=None, format="json": {
+            "results": {
+                "bindings": [
+                    {
+                        "entity": {"value": "https://example.org/entity/P1"},
+                        "nameIdentifier": {"value": "_instance_of"},
+                    },
+                    {
+                        "entity": {"value": "https://example.org/entity/P168"},
+                        "nameIdentifier": {"value": "_error_message"},
+                    },
+                    {
+                        "entity": {"value": "https://example.org/entity/P214"},
+                        "nameIdentifier": {"value": "_name_identifier"},
+                    },
+                    {
+                        "entity": {"value": "https://example.org/entity/Q50"},
+                        "nameIdentifier": {"value": "_wikibase-item"},
+                    },
+                    {
+                        "entity": {"value": "https://example.org/entity/Q99"},
+                        "nameIdentifier": {"value": "_wikibase_statement_type"},
+                    },
+                ]
+            }
+        },
+    )
+    monkeypatch.setattr(cli, "WikibaseApiClient", FakeWikibaseApiClient)
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "wikibase",
+            "init",
+            "--local-root",
+            str(tmp_path / "SpiritSafe"),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert (
+        payload["details"]["comparison_source"]["mode"]
+        == "live-compare-name-identifier"
+    )
+    assert payload["details"]["summary"]["skipped"] == 1
+    assert payload["details"]["summary"]["updated"] == 0
+
+
+def test_wikibase_init_uses_anchor_hints_when_sparql_misses_entity(
+    monkeypatch, capsys, tmp_path
+):
+    local_root = tmp_path / "SpiritSafe"
+    artifact_path = local_root / "config" / "semantic_anchors.json"
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text(
+        json.dumps(
+            {
+                "metadata": {},
+                "entities": {
+                    "_alias_guidance": {
+                        "id": "P187",
+                        "entity": "https://example.org/entity/P187",
+                        "datatype": "monolingualtext",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeWikibaseApiClient:
+        def __init__(self, api_url):
+            self.api_url = api_url
+
+        def get_entities(self, entity_ids):
+            assert "P187" in entity_ids
+            return {
+                "P187": {
+                    "id": "P187",
+                    "type": "property",
+                    "datatype": "monolingualtext",
+                    "labels": {"en": {"language": "en", "value": "alias guidance"}},
+                    "descriptions": {
+                        "en": {
+                            "language": "en",
+                            "value": "longer guidance statement provided as instructions for creating aliases for a GKC Entity",
+                        }
+                    },
+                    "claims": {
+                        "P214": [
+                            {
+                                "mainsnak": {
+                                    "snaktype": "value",
+                                    "property": "P214",
+                                    "datavalue": {
+                                        "type": "string",
+                                        "value": "_alias_guidance",
+                                    },
+                                },
+                                "type": "statement",
+                                "rank": "normal",
+                            }
+                        ]
+                    },
+                }
+            }
+
+    monkeypatch.setattr(
+        cli,
+        "resolve_spiritsafe_meta_wikibase_config",
+        lambda local_root: (
+            Path(local_root) / "config" / "dd-wikibase.yaml",
+            {
+                "name_identifier_property_id": "P214",
+                "sparql_endpoint": "https://example.org/query/sparql",
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "execute_sparql",
+        lambda query, endpoint=None, format="json": {"results": {"bindings": []}},
+    )
+    monkeypatch.setattr(cli, "WikibaseApiClient", FakeWikibaseApiClient)
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "wikibase",
+            "init",
+            "--local-root",
+            str(local_root),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["details"]["comparison_source"]["anchor_hint_count"] == 1
+    alias_guidance_action = next(
+        action
+        for action in payload["details"]["actions"]
+        if action["internal_name_identifier"] == "_alias_guidance"
+    )
+    assert alias_guidance_action["action"] == "skip"
+
+
 def test_osm_status_json(monkeypatch, capsys):
     """OSM status returns JSON output."""
     monkeypatch.setattr(cli, "OpenStreetMapAuth", FakeOpenStreetMapAuth)

--- a/tests/test_cli_spiritsafe_semantic_anchors.py
+++ b/tests/test_cli_spiritsafe_semantic_anchors.py
@@ -19,11 +19,16 @@ def test_spiritsafe_semantic_anchors_build_json(monkeypatch, capsys, tmp_path):
                 "property_count": 1,
                 "item_count": 1,
             },
+            "validation": {
+                "status": "warning",
+                "error_count": 0,
+                "warning_count": 1,
+            },
             "entities": {
-                "_foo": {"id": "Q1", "entity": "https://example.org/entity/Q1"},
+                "_foo": {"id": "https://example.org/entity/Q1", "kind": "item"},
                 "_bar": {
-                    "id": "P1",
-                    "entity": "https://example.org/entity/P1",
+                    "id": "https://example.org/entity/P1",
+                    "kind": "property",
                     "datatype": "string",
                 },
             },
@@ -51,6 +56,8 @@ def test_spiritsafe_semantic_anchors_build_json(monkeypatch, capsys, tmp_path):
     assert payload["details"]["anchor_count"] == 2
     assert payload["details"]["property_count"] == 1
     assert payload["details"]["item_count"] == 1
+    assert payload["details"]["validation_status"] == "warning"
+    assert payload["details"]["warning_count"] == 1
 
 
 def test_spiritsafe_semantic_anchors_build_requires_local_root(capsys):
@@ -78,12 +85,16 @@ def test_spiritsafe_semantic_anchors_validate_json(monkeypatch, capsys, tmp_path
 
     class FakeResult:
         valid = True
+        status = "valid"
         required_anchor_count = 2
         matched_anchor_count = 2
         evaluated_anchor_count = 1
+        error_count = 0
+        warning_count = 0
         freshness_checked = False
         freshness_match = None
         notices = []
+        entity_results = {}
 
     monkeypatch.setattr(
         cli, "validate_semantic_anchor_document", lambda *args, **kwargs: FakeResult()
@@ -105,6 +116,7 @@ def test_spiritsafe_semantic_anchors_validate_json(monkeypatch, capsys, tmp_path
     assert payload["command"] == "spiritsafe.semantic-anchors.validate"
     assert payload["ok"] is True
     assert payload["details"]["artifact_path"] == str(artifact_path)
+    assert payload["details"]["status"] == "valid"
     assert payload["details"]["required_anchor_count"] == 2
 
 
@@ -135,12 +147,16 @@ def test_spiritsafe_semantic_anchors_validate_can_compare_current_cache(
 
     class FakeResult:
         valid = True
+        status = "valid"
         required_anchor_count = 2
         matched_anchor_count = 2
         evaluated_anchor_count = 1
+        error_count = 0
+        warning_count = 0
         freshness_checked = True
         freshness_match = True
         notices = []
+        entity_results = {}
 
     monkeypatch.setattr(
         cli, "validate_semantic_anchor_document", lambda *args, **kwargs: FakeResult()

--- a/tests/test_fermenter_semantic_anchors.py
+++ b/tests/test_fermenter_semantic_anchors.py
@@ -1,7 +1,10 @@
 """Tests for semantic-anchor validation against the package-owned init contract."""
 
 from gkc.fermenter import validate_semantic_anchor_document
-from gkc.wikibase import build_meta_wikibase_semantic_anchor_contract
+from gkc.wikibase import (
+    build_meta_wikibase_semantic_anchor_contract,
+    get_meta_wikibase_init_contract_digest,
+)
 
 
 def _valid_anchor_document() -> dict:
@@ -14,20 +17,21 @@ def _valid_anchor_document() -> dict:
         if requirement.kind == "property":
             property_index += 1
             entities[anchor_name] = {
-                "id": f"P{property_index}",
-                "entity": f"https://datadistillery.wikibase.cloud/entity/P{property_index}",
+                "id": f"https://datadistillery.wikibase.cloud/entity/P{property_index}",
+                "kind": "property",
                 "datatype": str(requirement.datatype),
             }
         else:
             item_index += 1
             entities[anchor_name] = {
-                "id": f"Q{item_index}",
-                "entity": f"https://datadistillery.wikibase.cloud/entity/Q{item_index}",
+                "id": f"https://datadistillery.wikibase.cloud/entity/Q{item_index}",
+                "kind": "item",
             }
 
     return {
         "metadata": {
             "generated_at": "2026-04-04T00:00:00Z",
+            "contract_digest": get_meta_wikibase_init_contract_digest(),
             "property_count": property_index,
             "item_count": item_index,
         },
@@ -58,7 +62,9 @@ def test_validate_semantic_anchor_document_requires_entity_anchor() -> None:
 
 def test_validate_semantic_anchor_document_rejects_wrong_kind() -> None:
     artifact = _valid_anchor_document()
-    artifact["entities"]["_entity"]["id"] = "P999"
+    artifact["entities"]["_entity"][
+        "id"
+    ] = "https://datadistillery.wikibase.cloud/entity/P999"
 
     result = validate_semantic_anchor_document(artifact)
 
@@ -79,7 +85,9 @@ def test_validate_semantic_anchor_document_rejects_property_datatype_mismatch() 
 def test_validate_semantic_anchor_document_flags_stale_compare_source() -> None:
     artifact = _valid_anchor_document()
     current = _valid_anchor_document()
-    current["entities"]["_statement_type"]["id"] = "P12345"
+    current["entities"]["_statement_type"][
+        "id"
+    ] = "https://datadistillery.wikibase.cloud/entity/P12345"
 
     result = validate_semantic_anchor_document(
         artifact,

--- a/tests/test_spirit_safe_entity_profile_json.py
+++ b/tests/test_spirit_safe_entity_profile_json.py
@@ -411,7 +411,12 @@ def test_linkage_index_maps_statement_property_and_target_profile(tmp_path):
         semantic_anchor_document=_default_semantic_anchor_document(),
     )
 
-    linkage_index = docs[0]["metadata"]["linkage_index"]
+    source_doc = next(
+        doc
+        for doc in docs
+        if doc["id"] == "https://datadistillery.wikibase.cloud/entity/Q4"
+    )
+    linkage_index = source_doc["metadata"]["linkage_index"]
     assert linkage_index == {
         "outbound_by_statement": {
             "https://datadistillery.wikibase.cloud/entity/Q40": {
@@ -1082,8 +1087,8 @@ def test_profile_level_max_count_overrides_statement_level_baseline(tmp_path):
     assert by_entity["Q17"]["max_count"] == 2
 
 
-def test_export_json_skips_profile_when_mul_language_coverage_fails(tmp_path):
-    """Invalid mul coverage should skip writing profile and report failure."""
+def test_export_json_skips_profile_when_mul_label_prompt_coverage_fails(tmp_path):
+    """Missing mul label prompt should skip writing a profile."""
 
     cache_entities_dir = tmp_path / "cache" / "entities"
     cache_entities_dir.mkdir(parents=True, exist_ok=True)
@@ -1096,9 +1101,7 @@ def test_export_json_skips_profile_when_mul_language_coverage_fails(tmp_path):
             "aliases": {},
             "claims": {
                 "P1": [_build_entity_claim_entity_id("Q3")],
-                "P188": [_build_entity_claim_monolingual("Enter label")],
                 "P189": [_build_entity_claim_monolingual("Enter description")],
-                # Intentionally missing P190 mul prompt.
             },
         },
     }
@@ -1115,12 +1118,12 @@ def test_export_json_skips_profile_when_mul_language_coverage_fails(tmp_path):
     assert result.skipped_ids == ["Q4"]
     assert len(result.failures) == 1
     assert result.failures[0]["profile_id"] == "Q4"
-    assert "identification.aliases.mul.prompt" in result.failures[0]["missing_paths"]
+    assert "identification.labels.mul.prompt" in result.failures[0]["missing_paths"]
     assert not (output_dir / "Q4.json").exists()
 
 
-def test_export_json_filters_incomplete_non_mul_language(tmp_path):
-    """Incomplete non-mul languages should be excluded from written JSON profile."""
+def test_export_json_filters_languages_missing_label_prompt(tmp_path):
+    """Languages without label prompts should be excluded from written JSON profile."""
 
     cache_entities_dir = tmp_path / "cache" / "entities"
     cache_entities_dir.mkdir(parents=True, exist_ok=True)
@@ -1141,14 +1144,8 @@ def test_export_json_filters_incomplete_non_mul_language(tmp_path):
                 "P1": [_build_entity_claim_entity_id("Q3")],
                 "P188": [
                     _build_entity_claim_monolingual("Enter label", "mul"),
-                    _build_entity_claim_monolingual("Ingrese etiqueta", "es"),
+                    _build_entity_claim_monolingual("Enter label", "en"),
                 ],
-                "P189": [
-                    _build_entity_claim_monolingual("Enter description", "mul"),
-                    _build_entity_claim_monolingual("Ingrese descripcion", "es"),
-                ],
-                # Include only mul alias prompt so es is filtered as incomplete.
-                "P190": [_build_entity_claim_monolingual("Enter aliases", "mul")],
             },
         },
     }
@@ -1169,7 +1166,7 @@ def test_export_json_filters_incomplete_non_mul_language(tmp_path):
         entry["language"]
         for entry in result.language_filtering[0]["excluded_languages"]
     }
-    assert "es" in excluded
+    assert excluded == {"en", "es"}
 
     written = json.loads((output_dir / "Q4.json").read_text(encoding="utf-8"))
     assert written["metadata"]["languages"] == ["mul"]

--- a/tests/test_spirit_safe_runtime_artifacts.py
+++ b/tests/test_spirit_safe_runtime_artifacts.py
@@ -16,6 +16,7 @@ from gkc.spirit_safe import (
     validate_packet_structure,
 )
 from gkc.still_charger import create_curation_packet
+from gkc.wikibase import get_meta_wikibase_init_contract_digest
 
 
 @pytest.fixture
@@ -33,7 +34,7 @@ def setup_local_source(fixture_root: Path):
 
 
 def test_build_spiritsafe_semantic_anchor_document(tmp_path: Path, fixture_root: Path):
-    """Semantic anchor builder should emit metadata plus underscore mappings."""
+    """Semantic anchor builder should emit the richer artifact contract."""
 
     root = tmp_path / "spiritsafe"
     copytree(fixture_root, root)
@@ -72,7 +73,7 @@ spiritsafe:
                 "snaktype": "value",
                 "property": "P214",
                 "datavalue": {
-                    "value": "_TribalGovernmentInTheUnitedStates",
+                    "value": "_entity",
                     "type": "string",
                 },
                 "datatype": "string",
@@ -89,12 +90,19 @@ spiritsafe:
     assert anchors["metadata"]["property_count"] == 0
     assert anchors["metadata"]["item_count"] == 1
     assert isinstance(anchors["metadata"]["generated_at"], str)
-    assert anchors["entities"] == {
-        "_TribalGovernmentInTheUnitedStates": {
-            "id": "Q4",
-            "entity": "https://datadistillery.wikibase.cloud/entity/Q4",
-        }
-    }
+    assert (
+        anchors["metadata"]["contract_digest"]
+        == get_meta_wikibase_init_contract_digest()
+    )
+    assert anchors["validation"]["status"] in {"valid", "warning", "error"}
+    assert (
+        anchors["entities"]["_entity"]["id"]
+        == "https://datadistillery.wikibase.cloud/entity/Q4"
+    )
+    assert anchors["entities"]["_entity"]["kind"] == "item"
+    assert isinstance(anchors["entities"]["_entity"]["required"], dict)
+    assert isinstance(anchors["entities"]["_entity"]["resolved"], dict)
+    assert isinstance(anchors["entities"]["_entity"]["validation"], dict)
 
 
 def test_build_spiritsafe_semantic_anchor_document_includes_property_datatype(
@@ -162,13 +170,14 @@ spiritsafe:
 
     assert anchors["metadata"]["property_count"] == 1
     assert anchors["metadata"]["item_count"] == 0
-    assert anchors["entities"] == {
-        "_time": {
-            "id": "P192",
-            "entity": "https://datadistillery.wikibase.cloud/entity/P192",
-            "datatype": "time",
-        }
-    }
+    assert (
+        anchors["entities"]["_time"]["id"]
+        == "https://datadistillery.wikibase.cloud/entity/P192"
+    )
+    assert anchors["entities"]["_time"]["kind"] == "property"
+    assert anchors["entities"]["_time"]["datatype"] == "time"
+    assert isinstance(anchors["entities"]["_time"]["required"], dict)
+    assert isinstance(anchors["entities"]["_time"]["resolved"], dict)
 
 
 def test_build_spiritsafe_semantic_anchor_document_marks_internal_entries(
@@ -227,7 +236,8 @@ spiritsafe:
 
     assert anchors["metadata"]["property_count"] == 0
     assert anchors["metadata"]["item_count"] == 0
-    assert anchors["entities"] == {}
+    assert anchors["entities"]["_entity"]["id"] is None
+    assert anchors["entities"]["_entity"]["resolved"] is None
 
 
 def test_build_spiritsafe_semantic_anchor_document_requires_config(
@@ -281,7 +291,7 @@ spiritsafe:
                 "snaktype": "value",
                 "property": "P214",
                 "datavalue": {
-                    "value": "_TribalGovernmentInTheUnitedStates",
+                    "value": "_entity",
                     "type": "string",
                 },
                 "datatype": "string",
@@ -299,12 +309,12 @@ spiritsafe:
     assert output_path.exists()
     assert anchors["metadata"]["property_count"] == 0
     assert anchors["metadata"]["item_count"] == 1
-    assert anchors["entities"] == {
-        "_TribalGovernmentInTheUnitedStates": {
-            "id": "Q4",
-            "entity": "https://datadistillery.wikibase.cloud/entity/Q4",
-        }
-    }
+    assert anchors["validation"]["error_count"] >= 0
+    assert (
+        anchors["entities"]["_entity"]["id"]
+        == "https://datadistillery.wikibase.cloud/entity/Q4"
+    )
+    assert anchors["entities"]["_entity"]["kind"] == "item"
 
 
 def test_load_profile_reads_json_profile_document():

--- a/tests/test_wikibase.py
+++ b/tests/test_wikibase.py
@@ -1,16 +1,23 @@
 """Tests for Wikibase-specific helpers and registries."""
 
+from copy import deepcopy
+
 import pytest
 
 import gkc
+from gkc import bottler
 from gkc.wikibase import (
+    MetaWikibaseCompiledEntity,
     MetaWikibaseInitEntity,
     MetaWikibaseInitIndex,
+    MetaWikibaseSeedCompilation,
+    MetaWikibaseSeedPlan,
     MetaWikibaseSemanticAnchorContract,
     WikibaseDatatypeSpec,
     build_meta_wikibase_init_index,
     build_meta_wikibase_semantic_anchor_contract,
     canonicalize_wikibase_datatype,
+    compile_meta_wikibase_seed,
     get_meta_wikibase_init_entity,
     get_wikibase_datatype_spec,
     is_known_wikibase_datatype,
@@ -20,6 +27,7 @@ from gkc.wikibase import (
     load_wikibase_datatype_registry,
     load_wikibase_datatype_registry_json,
     normalize_meta_wikibase_init_document,
+    plan_meta_wikibase_seed_baseline,
 )
 
 
@@ -168,16 +176,262 @@ def test_build_meta_wikibase_semantic_anchor_contract_uses_active_prefix():
     assert contract.requirements["__has_statement"].datatype == "wikibase-item"
 
 
+def test_compile_meta_wikibase_seed_builds_symbolic_payloads():
+    compilation = compile_meta_wikibase_seed()
+
+    assert isinstance(compilation, MetaWikibaseSeedCompilation)
+    assert isinstance(compilation.entities["instance_of"], MetaWikibaseCompiledEntity)
+
+    property_payload = compilation.entities["instance_of"].payload
+    assert property_payload["type"] == "property"
+    assert property_payload["datatype"] == "wikibase-item"
+    assert property_payload["labels"]["en"]["value"] == "instance of"
+    assert (
+        property_payload["claims"]["_name_identifier"][0]["mainsnak"]["datavalue"][
+            "value"
+        ]
+        == "_instance_of"
+    )
+
+    item_payload = compilation.entities["entity_profile"].payload
+    assert item_payload["type"] == "item"
+    assert "datatype" not in item_payload
+    assert (
+        item_payload["claims"]["_subclass_of"][0]["mainsnak"]["datavalue"]["value"][
+            "id"
+        ]
+        == "_entity"
+    )
+    assert (
+        "numeric-id"
+        not in item_payload["claims"]["_subclass_of"][0]["mainsnak"]["datavalue"][
+            "value"
+        ]
+    )
+
+    error_message_claim = compilation.entities["wikibase-item"].payload["claims"][
+        "_error_message"
+    ][0]
+    assert error_message_claim["mainsnak"]["datavalue"]["type"] == "monolingualtext"
+    assert error_message_claim["mainsnak"]["datavalue"]["value"]["language"] == "mul"
+
+
+def test_compile_meta_wikibase_seed_uses_package_language_for_display_text(
+    monkeypatch,
+):
+    monkeypatch.setattr(gkc, "get_languages", lambda: "fr")
+
+    compilation = compile_meta_wikibase_seed()
+
+    payload = compilation.entities["instance_of"].payload
+    assert payload["labels"]["fr"]["value"] == "instance of"
+    assert payload["descriptions"]["fr"]["value"] == (
+        "type to which this subject belongs or corresponds"
+    )
+
+
+def test_plan_meta_wikibase_seed_baseline_compares_live_state_and_requires_mul():
+    current_entities = {
+        "_wikibase-item": {
+            "id": "Q50",
+            "type": "item",
+            "labels": {"en": {"language": "en", "value": "wikibase-item"}},
+            "descriptions": {
+                "en": {
+                    "language": "en",
+                    "value": "wikibase item property template used to set a data type for a statement, reference, or qualifier and any additional specifications",
+                }
+            },
+            "claims": {
+                "P1": [
+                    {
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P1",
+                            "datavalue": {
+                                "type": "wikibase-entityid",
+                                "value": {
+                                    "entity-type": "item",
+                                    "id": "Q99",
+                                    "numeric-id": 99,
+                                },
+                            },
+                        },
+                        "type": "statement",
+                        "rank": "normal",
+                    }
+                ],
+                "P214": [
+                    {
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P214",
+                            "datavalue": {
+                                "type": "string",
+                                "value": "_wikibase-item",
+                            },
+                        },
+                        "type": "statement",
+                        "rank": "normal",
+                    }
+                ],
+                "P168": [
+                    {
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P168",
+                            "datavalue": {
+                                "type": "monolingualtext",
+                                "value": {
+                                    "language": "mul",
+                                    "text": "Item must be or resolve to a valid QID identifier.",
+                                },
+                            },
+                        },
+                        "type": "statement",
+                        "rank": "normal",
+                    }
+                ],
+            },
+        }
+    }
+    entity_id_to_internal_name_identifier = {
+        "P1": "_instance_of",
+        "P168": "_error_message",
+        "P214": "_name_identifier",
+        "Q99": "_wikibase_statement_type",
+    }
+
+    plan = plan_meta_wikibase_seed_baseline(
+        current_entities_by_internal_name_identifier=current_entities,
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+    )
+
+    matching_entry = next(
+        operation
+        for operation in plan.operations
+        if operation.internal_name_identifier == "_wikibase-item"
+    )
+    assert matching_entry.action == "skip"
+    assert matching_entry.current_entity_id == "Q50"
+
+    invalid_current_entities = deepcopy(current_entities)
+    invalid_current_entities["_wikibase-item"]["claims"]["P168"][0]["mainsnak"][
+        "datavalue"
+    ]["value"]["language"] = "en"
+
+    invalid_plan = plan_meta_wikibase_seed_baseline(
+        current_entities_by_internal_name_identifier=invalid_current_entities,
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+    )
+    invalid_entry = next(
+        operation
+        for operation in invalid_plan.operations
+        if operation.internal_name_identifier == "_wikibase-item"
+    )
+    assert invalid_entry.action == "update"
+    assert "_error_message.language" in (invalid_entry.changed_fields or [])
+
+
+def test_compile_meta_wikibase_seed_uses_bottler_primitives(monkeypatch):
+    call_counts = {"shell": 0, "claim": 0, "claim_from_datavalue": 0}
+
+    original_build_entity_shell = bottler.EntityShellBuilder.build_entity_shell
+    original_create_claim = bottler.ClaimBuilder.create_claim
+    original_create_claim_from_datavalue = (
+        bottler.ClaimBuilder.create_claim_from_datavalue
+    )
+
+    def counting_build_entity_shell(self, entity_metadata):
+        call_counts["shell"] += 1
+        return original_build_entity_shell(self, entity_metadata)
+
+    def counting_create_claim(
+        self,
+        property_id,
+        value,
+        datatype,
+        transform_config=None,
+        qualifiers=None,
+        references=None,
+        rank="normal",
+    ):
+        call_counts["claim"] += 1
+        return original_create_claim(
+            self,
+            property_id,
+            value,
+            datatype,
+            transform_config,
+            qualifiers,
+            references,
+            rank,
+        )
+
+    def counting_create_claim_from_datavalue(
+        self, property_id, datavalue, qualifiers=None, references=None, rank="normal"
+    ):
+        call_counts["claim_from_datavalue"] += 1
+        return original_create_claim_from_datavalue(
+            self,
+            property_id,
+            datavalue,
+            qualifiers=qualifiers,
+            references=references,
+            rank=rank,
+        )
+
+    monkeypatch.setattr(
+        bottler.EntityShellBuilder,
+        "build_entity_shell",
+        counting_build_entity_shell,
+    )
+    monkeypatch.setattr(
+        bottler.ClaimBuilder,
+        "create_claim",
+        counting_create_claim,
+    )
+    monkeypatch.setattr(
+        bottler.ClaimBuilder,
+        "create_claim_from_datavalue",
+        counting_create_claim_from_datavalue,
+    )
+
+    compilation = compile_meta_wikibase_seed()
+
+    assert len(compilation.entities) > 0
+    assert call_counts["shell"] == len(compilation.entities)
+    assert call_counts["claim"] > 0
+    assert call_counts["claim_from_datavalue"] > 0
+
+
+def test_plan_meta_wikibase_seed_baseline_returns_dry_run_operations():
+    plan = plan_meta_wikibase_seed_baseline()
+
+    assert isinstance(plan, MetaWikibaseSeedPlan)
+    assert len(plan.operations) > 0
+    assert all(operation.action == "create" for operation in plan.operations)
+    assert plan.operations == sorted(
+        plan.operations,
+        key=lambda operation: operation.internal_name_identifier,
+    )
+    assert plan.operations[0].payload["type"] in {"item", "property"}
+
+
 def test_wikibase_helpers_are_exported_from_package_namespace():
     """Top-level gkc exports include the initial wikibase registry helpers."""
+    assert hasattr(gkc, "MetaWikibaseCompiledEntity")
     assert hasattr(gkc, "MetaWikibaseInitEntity")
     assert hasattr(gkc, "MetaWikibaseInitIndex")
     assert hasattr(gkc, "MetaWikibaseInitMetadata")
     assert hasattr(gkc, "MetaWikibaseSemanticAnchorContract")
     assert hasattr(gkc, "WikibaseDatatypeSpec")
+    assert hasattr(gkc, "MetaWikibaseSeedCompilation")
+    assert hasattr(gkc, "MetaWikibaseSeedPlan")
     assert hasattr(gkc, "build_meta_wikibase_init_index")
     assert hasattr(gkc, "build_meta_wikibase_semantic_anchor_contract")
     assert hasattr(gkc, "canonicalize_wikibase_datatype")
+    assert hasattr(gkc, "compile_meta_wikibase_seed")
     assert hasattr(gkc, "get_meta_wikibase_init_entity")
     assert hasattr(gkc, "get_wikibase_datatype_spec")
     assert hasattr(gkc, "is_known_wikibase_datatype")
@@ -187,3 +441,4 @@ def test_wikibase_helpers_are_exported_from_package_namespace():
     assert hasattr(gkc, "load_wikibase_datatype_registry")
     assert hasattr(gkc, "load_wikibase_datatype_registry_json")
     assert hasattr(gkc, "normalize_meta_wikibase_init_document")
+    assert hasattr(gkc, "plan_meta_wikibase_seed_baseline")


### PR DESCRIPTION
## Summary

- add Meta-Wikibase seed compilation and dry-run baseline planning
- seed the initial Wikimedia Commons profile and related helper/value-list entities
- upgrade semantic anchors to URI-backed artifacts with top-level and per-entity validation state
- refresh CLI, runtime tests, and architecture docs for the new contract

## Verification

- poetry run black --check gkc tests
- poetry run ruff check gkc tests
- poetry run pytest

Closes #235.

Continues #216.
