### PR TITLE
feat: align Meta-Wikibase cache and talk-page sync

### DIFF
--- a/docs/architecture/meta-wikibase/DataDistillery-Wikibase.md
+++ b/docs/architecture/meta-wikibase/DataDistillery-Wikibase.md
@@ -1,6 +1,6 @@
 # Data Distillery Wikibase
 
-Data Distillery Wikibase (`datadistillery.wikibase.cloud`) is the semantic registry for GKC ontology terms, profile metadata relationships, statement/value-list semantics, and multilingual guidance content that must be queryable and collaboratively maintained.
+Data Distillery Wikibase (`datadistillery.wikibase.cloud`) is the seminal reference implementation for the [metaWikibase infrastructure](index.md). It provides the semantic registry for GKC ontology terms, profile metadata relationships, statement/value-list semantics, and multilingual guidance content that must be queryable and collaboratively maintained.
 
 This page describes the current reference implementation of the generic [Meta-Wikibase Architecture](index.md).
 

--- a/docs/architecture/meta-wikibase/index.md
+++ b/docs/architecture/meta-wikibase/index.md
@@ -99,12 +99,12 @@ Current runtime use is limited to endpoint resolution plus preservation of seman
 
 In addition to the instance-targeting config file, `gkc` now ships a package-owned Meta-Wikibase initialization fixture under `gkc/registry/meta_wb_init.yaml`.
 
-This fixture is not environment config. It is a package artifact that defines the authored backbone terms needed to bootstrap a clean Meta-Wikibase with the minimum ontology required by `gkc` and SpiritSafe.
+This fixture is not environment config. It is the source ontology contract used to drive convergence and semantic-anchor artifact generation.
 
 The current fixture covers:
 
 - backbone properties such as `instance_of`, `subclass_of`, `name_identifier`, and profile/statement linkage terms
-- backbone item classes such as `entity`, `entity_profile`, `entity_statement`, and `value_list`
+- backbone item classes such as `entity`, `entity_profile`, `entity_statement`, `sparql_value_list`, and `embedded_value_list`
 - datatype template items such as `wikibase-item`, `url`, `time`, and `monolingualtext`
 
 ## Datatype Contract In The Init Fixture
@@ -133,6 +133,7 @@ The initial helper surface includes:
 - normalizing authored datatype values against the canonical datatype registry
 - building a typed index over properties, items, and derived internal name identifiers
 - compiling the typed index into a required internal semantic-anchor contract using the active internal prefix
+- preparing normalized contract views for dry-run conformance planning and optional execution
 
 This keeps the fixture, datatype registry, and later ontology-init logic aligned behind one Wikibase-specific access layer.
 
@@ -140,52 +141,42 @@ This keeps the fixture, datatype registry, and later ontology-init logic aligned
 
 For the conceptual overview, lifecycle, and runtime usage model, see [Semantic Anchors](semantic-anchors.md).
 
-The current implementation treats semantic-anchor evaluation as a narrow conformance problem.
+Semantic-anchor processing is a contract-convergence workflow.
 
-The package-owned init fixture defines the required internal ontology backbone. The SpiritSafe semantic-anchor artifact is then validated against that backbone for runtime use.
+The package-owned init fixture defines required ontology semantics. Live Meta-Wikibase state is evaluated against that contract through cache-backed planning, with report-first behavior and optional execution.
 
-The validation boundary is intentionally small:
+The conformance boundary includes:
 
-- load the package-owned ontology seed
-- compile the required internal semantic-anchor contract
-- load a semantic-anchor document
-- validate required internal names, kinds, and property datatypes
-- emit machine-readable results plus fermenter-style notices
-
-This implementation does not attempt to validate class hierarchy, solve ontology-init ordering, or perform a separate live SPARQL conformance pass.
+- load and normalize `meta_wb_init.yaml`
+- resolve each declared internal entity against current state
+- emit dry-run create/update/no-op requirements
+- optionally execute corrections through standard write boundaries
+- transform resolved state to `config/semantic_anchors.json`
+- validate artifact completeness and datatype/kind conformance
 
 The implementation split is:
 
-- `gkc.wikibase` compiles the required semantic-anchor contract from `meta_wb_init.yaml`
-- `gkc.fermenter` validates semantic-anchor documents against that contract
-- `gkc spiritsafe semantic-anchors validate` exposes the operator-facing CLI entry point
+- `gkc.wikibase` normalizes the source contract and compiles required anchor requirements
+- `gkc.spirit_safe` owns planning/execution orchestration and runtime resolver loading
+- `gkc.fermenter` validates semantic-anchor documents against the compiled requirements
 
-When a local SpiritSafe root is available, workflows may also rebuild semantic anchors from current cache entities and compare them with a stored artifact to detect staleness.
+When a local SpiritSafe root is available, workflows may rebuild semantic anchors from current cache entities and compare them with the stored artifact to detect drift.
 
 Current runtime consumers in `gkc.spirit_safe` now resolve internal ontology concepts through a shared semantic-anchor lookup layer rather than carrying inline DD-specific P/Q ids. That keeps profile/entity-index generation aligned with the generated SpiritSafe artifact and confines anchor loading/validation to one integration boundary.
 
-## Continuing Work on Semantic Definition
+## Value-List Classifications
 
-The current `meta_wb_init.yaml` fixture is intended to capture the minimum authored backbone needed to bootstrap the Meta-Wikibase and support the present runtime architecture.
+Value-list semantics are class-driven:
 
-This means the seed intentionally includes:
+- `sparql_value_list` requires a SPARQL talk-page block and endpoint semantics
+- `embedded_value_list` requires a JSON talk-page block
 
-- core entity/profile/statement/value-list concepts
-- backbone linkage properties
-- datatype template items aligned to the canonical runtime datatype registry
-- selected operational guidance terms already exercised in code and workflow design
+Both list classes still resolve to the same runtime candidate row shape:
 
-It also intentionally defers some deeper semantic layers until they are hardened through real use cases.
+- `item`
+- `itemLabel`
 
-In particular, `gkc` is not currently trying to fully enumerate:
-
-- richer cardinality concepts beyond the lightweight limits already in use
-- separate ontology terms for every value-constraint or coercion mode
-- the full class hierarchy needed to distinguish abstract statement definitions from profile-context-specific statement use
-
-This is a deliberate design choice, not an omission by accident.
-
-The expectation is that these concepts will be added as contribution workflows, validation primitives, and cross-system shipping behavior become concrete enough to justify stable semantic labels in the Meta-Wikibase and its reference implementation.
+SPARQL hydration stays separate from talk-page extraction.
 
 ## Boundary
 

--- a/docs/architecture/meta-wikibase/semantic-anchors.md
+++ b/docs/architecture/meta-wikibase/semantic-anchors.md
@@ -1,200 +1,111 @@
 # Semantic Anchors
 
-Semantic anchors are the bridge between the authored internal ontology in the Meta-Wikibase and the stable IDs that runtime code needs to use.
+Semantic anchors are the transformed runtime artifact that binds authored ontology semantics in `meta_wb_init.yaml` to concrete Meta-Wikibase entity URIs.
 
-Plain meaning: a semantic anchor says that an internal concept such as `_entity_profile`, `_has_statement`, or `_value_list` currently resolves to a specific Wikibase entity ID such as `Q3`, `P157`, or `Q7`.
+Plain meaning: runtime code resolves internal names such as `_has_statement` and `_name_identifier` from one deterministic artifact file, instead of hardcoding P/Q ids.
 
-They exist so that runtime code can depend on semantic names instead of baking Data Distillery-specific `P` and `Q` IDs into implementation logic.
+## Source Contract And Artifact
 
-## Why They Exist
+The architecture has two distinct layers that must stay synchronized.
 
-The project needs three things at once:
+### Source Contract
 
-- an authored ontology that lives in a Meta-Wikibase
-- deterministic runtime artifacts that can be stored in SpiritSafe
-- runtime code that stays aligned with the authored ontology even if concrete IDs change
+`gkc/registry/meta_wb_init.yaml` is the source contract.
 
-Semantic anchors are the narrow contract that connects those layers.
+It defines the required ontology entities, required authored fields, expected datatypes for properties, and value-list classes.
 
-Instead of asking runtime code to know that `_has_value` means `P161`, we generate and validate an artifact that says so explicitly.
+### Transformed Artifact
 
-## Core Idea
+`SpiritSafe/config/semantic_anchors.json` is the transformed runtime artifact.
 
-There are three different things involved, and keeping them separate matters.
+It is generated from the source contract plus live Meta-Wikibase resolution and contains stable runtime lookup records keyed by internal name identifier.
 
-### 1. Package-Owned Ontology Seed
+The artifact stores `id` as the full entity URI.
 
-`gkc/registry/meta_wb_init.yaml` defines the minimum authored ontology backbone that `gkc` expects to exist.
+If a simple QID/PID token is needed, resolver helpers derive that from the URI.
 
-This layer defines internal semantic names such as:
+## Operational Lifecycle
 
-- `_entity`
-- `_entity_profile`
-- `_has_statement`
-- `_has_value`
-- `_value_list`
+The contract lifecycle is:
 
-At this layer, we are defining concepts and expected datatypes, not binding to a specific running Wikibase instance.
+1. Load and normalize `meta_wb_init.yaml`.
 
-### 2. SpiritSafe Semantic-Anchor Artifact
+2. Resolve each declared entity against Meta-Wikibase state (via SpiritSafe cache-backed workflows).
 
-`config/semantic_anchors.json` is the materialized artifact that maps those internal names to the concrete IDs currently present in the Meta-Wikibase-backed cache.
+3. Produce a conformance plan and report required corrections.
 
-Typical shape:
+4. Optionally execute corrective actions.
 
-```json
-{
-  "metadata": {
-    "generated_at": "2026-04-04T00:00:00Z",
-    "contract_digest": "4c9f...",
-    "property_count": 12,
-    "item_count": 8
-  },
-  "validation": {
-    "status": "warning",
-    "checked_at": "2026-04-04T00:00:01Z",
-    "required_anchor_count": 20,
-    "matched_anchor_count": 20,
-    "evaluated_anchor_count": 20,
-    "error_count": 0,
-    "warning_count": 2,
-    "freshness_checked": false,
-    "freshness_match": null
-  },
-  "entities": {
-    "_has_statement": {
-      "id": "https://datadistillery.wikibase.cloud/entity/P157",
-      "kind": "property",
-      "datatype": "wikibase-item",
-      "required": {"kind": "property"},
-      "resolved": {"kind": "property"},
-      "validation": {
-        "status": "valid",
-        "notices": []
-      }
-    },
-    "_entity_profile": {
-      "id": "https://datadistillery.wikibase.cloud/entity/Q3",
-      "kind": "item",
-      "required": {"kind": "item"},
-      "resolved": {"kind": "item"},
-      "validation": {
-        "status": "warning",
-        "notices": [
-          {"severity": "warning", "code": "label_missing"}
-        ]
-      }
-    }
-  }
-}
-```
+5. Transform resolved entities into `semantic_anchors.json` with deterministic ordering.
 
-This is both the runtime-facing lookup document and the operator-facing conformance report.
+6. Use shared resolver APIs in `gkc.spirit_safe` for all runtime semantic lookups.
 
-### 3. Runtime Resolver
+Default mode is report-only. Execution is opt-in.
 
-Runtime code in `gkc.spirit_safe` loads the semantic-anchor artifact, validates it against the package-owned contract, and resolves the IDs it needs through a shared resolver.
+## Corrective-Action Semantics
 
-That means runtime code asks for `_has_statement` or `_value_list`, not for a hardcoded `P157` or `Q7`.
+Conformance processing uses this identity precedence:
 
-## Lifecycle
+1. Match by `name identifier` claim.
 
-The intended flow is:
+2. If missing, fallback to label + description (+ datatype for properties).
 
-1. Define the required ontology backbone in `meta_wb_init.yaml`.
+3. If fallback resolves exactly one entity, repair the `name identifier` claim.
 
-2. Author and maintain the concrete ontology terms in the Meta-Wikibase.
+4. If fallback is ambiguous, stop that entity as a hard blocker.
 
-3. Materialize cache entities in SpiritSafe.
+Corrective actions may include:
 
-4. Build `config/semantic_anchors.json` from those cached entities.
+- create missing items/properties
+- repair `name identifier` claim drift
+- align labels, descriptions, and declared authored attributes
+- align `instance of` and `subclass of` semantics
+- align required talk-page payload content for value-list entities
 
-5. Validate that artifact against the package-owned contract.
+## Value-List Talk-Page Contract
 
-6. Load the artifact in runtime code and resolve internal concepts through the shared lookup layer.
+Value-list talk payload extraction is class-coupled.
 
-This keeps the authored semantic layer, the materialized artifact layer, and the runtime layer synchronized while preserving clear boundaries between them.
+- `sparql_value_list` expects a `<sparql>` block on the item talk page
+- `embedded_value_list` expects a `<syntaxhighlight lang="json">` block on the item talk page
 
-## What Semantic Anchors Do And Do Not Do
+For each block type, only the first matching block is extracted.
 
-Semantic anchors do:
+Extraction paths are:
 
-- map internal semantic names to concrete property and item IDs
-- preserve expected property datatypes for runtime checks
-- keep a contract digest and per-entity validation status close to the resolved binding
-- give runtime consumers one stable lookup mechanism
-- let tests and ad hoc callers provide a synthetic anchor document explicitly when they are not operating inside a full SpiritSafe checkout
+- first `<sparql>` -> `SpiritSafe/still/value_lists/<QID>.sparql`
+- first JSON `<syntaxhighlight>` -> `SpiritSafe/still/value_lists/cache/<QID>.json`
 
-Semantic anchors do not:
+SPARQL hydration remains a separate workflow from talk-page extraction.
 
-- replace the authored ontology in the Meta-Wikibase
-- validate every modeling choice in the authored ontology
-- define endpoint URLs, credentials, or other environment configuration
-- eliminate the need for SpiritSafe materialization
+## Runtime Boundary
 
-## Runtime Contract
+Runtime code should treat semantic anchors as a required dependency for ontology concept resolution.
 
-Anchor-backed runtime workflows assume two things are present under a local SpiritSafe root:
+Anchor-backed workflows expect:
 
-- `config/dd-wikibase.yaml` or another supported Meta-Wikibase config filename under `config/`
+- a Meta-Wikibase config file under SpiritSafe `config/`
 - `config/semantic_anchors.json`
 
-The config file supplies the semantic convention needed to interpret internal names:
+When these are unavailable, workflows should fail explicitly rather than silently falling back to stale assumptions.
 
-- `semantic_conventions.name_identifier_property_id`
-- `semantic_conventions.internal_name_identifier_prefix`
+## Module Ownership
 
-The semantic-anchor artifact supplies the actual ID bindings plus the latest build-time validation state.
+Ownership split:
 
-When both are available, runtime consumers such as profile export, value-list hydration, and entity-index generation can resolve internal ontology labels consistently.
+- `gkc.wikibase`: normalize source contract and compile required semantic requirements
+- `gkc.spirit_safe`: conformance orchestration, artifact transform, and runtime resolver loading
+- `gkc.fermenter`: semantic-anchor document validation primitives
 
-When they are not available, anchor-backed workflows fail deliberately rather than silently falling back to stale assumptions.
+## Practical Rules
 
-## Synthetic And Test-Only Use
-
-Not every caller works from a full SpiritSafe checkout.
-
-For tests or ad hoc tooling that only has a temporary `still/entities` directory, the relevant APIs accept an explicit `semantic_anchor_document` argument.
-
-Use that route when:
-
-- constructing synthetic cache fixtures in tests
-- exercising one runtime helper in isolation
-- running outside the standard SpiritSafe directory layout
-
-Do not treat that override path as the normal production contract. The normal production contract is the validated artifact under `config/semantic_anchors.json`.
-
-## Where To Look In The Codebase
-
-The main ownership split is:
-
-- `gkc.wikibase`: compile the package-owned semantic-anchor contract from `meta_wb_init.yaml`
-- `gkc.fermenter`: validate semantic-anchor documents against that contract
-- `gkc.spirit_safe`: build, load, and consume semantic-anchor artifacts during runtime workflows
-
-The main operator-facing CLI routes are:
-
-- `gkc spiritsafe semantic-anchors build`
-- `gkc spiritsafe semantic-anchors validate`
-
-The main runtime consumers currently relying on semantic anchors are:
-
-- JSON profile export
-- value-list discovery and hydration
-- SpiritSafe entity-index generation
-
-## Practical Rule Of Thumb
-
-If you are working on authored ontology structure, start with the package-owned init fixture and the Meta-Wikibase.
-
-If you are working on SpiritSafe artifact maintenance, start with the semantic-anchor build and validate routes.
-
-If you are working on runtime code, never introduce new hardcoded internal `P` or `Q` IDs when the concept should instead resolve through a semantic anchor.
+- Use `meta_wb_init.yaml` as the only authored source for required ontology backbone semantics.
+- Do not edit `SpiritSafe/config/semantic_anchors.json` by hand.
+- Do not introduce hardcoded metaWikibase P/Q ids where semantic anchors exist.
 
 ## Related Documentation
 
 - [Meta-Wikibase Architecture](index.md)
 - [SpiritSafe Architecture](../SpiritSafe/index.md)
+- [Module Contracts](../module-contracts.md)
 - [SpiritSafe CLI](../../gkc/cli/spiritsafe.md)
-- [SpiritSafe API](../../gkc/api/spirit_safe.md)
-- [Fermenter API](../../gkc/api/fermenter.md)

--- a/docs/architecture/module-contracts.md
+++ b/docs/architecture/module-contracts.md
@@ -47,7 +47,7 @@ Responsibility:
 
 - Load SpiritSafe profile sources (GitHub or local).
 - Build JSON Entity Profiles from SpiritSafe cache entities.
-- Extract value-list SPARQL query files from value-list talk pages.
+- Extract value-list talk-page payload blocks based on value-list classification.
 - Hydrate value-list cache artifacts from extracted SPARQL queries.
 - Export profile JSON artifacts for downstream packet assembly and hydration.
 - Provide profile graph metadata and profile-loading utilities.
@@ -270,11 +270,13 @@ Current anchor surface:
 
 ### Flow 2.7: Value-List Query Hydration (Active)
 
-1. `spirit_safe` discovers value-list entities from cache (`P1 -> Q7`).
-2. `mash` reads value-list talk pages and extracts the first `<sparql>` block.
-3. `spirit_safe` writes query files (`queries/QID.sparql`).
-4. `sparql` executes paginated query hydration to `cache/queries/QID.json`.
-5. Failed hydration does not overwrite an existing cache file for that value list.
+1. `spirit_safe` discovers value-list entities and resolves list class semantics.
+2. `mash` reads value-list talk pages and extracts class-coupled payload blocks.
+3. For `sparql_value_list`, `spirit_safe` writes the first `<sparql>` block to `still/value_lists/queries/<QID>.sparql`.
+4. For `embedded_value_list`, `spirit_safe` writes the first `<syntaxhighlight lang="json">` block to `still/value_lists/cache/<QID>.json`.
+5. If a watched talk-page block is deleted, the corresponding materialized artifact is removed on the next sync.
+6. SPARQL hydration runs as a separate step for SPARQL-backed lists and does not overwrite cache on failed refresh.
+7. Meta-Wikibase conformance checks compare against the materialized SpiritSafe query/cache artifacts rather than the live Wikibase talk pages.
 
 ### Flow 2.8: Packet Re-entry and Forward Migration (Planned)
 

--- a/docs/gkc/api/spirit_safe.md
+++ b/docs/gkc/api/spirit_safe.md
@@ -8,7 +8,7 @@ Current architecture:
 
 - Runtime packet assembly loads `still/profiles/<QID>.json` directly.
 - Registry/discovery tooling enumerates `still/profiles/*.json` directly.
-- Value lists are materialized in `still/value_lists/cache/<QID>.json` and consumed as cache artifacts.
+- Value-list artifacts are class-coupled to ontology semantics and materialized under `still/value_lists/`.
 
 ## Quick Start
 
@@ -123,7 +123,7 @@ result = export_entity_profile_json_documents(
 print(result.written_ids)
 ```
 
-When `cache_entities_dir` is part of a normal SpiritSafe checkout, the exporter loads `config/semantic_anchors.json` and the local meta-wikibase config automatically and uses them to resolve internal ontology concepts such as profile class, statement links, prompts, and value-list classification.
+When `cache_entities_dir` is part of a normal SpiritSafe checkout, the exporter loads `config/semantic_anchors.json` and the local meta-wikibase config automatically and uses them to resolve internal ontology concepts such as profile class, statement links, prompts, and value-list classifications.
 
 For the full concept, lifecycle, and runtime boundary, see [Semantic Anchors](../../architecture/meta-wikibase/semantic-anchors.md).
 
@@ -134,10 +134,10 @@ from gkc.spirit_safe import build_entity_profile_json_documents
 
 anchors = {
     "entities": {
-        "_instance_of": {"id": "P1", "datatype": "wikibase-item"},
-        "_entity_profile": {"id": "Q3"},
-        "_has_statement": {"id": "P157", "datatype": "wikibase-item"},
-        "_name_identifier": {"id": "P214", "datatype": "string"},
+        "_instance_of": {"id": "https://datadistillery.wikibase.cloud/entity/P1", "datatype": "wikibase-item"},
+        "_entity_profile": {"id": "https://datadistillery.wikibase.cloud/entity/Q3"},
+        "_has_statement": {"id": "https://datadistillery.wikibase.cloud/entity/P157", "datatype": "wikibase-item"},
+        "_name_identifier": {"id": "https://datadistillery.wikibase.cloud/entity/P214", "datatype": "string"},
     }
 }
 
@@ -147,7 +147,7 @@ documents = build_entity_profile_json_documents(
 )
 ```
 
-### Hydrate Value Lists from Cache Entities
+### Extract And Hydrate Value Lists
 
 ```python
 from gkc.spirit_safe import hydrate_value_lists_from_cache
@@ -159,6 +159,15 @@ result = hydrate_value_lists_from_cache(
 )
 print(result.hydrated_ids)
 ```
+
+Class-coupled value-list contract:
+
+- `sparql_value_list` items are expected to provide a talk-page `<sparql>` block, which is exported to `still/value_lists/queries/<QID>.sparql`.
+- `embedded_value_list` items are expected to provide a talk-page `<syntaxhighlight lang="json">` block, which is exported to `still/value_lists/cache/<QID>.json`.
+- For each block type, only the first matching block is extracted.
+- If the relevant talk-page block is deleted, the corresponding materialized SpiritSafe artifact is removed on the next sync.
+
+SPARQL hydration remains a separate step and applies only to SPARQL-backed value lists. Meta-Wikibase conformance checks compare against these materialized SpiritSafe artifacts rather than the live talk pages.
 
 ## Public API Reference
 

--- a/docs/gkc/cli/profiles.md
+++ b/docs/gkc/cli/profiles.md
@@ -6,11 +6,12 @@ Plain meaning: Work with SpiritSafe-backed Entity Profiles and value-list artifa
 
 The `gkc profile` command group handles profile export, value-list hydration, and profile package loading.
 
-Profile export and value-list hydration now rely on semantic anchors to resolve internal ontology concepts. For background, see [Semantic Anchors](../../architecture/meta-wikibase/semantic-anchors.md).
+Profile export and value-list processing rely on semantic anchors to resolve internal ontology concepts and value-list classifications. For background, see [Semantic Anchors](../../architecture/meta-wikibase/semantic-anchors.md).
 
 Current subcommands:
 
 - `gkc profile export-json`
+- `gkc profile value-lists sync`
 - `gkc profile value-lists hydrate`
 - `gkc profile package load`
 - `gkc profile package validate`
@@ -38,31 +39,49 @@ Common options:
 
 When `--cache-entities-dir` points into a normal local SpiritSafe checkout, this route loads `config/semantic_anchors.json` and local Meta-Wikibase semantic conventions automatically. If you point it at an ad hoc cache directory outside that layout, use the Python API instead and pass an explicit semantic-anchor document.
 
-### `gkc profile value-lists hydrate`
+### `gkc profile value-lists sync`
 
-Export value-list queries and hydrate `still/value_lists/cache/<QID>.json`.
+Sync only the materialized SpiritSafe value-list artifacts from the watched talk-page blocks.
 
 ```bash
-gkc profile value-lists hydrate --source local --local-root /path/to/SpiritSafe
+gkc profile value-lists sync --source local --local-root /path/to/SpiritSafe
 ```
 
 Common options:
 
 - `--cache-entities-dir`: Override the cache entity directory.
 - `--queries-dir`: Override the output directory for exported SPARQL query files.
-- `--cache-queries-dir`: Override the hydrated value-list cache directory.
-- `--value-list-id`: Restrict hydration to one or more specific value-list QIDs.
+- `--cache-queries-dir`: Override the embedded JSON value-list cache directory.
+- `--value-list-id`: Restrict sync to one or more specific value-list QIDs.
 - `--api-url`: API URL used for talk-page retrieval.
-- `--endpoint`: SPARQL endpoint used for hydration.
-- `--page-size`: Query page size for pagination.
-- `--max-results`: Maximum total results per value list query.
-- `--continue-on-error`: Keep hydrating other value lists if one fails.
+- `--continue-on-error`: Keep syncing other value lists if one fails.
 - `--source`: Source override, either `github` or `local`.
 - `--local-root`: Local SpiritSafe root when using `--source local`.
 - `--repo`: GitHub repository slug when using `--source github`.
 - `--ref`: Git ref when using `--source github`.
 
-Like profile export, this route expects semantic-anchor-backed local context when operating from a SpiritSafe checkout.
+### `gkc profile value-lists hydrate`
+
+Run the same artifact sync and then hydrate SPARQL-backed value-list caches.
+
+```bash
+gkc profile value-lists hydrate --source local --local-root /path/to/SpiritSafe
+```
+
+Additional hydration options:
+
+- `--endpoint`: SPARQL endpoint used for hydration.
+- `--page-size`: Query page size for pagination.
+- `--max-results`: Maximum total results per value list query.
+
+Contract notes:
+
+- `sparql_value_list` items are expected to provide a talk-page `<sparql>` block.
+- `embedded_value_list` items are expected to provide a talk-page `<syntaxhighlight lang="json">` block.
+- For each block type, only the first matching block is extracted.
+- SPARQL hydration is a separate stage and applies only to SPARQL-backed lists.
+
+Like profile export, these routes expect semantic-anchor-backed local context when operating from a SpiritSafe checkout.
 
 ### `gkc profile package load`
 

--- a/docs/gkc/cli/spiritsafe.md
+++ b/docs/gkc/cli/spiritsafe.md
@@ -39,7 +39,9 @@ Common options:
 
 Build the SpiritSafe semantic anchor artifact from local cache entities.
 
-This command materializes the runtime lookup document that binds internal ontology names such as `_entity_profile` or `_has_statement` to the concrete IDs currently present in the SpiritSafe-backed Meta-Wikibase cache.
+This command materializes the transformed runtime lookup document derived from the package contract in `meta_wb_init.yaml` and current cache-backed Meta-Wikibase resolution.
+
+The artifact binds internal ontology names such as `_entity_profile` and `_has_statement` to concrete entity URIs in `config/semantic_anchors.json`.
 
 ```bash
 gkc spiritsafe semantic-anchors build --source local --local-root /path/to/SpiritSafe
@@ -80,8 +82,9 @@ Common options:
 This command checks the runtime contract only:
 
 - required internal semantic anchors are present
-- property anchors resolve to property IDs and carry the expected datatype
-- item anchors resolve to item IDs
+- property anchors resolve to property ids and carry the expected datatype
+- item anchors resolve to item ids
+- anchor `id` values use URI form for stable runtime resolution
 - the artifact shape is valid
 
 When `--check-current-cache` is used, stale-artifact drift against current cache-derived anchors is also reported.

--- a/gkc/__init__.py
+++ b/gkc/__init__.py
@@ -115,6 +115,7 @@ from gkc.spirit_safe import (
     SpiritSafeSourceConfig,
     ValueListHydrationResult,
     build_entity_profile_json_documents,
+    build_spiritsafe_meta_wikibase_conformance_report,
     build_spiritsafe_semantic_anchor_document,
     discover_value_list_ids,
     export_entity_profile_json_documents,
@@ -132,6 +133,8 @@ from gkc.spirit_safe import (
     resolve_query_ref,
     resolve_spiritsafe_meta_wikibase_config,
     set_spirit_safe_source,
+    sync_spiritsafe_meta_wikibase_seed,
+    sync_value_list_artifacts_from_cache,
     validate_packet_structure,
 )
 from gkc.still_charger import (
@@ -333,6 +336,7 @@ __all__ = [
     "LookupCache",
     "LookupFetcher",
     "build_entity_profile_json_documents",
+    "build_spiritsafe_meta_wikibase_conformance_report",
     "build_spiritsafe_semantic_anchor_document",
     "create_curation_packet",
     "discover_value_list_ids",
@@ -349,5 +353,7 @@ __all__ = [
     "resolve_profile_link",
     "resolve_profile_path",
     "resolve_query_ref",
+    "sync_spiritsafe_meta_wikibase_seed",
+    "sync_value_list_artifacts_from_cache",
     "validate_packet_structure",
 ]

--- a/gkc/cli.py
+++ b/gkc/cli.py
@@ -597,9 +597,59 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="profile_value_lists_command"
     )
 
+    profile_value_lists_sync = profile_value_lists_subparsers.add_parser(
+        "sync",
+        help="Sync talk-page-derived value-list artifacts without SPARQL hydration",
+    )
+    profile_value_lists_sync.add_argument(
+        "--cache-entities-dir",
+        help=(
+            "Directory containing SpiritSafe cache entity JSON files "
+            f"(defaults to <local_root>/{layout.entities_path} when using --source local)"
+        ),
+    )
+    profile_value_lists_sync.add_argument(
+        "--queries-dir",
+        help=(
+            "Directory to write SPARQL query files "
+            f"(defaults to <local_root>/{layout.value_list_queries_path} when using --source local)"
+        ),
+    )
+    profile_value_lists_sync.add_argument(
+        "--cache-queries-dir",
+        help=(
+            "Directory to write embedded JSON value-list artifacts "
+            f"(defaults to <local_root>/{layout.value_list_cache_path} when using --source local)"
+        ),
+    )
+    profile_value_lists_sync.add_argument(
+        "--value-list-id",
+        action="append",
+        dest="value_list_ids",
+        help="Optional value list QID filter (repeatable)",
+    )
+    profile_value_lists_sync.add_argument(
+        "--api-url",
+        default=runtime_config.api_url,
+        help=(
+            "Wikibase API URL used for talk-page retrieval "
+            "(default: META_WB_API_URL env var, config file, or Data Distillery API)"
+        ),
+    )
+    profile_value_lists_sync.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        help="Continue syncing other value lists when one fails",
+    )
+    _add_profile_source_args(profile_value_lists_sync)
+    profile_value_lists_sync.set_defaults(
+        handler=_handle_profile_value_lists_sync,
+        command_path="profile.value_lists.sync",
+    )
+
     profile_value_lists_hydrate = profile_value_lists_subparsers.add_parser(
         "hydrate",
-        help="Extract talk-page SPARQL queries for GKC Value Lists and hydrate cache",
+        help="Sync value-list artifacts and hydrate SPARQL-backed caches",
     )
     profile_value_lists_hydrate.add_argument(
         "--cache-entities-dir",
@@ -2037,73 +2087,135 @@ def _merge_profile_export_summary(
     return str(summary_path.resolve())
 
 
+def _resolve_profile_value_list_paths(
+    args: argparse.Namespace,
+) -> tuple[Path, Path, Path, list[str]]:
+    cache_entities_dir: Optional[Path]
+    queries_dir: Optional[Path]
+    cache_queries_dir: Optional[Path]
+
+    if args.cache_entities_dir:
+        cache_entities_dir = Path(args.cache_entities_dir)
+    else:
+        source = gkc.get_spirit_safe_source()
+        cache_entities_dir = (
+            _resolve_local_spiritsafe_layout(source.local_root).entities_dir(
+                source.local_root
+            )
+            if source.mode == "local" and source.local_root is not None
+            else None
+        )
+
+    if args.queries_dir:
+        queries_dir = Path(args.queries_dir)
+    else:
+        source = gkc.get_spirit_safe_source()
+        queries_dir = (
+            _resolve_local_spiritsafe_layout(source.local_root).value_list_queries_dir(
+                source.local_root
+            )
+            if source.mode == "local" and source.local_root is not None
+            else None
+        )
+
+    if args.cache_queries_dir:
+        cache_queries_dir = Path(args.cache_queries_dir)
+    else:
+        source = gkc.get_spirit_safe_source()
+        cache_queries_dir = (
+            _resolve_local_spiritsafe_layout(source.local_root).value_list_cache_dir(
+                source.local_root
+            )
+            if source.mode == "local" and source.local_root is not None
+            else None
+        )
+
+    if cache_entities_dir is None:
+        raise CLIError(
+            "Unable to resolve cache entities directory. Provide "
+            "--cache-entities-dir or use --source local with --local-root."
+        )
+    if queries_dir is None:
+        raise CLIError(
+            "Unable to resolve queries directory. Provide --queries-dir or use "
+            "--source local with --local-root."
+        )
+    if cache_queries_dir is None:
+        raise CLIError(
+            "Unable to resolve cache queries directory. Provide "
+            "--cache-queries-dir or use --source local with --local-root."
+        )
+
+    if not cache_entities_dir.exists():
+        raise CLIError(f"Cache entities directory not found: {cache_entities_dir}")
+
+    selected_ids = sorted(set(args.value_list_ids or []))
+    if not selected_ids:
+        selected_ids = gkc.discover_value_list_ids(cache_entities_dir)
+
+    return cache_entities_dir, queries_dir, cache_queries_dir, selected_ids
+
+
+def _handle_profile_value_lists_sync(args: argparse.Namespace) -> dict[str, Any]:
+    """Sync talk-page-derived value-list artifacts without SPARQL hydration."""
+    previous_source, source_overridden = _apply_source_override(args)
+
+    try:
+        cache_entities_dir, queries_dir, cache_queries_dir, selected_ids = (
+            _resolve_profile_value_list_paths(args)
+        )
+
+        result = gkc.sync_value_list_artifacts_from_cache(
+            cache_entities_dir=cache_entities_dir,
+            queries_dir=queries_dir,
+            cache_queries_dir=cache_queries_dir,
+            api_url=args.api_url,
+            value_list_ids=selected_ids,
+            fail_on_error=not args.continue_on_error,
+        )
+
+        failure_count = len(result.failures)
+        ok = failure_count == 0
+        message = (
+            "Synchronized value-list artifacts: "
+            f"{len(result.discovered_ids)} inspected"
+        )
+        if failure_count:
+            message += f" ({failure_count} failures)"
+
+        details = {
+            "cache_entities_dir": str(cache_entities_dir.resolve()),
+            "queries_dir": result.queries_dir,
+            "cache_queries_dir": result.cache_queries_dir,
+            "value_list_ids_requested": selected_ids,
+            "discovered_count": len(result.discovered_ids),
+            "query_files_written": result.query_files_written,
+            "cache_files_written": result.cache_files_written,
+            "query_files_deleted": result.query_files_deleted,
+            "cache_files_deleted": result.cache_files_deleted,
+            "failures": result.failures,
+        }
+
+        return {
+            "command": args.command_path,
+            "ok": ok,
+            "message": message,
+            "details": details,
+        }
+    except Exception as exc:
+        raise CLIError(str(exc)) from exc
+    finally:
+        _restore_source_override(previous_source, source_overridden)
+
+
 def _handle_profile_value_lists_hydrate(args: argparse.Namespace) -> dict[str, Any]:
     """Extract value-list SPARQL and hydrate cache/queries artifacts."""
     previous_source, source_overridden = _apply_source_override(args)
 
     try:
-        cache_entities_dir: Optional[Path]
-        queries_dir: Optional[Path]
-        cache_queries_dir: Optional[Path]
-
-        if args.cache_entities_dir:
-            cache_entities_dir = Path(args.cache_entities_dir)
-        else:
-            source = gkc.get_spirit_safe_source()
-            cache_entities_dir = (
-                _resolve_local_spiritsafe_layout(source.local_root).entities_dir(
-                    source.local_root
-                )
-                if source.mode == "local" and source.local_root is not None
-                else None
-            )
-
-        if args.queries_dir:
-            queries_dir = Path(args.queries_dir)
-        else:
-            source = gkc.get_spirit_safe_source()
-            queries_dir = (
-                _resolve_local_spiritsafe_layout(
-                    source.local_root
-                ).value_list_queries_dir(source.local_root)
-                if source.mode == "local" and source.local_root is not None
-                else None
-            )
-
-        if args.cache_queries_dir:
-            cache_queries_dir = Path(args.cache_queries_dir)
-        else:
-            source = gkc.get_spirit_safe_source()
-            cache_queries_dir = (
-                _resolve_local_spiritsafe_layout(
-                    source.local_root
-                ).value_list_cache_dir(source.local_root)
-                if source.mode == "local" and source.local_root is not None
-                else None
-            )
-
-        if cache_entities_dir is None:
-            raise CLIError(
-                "Unable to resolve cache entities directory. Provide "
-                "--cache-entities-dir or use --source local with --local-root."
-            )
-        if queries_dir is None:
-            raise CLIError(
-                "Unable to resolve queries directory. Provide --queries-dir or use "
-                "--source local with --local-root."
-            )
-        if cache_queries_dir is None:
-            raise CLIError(
-                "Unable to resolve cache queries directory. Provide "
-                "--cache-queries-dir or use --source local with --local-root."
-            )
-
-        if not cache_entities_dir.exists():
-            raise CLIError(f"Cache entities directory not found: {cache_entities_dir}")
-
-        selected_ids = sorted(set(args.value_list_ids or []))
-        if not selected_ids:
-            selected_ids = gkc.discover_value_list_ids(cache_entities_dir)
+        cache_entities_dir, queries_dir, cache_queries_dir, selected_ids = (
+            _resolve_profile_value_list_paths(args)
+        )
 
         result = gkc.hydrate_value_lists_from_cache(
             cache_entities_dir=cache_entities_dir,
@@ -2135,6 +2247,8 @@ def _handle_profile_value_lists_hydrate(args: argparse.Namespace) -> dict[str, A
             "hydrated_count": len(result.hydrated_ids),
             "query_files_written": result.query_files_written,
             "cache_files_written": result.cache_files_written,
+            "query_files_deleted": result.query_files_deleted,
+            "cache_files_deleted": result.cache_files_deleted,
             "failures": result.failures,
         }
 

--- a/gkc/registry/meta_wb_init.yaml
+++ b/gkc/registry/meta_wb_init.yaml
@@ -1,585 +1,667 @@
 metadata:
   name: Meta-Wikibase Initialization Data
   description: Seed ontology fixture for bootstrapping the Meta-Wikibase backbone used by gkc and SpiritSafe.
-  source: https://github.com/skybristol/gkc
+  source: https://github.com/skybristol/gkc/registry/meta_wb_init.yaml
   reference: https://datadistillery.org/
   internal_name_identifier_prefix: "_"
+  languages: ["en"]
 
 entities:
-  wikibase_entities:
-    properties:
-      instance_of:
-        label: instance of
-        description: type to which this subject belongs or corresponds
-        datatype: wikibase-item
-        kind: property
-
-      subclass_of:
-        label: subclass of
-        description: this item is a subclass (subset) of that item
-        datatype: wikibase-item
-        kind: property
-
-      name_identifier:
-        label: name identifier
-        description: human-readable identifier for entities in this Wikibase used as a unique identifier in the JSON translations used by and within the SpiritSafe and gkc software package
-        datatype: string
-        kind: property
-
-      see_also:
-        label: see also
-        description: link to a Wikidata Entity Schema or another representation of a GKC Entity Profile
-        datatype: url
-        kind: property
-
-      same_as:
-        label: same as
-        description: link to an entity in another knowledge system that is considered to be the same as the subject entity; used for shipping data to other systems
-        datatype: url
-        kind: property
-
-      has_statement:
-        label: has statement
-        description: links a GKC Entity Profile to a GKC Entity Property included as a statement in that profile
-        datatype: wikibase-item
-        kind: property
-
-      refresh_policy:
-        label: refresh policy
-        description: specifies when or how often an entity such as a value list represented by an item should be refreshed
-        datatype: wikibase-item
-        kind: property
-
-      statement_type:
-        label: statement type
-        description: links to a wikibase property with data type and other optional specifications for a statement
-        datatype: wikibase-item
-        kind: property
-
-      has_value:
-        label: has value
-        description: links the value for a GKC Entity Statement to another entity with rules governing validation or coercion behavior that will be applied on that value
-        datatype: wikibase-item
-        kind: property
-
-      has_fixed_value:
-        label: has fixed value
-        description: links a statement directly to the canonical external identifier that must be used as its exact value when no local GKC value entity is needed
-        datatype: url
-        kind: property
-
-      has_fixed_value_label:
-        label: has fixed value label
-        description: human-readable label accompanying a fixed external value identifier for profile export and display use
-        datatype: string
-        kind: property
-
-      has_qualifier:
-        label: has qualifier
-        description: links a statement that is required as a qualifier on the subject statement
-        datatype: wikibase-item
-        kind: property
-
-      has_reference:
-        label: has reference
-        description: links a statement that is available as a reference on the subject statement
-        datatype: wikibase-item
-        kind: property
-
-      applies_to_profile:
-        label: applies to profile
-        description: used as a qualifier indicating that the subject statement applies to a particular GKC Entity Profile
-        datatype: wikibase-item
-        kind: property
-
-      applies_to_statement:
-        label: applies to statement
-        description: links a value list item to the statement that should be filled by a value in the list
-        datatype: wikibase-item
-        kind: property
-
-      max_count:
-        label: max count
-        description: qualifier used to specify the maximum number of instances allowed for a statement of a particular type on an item
-        datatype: quantity
-        kind: property
-
-      label_prompt:
-        label: label prompt
-        description: short guidance statement provided as instructions for creating labels for a GKC Entity
-        datatype: monolingualtext
-        kind: property
-
-      label_guidance:
-        label: label guidance
-        description: longer guidance statement provided as instructions for creating a label for a GKC Entity
-        datatype: monolingualtext
-        kind: property
-
-      description_prompt:
-        label: description prompt
-        description: short guidance statement provided as instructions for creating descriptions for a GKC Entity
-        datatype: monolingualtext
-        kind: property
-
-      description_guidance:
-        label: description guidance
-        description: longer guidance statement provided as instructions for creating descriptions for a GKC Entity
-        datatype: monolingualtext
-        kind: property
-
-      alias_prompt:
-        label: alias prompt
-        description: short guidance statement provided as instructions for creating aliases for a GKC Entity
-        datatype: monolingualtext
-        kind: property
-
-      alias_guidance:
-        label: alias guidance
-        description: longer guidance statement provided as instructions for creating aliases for a GKC Entity
-        datatype: monolingualtext
-        kind: property
-
-      statement_prompt:
-        label: statement prompt
-        description: monolingual text template for actionable suggestions in review and correction workflows
-        datatype: monolingualtext
-        kind: property
-
-      statement_guidance:
-        label: statement guidance
-        description: monolingual text template for additional guidance shown to users
-        datatype: monolingualtext
-        kind: property
-
-      error_message:
-        label: error message
-        description: monolingual text template for error presentation with placeholders resolved by fermenter
-        datatype: monolingualtext
-        kind: property
-
-      default_value:
-        label: default value
-        description: default identifier value for statement, qualifier, or reference in a remote system
-        datatype: url
-        kind: property
-
-      default_label:
-        label: default label
-        description: label for a default value that may accompany default identifier as informative text
-        datatype: string
-        kind: property
-
-      derives_default_value_from:
-        label: derives default value from
-        description: when the subject statement is used as a reference or qualifier on the object statement, its value should be populated by the object statement's value
-        datatype: wikibase-item
-        kind: property
-
-      regex:
-        label: format as a regular expression
-        description: regex describing the format or shape of a value in PCRE syntax
-        datatype: string
-        kind: property
-
-    items:
-      entity:
-        label: entity
-        description: anything that can be labeled and described; root item in this wikibase
-        kind: item
-
-      entity_profile:
-        label: GKC Entity Profile
-        description: formal specification for the content model used to build, validate, and organize GKC Entities
-        subclass_of: entity
-        kind: item
-
-      entity_statement:
-        label: GKC Entity Statement
-        description: a statement used to define a characteristic of or facts about a GKC Entity
-        subclass_of: entity
-        kind: item
-
-      value_list:
-        label: GKC Value List
-        description: list of values to be used for a statement, qualifier, or reference requiring specified values
-        subclass_of: entity
-        kind: item
-
-      wikibase_statement_modifier:
-        label: Wikibase Statement Modifier
-        description: specialized type of statement used to modify the configuration of values such as units of measure and precision
-        subclass_of: entity
-        kind: item
-
-      value_list_refresh_policy:
-        label: GKC Refresh Policy
-        description: refresh cadence term used for SPARQL-backed lookup hydration
-        subclass_of: entity
-        kind: item
-
-      manual_refresh_policy:
-        label: manual refresh
-        description: refresh policy where something is only refreshed manually and not on a schedule
-        instance_of: value_list_refresh_policy
-        kind: item
-
-      wikibase_statement_type:
-        label: Wikibase Statement Type
-        description: classification of items describing the basic data type aligned with the Wikibase framework
-        kind: item
-
-      wikibase-item:
-        label: wikibase-item
-        description: wikibase item property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Item must be or resolve to a valid QID identifier.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      url:
-        label: url
-        description: URL property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Enter a complete URL starting with http:// or https://.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      time:
-        label: time
-        description: date/time property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Enter a valid date/time value such as 2024-01-31 or +2024-01-31T00:00:00Z.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      commonsMedia:
-        label: commonsMedia
-        description: Commons media file property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Provide a valid Wikimedia Commons file name such as Example.jpg.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      external-id:
-        label: external-id
-        description: external identifier property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Enter the identifier in the required format for this external ID.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      globe-coordinate:
-        label: globe-coordinate
-        description: geographic coordinates property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Enter valid latitude and longitude coordinates.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      monolingualtext:
-        label: monolingualtext
-        description: monolingual text property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Enter text and choose the correct language code.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      quantity:
-        label: quantity
-        description: quantity property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Enter a numeric value; include unit only when required.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      string:
-        label: string
-        description: string property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Enter plain text without unsupported formatting.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      geo-shape:
-        label: geo-shape
-        description: geographic shape property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Provide a valid Commons Data namespace geo-shape reference.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      math:
-        label: math
-        description: mathematical expression property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Enter a valid math expression in supported syntax.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      musical-notation:
-        label: musical-notation
-        description: musical notation property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: This field requires musical notation encoded in a supported format such as MusicXML or LilyPond. Enter a valid notation snippet rather than plain text or a link.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      tabular-data:
-        label: tabular-data
-        description: tabular data property template used to set a data type for a statement, reference, or qualifier and any additional specifications
-        error_message: Provide a valid Commons Data namespace tabular-data reference.
-        instance_of: wikibase_statement_type
-        kind: item
-
-      commons_media_object:
-        label: Commons Media Object
-        description: profile laying out the specifications and statements used in documenting media items in Wikimedia Commons with structured data content
-        instance_of: entity_profile
-        kind: item
-        label_prompt: caption used for the media object
-        label_guidance: Provide a short but descriptive caption for the image file or other media object that will be used widely whereve the media is displayed
-        has_statement:
-          - depicts
-          - copyright_status
-          - copyright_license
-          - inception
-          - media_type
-          - height
-          - width
-          - data_size
-          - checksum
-          - coordinates_of_the_point_of_view
-
-      format_specification:
-        label: Format Specification
-        description: items in this class contain specific format constraints or specifications for string values
-        subclass_of: entity
-        kind: item
-
-      depicts:
-        label: depicts
-        description: entity visually depicted in an image, literarily described in a work, or otherwise incorporated into an audiovisual or other medium
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P180
-        statement_type: wikibase-item
-        statement_prompt: enter or choose the Wikidata item that the subject image portrays or depicts
-        statement_guidance: Select the Wikidata item that the subject media object depicts
-        error_message: Failure to identify a Wikidata item that is a subject of the media object will degarade the full functionallity of the information content
-        # null encodes a DD Wikibase novalue claim on max_count, meaning 0-n values are allowed.
-        max_count: null
-
-      copyright_status:
-        label: copyright status
-        description: copyright status for intellectual creations like works of art, publications, software, etc.
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P6216
-        statement_type: wikibase-item
-        has_value: copyright_status_values
-        statement_prompt: enter or select the Wikidata item specifying copyright status for the subject media item
-        statement_guidance: Link to the Wikidata item from a controlled list representing the copyright status for the subject media item to clarify legal use of the media object
-        error_message: Failure to select a valid copyright status value for a media object means the legal uses for the object will be ambiguous or unclear
-        max_count: 1
-
-      copyright_license:
-        label: copyright license
-        description: license under which this copyrighted work is released
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P275
-        statement_type: wikibase-item
-        has_value: copyright_license_values
-        statement_prompt: enter or select the Wikidata item specifying the specific license the subject item is released under
-        statement_guidance: Link to the Wikidata item from a controlled list representing the license governing usage of the subject item
-        error_message: Failure to select a valid license designation for a media object means the legal uses for the object will be ambiguous or unclear
-        max_count: 1
-
-      inception:
-        label: inception
-        description: time when an entity begins to exist
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P571
-        statement_type: time
-        has_qualifier: datetime_precision
-        statement_prompt: enter the date that the subject entity began to exist
-        statement_guidance: Enter the date that the subject item came into existence or was established, citing a reliable reference.
-        error_message: Without a value, the founding or creation date is unknown, making chronological ordering and timeline display impossible.
-        max_count: null
-
-      media_type:
-        label: media type
-        description: IANA-registered identifier for a file type
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P1163
-        statement_type: string
-        has_value: iana_media_type
-        statement_prompt: specify the media type for the subject media object using an approved value from IANA
-        statement_guidance: Provide the official file object type from the Internet Assigned Numbers Authority
-        error_message: Failure to include a media type string may result in an inability for certain applications to use the information in the most efficient way
-        max_count: 1
-
-      height:
-        label: height
-        description: vertical length of an entity
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P2048
-        statement_type: quantity
-        has_qualifier: height_units
-        statement_prompt: enter a value for height of the subject item
-        statement_guidance: Enter a value for the height of the subject and specify an appropriate unit of measure
-        error_message: Failure to provide a height measurement with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
-        max_count: null
-
-      width:
-        label: width
-        description: horizontal length of an object
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P2049
-        statement_type: quantity
-        has_qualifier: width_units
-        statement_prompt: enter a value for width of the subject item
-        statement_guidance: Enter a value for the width of the subject and specify an appropriate unit of measure
-        error_message: Failure to provide a width measurement with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
-        max_count: null
-
-      data_size:
-        label: data size
-        description: size of a software, dataset, neural network, or individual file
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P3575
-        statement_type: quantity
-        has_qualifier: data_size_units
-        statement_prompt: enter a value for total size of the data item
-        statement_guidance: Enter a value for the data size of the subject and specify an appropriate unit of measure
-        error_message: Failure to provide a data size with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
-        max_count: null
-
-      checksum:
-        label: checksum
-        description: small-sized datum derived from a block of digital data for the purpose of detecting errors
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P4092
-        statement_type: string
-        has_value: checksum_format
-        statement_prompt: provide the checksum string for the subject item
-        statement_guidance: Provide the generated checksum and specify the determination method (e.g., sha1) in the associated qualifier
-        error_message: Failure to include the checksum may result in lack of trustworthiness in the veracity of the subject data
-        max_count: 1
-
-      coordinates_of_the_point_of_view:
-        label: coordinates of the point of view
-        description: point from which the scene depicted by the element is seen (element can be a photo, a painting, etc.)
-        instance_of: entity_statement
-        kind: item
-        same_as: http://www.wikidata.org/entity/P1259
-        statement_type: globe-coordinate
-        has_qualifier: coordinate_precision
-        statement_prompt: provide the coordinates from which the subject entity was observed or captured in a media object
-        statement_guidance: Record the coordinates for a point on earth where an image was recorded or created
-        error_message: Failure to provide the point of view location may result in reduced usability for the subject item
-        max_count: 1
-
-      datetime_precision:
-        label: datetime precision
-        description: specialized qualifier/modifier used to set the time precision value for Wikibase data representations; generally set dynamically through coercion code
-        instance_of: entity_statement
-        additional_instance_of:
-          - wikibase_statement_modifier
-        kind: item
-        has_value: time_precision_values
-        statement_prompt: set the time precision value for the datetime statement
-        statement_guidance: Time precision values will be computed dynamically in most cases
-        error_message: Statements with time values must include a precision value or they will be rejected when submitted to a Wikibase instance
-        max_count: 1
-
-      coordinate_precision:
-        label: coordinate precision
-        description: specialized qualifier/modifier used to set the globe-coordinate precision value for Wikibase data representations; generally set dynamically through coercion code
-        instance_of: entity_statement
-        additional_instance_of:
-          - wikibase_statement_modifier
-        kind: item
-        has_value: coordinate_precision_values
-        statement_prompt: set the coordinate precision value for the globe-coordinate statement
-        statement_guidance: Coordinate precision values will be computed dynamically in most cases
-        error_message: Statements with globe-coordinate values must include a precision value or they will be rejected when submitted to a Wikibase instance
-        max_count: 1
-
-      iana_media_type:
-        label: IANA media type value
-        description: format specification containing a regular expression that controls values applied to media type statements
-        instance_of: format_specification
-        kind: item
-        regex: '(application|audio|chemical|example|font|image|message|model|multipart|text|video)/[a-zA-Z0-9+.-]+'
-
-      checksum_format:
-        label: checksum string format
-        description: regex formatter for checksum values pulled from Wikidata property constraints
-        instance_of: format_specification
-        kind: item
-        regex: '[a-z\d]{128}|[a-z\d]{64}|[a-z\d]{40}|[a-z\d]{32}|[a-z\d]{16}|[a-z\d]{8}(-[a-z\d]{4}){3}-[a-z\d]{12}'
-
-      copyright_status_values:
-        label: List of Copyright Status Values
-        description: value list of valid copyright status values from Wikidata
-        instance_of: value_list
-        kind: item
-        refresh_policy: manual_refresh_policy
-        query_fixture: copyright_status_values
-
-      copyright_license_values:
-        label: List of Copyright Licenses
-        description: list of copyright license values from Wikidata for use in copyright license statements
-        instance_of: value_list
-        kind: item
-        refresh_policy: manual_refresh_policy
-        query_fixture: copyright_license_values
-
-      height_units:
-        label: List of Units for Height
-        description: list of units for height statements pulled from property constraints
-        instance_of: value_list
-        kind: item
-        refresh_policy: manual_refresh_policy
-        query_fixture: height_units
-
-      width_units:
-        label: List of Units for Width
-        description: list of units for width statements pulled from Wikidata property constraints
-        instance_of: value_list
-        kind: item
-        refresh_policy: manual_refresh_policy
-        query_fixture: width_units
-
-      data_size_units:
-        label: List of Units for Data Size
-        description: list of units for data size statements pulled from Wikidata property constraint
-        instance_of: value_list
-        kind: item
-        refresh_policy: manual_refresh_policy
-        query_fixture: data_size_units
-
-      time_precision_values:
-        label: Time Precision Values
-        description: value list of time precision numerical values and labels for use in setting time precision qualifiers/modifiers
-        instance_of: value_list
-        kind: item
-        error_message: The time value provided requires a qualifier specifying the precision (e.g., year, month, day, etc.). Please select from the list provided or consult the query source for more context.
-        query_fixture: time_precision_values
-
-      coordinate_precision_values:
-        label: Coordinate Precision Values
-        description: value list of time precision values and labels for use in setting globe-coordinate precision qualifiers/modifiers
-        instance_of: value_list
-        kind: item
-        error_message: The geographic coordinates provided require a precision qualifier. Please select from the list provided or consult the query source for more context.
-        query_fixture: coordinate_precision_values
-
-value_list_query_fixtures:
+  instance_of:
+    label_en: instance of
+    description_en: type to which this subject belongs or corresponds
+    datatype: wikibase-item
+    instance_of: meta_wikibase_organizational_property
+    kind: property
+
+  subclass_of:
+    label_en: subclass of
+    description_en: this item is a subclass (subset) of that item
+    datatype: wikibase-item
+    instance_of: meta_wikibase_organizational_property
+    kind: property
+
+  name_identifier:
+    label_en: name identifier
+    description_en: human-readable identifier for entities in this Wikibase used as a unique identifier in the JSON translations used by and within the SpiritSafe and gkc software package
+    datatype: string
+    instance_of: meta_wikibase_organizational_property
+    kind: property
+
+  see_also:
+    label_en: see also
+    description_en: link to a Wikidata Entity Schema or another representation of an Entity Profile
+    datatype: url
+    instance_of: meta_wikibase_organizational_property
+    kind: property
+
+  same_as:
+    label_en: same as
+    description_en: link to an entity in another knowledge system that is considered to be the same as the subject entity; used for shipping data to other systems
+    datatype: url
+    instance_of: meta_wikibase_organizational_property
+    kind: property
+
+  sparql_endpoint:
+    label_en: SPARQL endpoint
+    description_en: SPARQL API endpoint for use in fulfilling an embedded SPARQL query contained in the item discussion wikitext of the subject item
+    datatype: url
+    instance_of: meta_wikibase_organizational_property
+    kind: property
+
+  has_statement:
+    label_en: has statement
+    description_en: links an Entity Profile to a Entity Property included as a statement in that profile
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  refresh_policy:
+    label_en: refresh policy
+    description_en: specifies when or how often an entity such as a value list represented by an item should be refreshed
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  statement_type:
+    label_en: statement type
+    description_en: links to a wikibase property with data type and other optional specifications for a statement
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  has_value:
+    label_en: has value
+    description_en: links the value for an Entity Statement to another entity with rules governing validation or coercion behavior that will be applied on that value
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  has_fixed_value:
+    label_en: has fixed value
+    description_en: links a statement directly to the canonical external identifier that must be used as its exact value when no local value is needed
+    datatype: url
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  has_fixed_value_label:
+    label_en: has fixed value label
+    description_en: human-readable label accompanying a fixed external value identifier for profile export and display use
+    datatype: string
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  has_qualifier:
+    label_en: has qualifier
+    description_en: links a statement that is required as a qualifier on the subject statement
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  has_reference:
+    label_en: has reference
+    description_en: links a statement that is available as a reference on the subject statement
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  applies_to_profile:
+    label_en: applies to profile
+    description_en: used as a qualifier indicating that the subject statement applies to a particular Entity Profile
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  applies_to_statement:
+    label_en: applies to statement
+    description_en: links a value list item to the statement that should be filled by a value in the list
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  max_count:
+    label_en: max count
+    description_en: qualifier used to specify the maximum number of instances allowed for a statement of a particular type on an item
+    datatype: quantity
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  default_value:
+    label_en: default value
+    description_en: default identifier value for statement, qualifier, or reference in a remote system
+    datatype: url
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  default_label:
+    label_en: default label
+    description_en: label for a default value that may accompany default identifier as informative text
+    datatype: string
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  derives_default_value_from:
+    label_en: derives default value from
+    description_en: when the subject statement is used as a reference or qualifier on the object statement, its value should be populated by the object statement's value
+    datatype: wikibase-item
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  regex:
+    label_en: format as a regular expression
+    description_en: regex describing the format or shape of a value in PCRE syntax
+    datatype: string
+    instance_of: entity_profile_ontology_property
+    kind: property
+
+  label_prompt:
+    label_en: label prompt
+    description_en: short guidance statement provided as instructions for creating labels for a GKC Entity
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  label_guidance:
+    label_en: label guidance
+    description_en: longer guidance statement provided as instructions for creating a label for a GKC Entity
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  description_prompt:
+    label_en: description prompt
+    description_en: short guidance statement provided as instructions for creating descriptions for a GKC Entity
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  description_guidance:
+    label_en: description guidance
+    description_en: longer guidance statement provided as instructions for creating descriptions for a GKC Entity
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  alias_prompt:
+    label_en: alias prompt
+    description_en: short guidance statement provided as instructions for creating aliases for a GKC Entity
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  alias_guidance:
+    label_en: alias guidance
+    description_en: longer guidance statement provided as instructions for creating aliases for a GKC Entity
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  statement_prompt:
+    label_en: statement prompt
+    description_en: monolingual text template for actionable suggestions in review and correction workflows
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  statement_guidance:
+    label_en: statement guidance
+    description_en: monolingual text template for additional guidance shown to users
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  error_message:
+    label_en: error message
+    description_en: monolingual text template for error presentation with placeholders resolved by fermenter
+    datatype: monolingualtext
+    instance_of: data_curation_help_text_property
+    kind: property
+
+  entity:
+    label_en: entity
+    description_en: anything that can be labeled and described; root item in this wikibase
+    subclass_of: novalue
+    kind: item
+
+  property_entity:
+    label_en: property entity
+    description_en: a property entity used to characterize and define other entities
+    subclass_of: entity
+    kind: item
+
+  meta_wikibase_organizational_property:
+    label_en: metaWikibase Organizational Property
+    description_en: property within the metaWikibase providing semantic structure
+    subclass_of: property_entity
+    kind: item
+
+  data_curation_help_text_property:
+    label_en: Data Curation Help Text Property
+    description_en: property used to create statements with text in different languages providing guidance or input for data curation activities
+    subclass_of: property_entity
+    kind: item
+
+  entity_profile_ontology_property:
+    label_en: Entity Profile Ontology Property
+    description_en: property that makes up part of the Entity Profile organizational structure
+    subclass_of: property_entity
+    kind: item
+
+  wikibase_statement_type:
+    label_en: Wikibase Statement Type
+    description_en: classification of items describing the basic data type aligned with the Wikibase framework
+    subclass_of: entity
+    kind: item
+
+  entity_profile:
+    label_en: GKC Entity Profile
+    description_en: formal specification for the content model used to build, validate, and organize GKC Entities
+    subclass_of: entity
+    kind: item
+
+  entity_statement:
+    label_en: Entity Statement
+    description_en: a statement used to define a characteristic of or facts about an Entity
+    subclass_of: entity
+    kind: item
+
+  sparql_value_list:
+    label_en: SPARQL-backed Value List
+    description_en: items that describe and embed a SPARQL query for use in building a list of viable items and labels used to fulfill wikibase-item statement values
+    subclass_of: entity
+    kind: item
+
+  embedded_value_list:
+    label_en: Embedded Value List
+    description_en: items that contain an embedded list of values for use in specifying a list of viable items and labels used to fulfill statement or parameter values
+    subclass_of: entity
+    kind: item
+
+  wikibase_statement_modifier:
+    label_en: Wikibase Statement Modifier
+    description_en: specialized type of statement used to modify the configuration of values such as units of measure and precision
+    subclass_of: entity_statement
+    kind: item
+
+  value_list_refresh_policy:
+    label_en: Refresh Policy
+    description_en: refresh cadence term used for SPARQL-backed lookup hydration
+    subclass_of: entity
+    kind: item
+
+  manual_refresh_policy:
+    label_en: manual refresh
+    description_en: refresh policy where something is only refreshed manually and not on a schedule
+    instance_of: value_list_refresh_policy
+    kind: item
+
+  format_specification:
+    label_en: Format Specification
+    description_en: items in this class contain specific format constraints or specifications for string values
+    subclass_of: entity
+    kind: item
+
+  wikibase-item:
+    label_en: wikibase-item
+    description_en: wikibase item property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Item must be or resolve to a valid QID identifier.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  url:
+    label_en: url
+    description_en: URL property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Enter a complete URL starting with http:// or https://.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  time:
+    label_en: time
+    description_en: date/time property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Enter a valid date/time value such as 2024-01-31 or +2024-01-31T00:00:00Z.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  commonsMedia:
+    label_en: commonsMedia
+    description_en: Commons media file property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Provide a valid Wikimedia Commons file name such as Example.jpg.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  external-id:
+    label_en: external-id
+    description_en: external identifier property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Enter the identifier in the required format for this external ID.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  globe-coordinate:
+    label_en: globe-coordinate
+    description_en: geographic coordinates property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Enter valid latitude and longitude coordinates.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  monolingualtext:
+    label_en: monolingualtext
+    description_en: monolingual text property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Enter text and choose the correct language code.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  quantity:
+    label_en: quantity
+    description_en: quantity property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Enter a numeric value; include unit only when required.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  string:
+    label_en: string
+    description_en: string property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Enter plain text without unsupported formatting.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  geo-shape:
+    label_en: geo-shape
+    description_en: geographic shape property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Provide a valid Commons Data namespace geo-shape reference.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  math:
+    label_en: math
+    description_en: mathematical expression property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Enter a valid math expression in supported syntax.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  musical-notation:
+    label_en: musical-notation
+    description_en: musical notation property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: This field requires musical notation encoded in a supported format such as MusicXML or LilyPond. Enter a valid notation snippet rather than plain text or a link.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  tabular-data:
+    label_en: tabular-data
+    description_en: tabular data property template used to set a data type for a statement, reference, or qualifier and any additional specifications
+    error_message_mul: Provide a valid Commons Data namespace tabular-data reference.
+    instance_of: wikibase_statement_type
+    kind: item
+
+  commons_media_object:
+    label_en: Commons Media Object
+    description_en: profile laying out the specifications and statements used in documenting media items in Wikimedia Commons with structured data content
+    instance_of: entity_profile
+    kind: item
+    label_prompt_en: caption used for the media object
+    label_guidance_en: Provide a short but descriptive caption for the image file or other media object that will be used widely whereve the media is displayed
+    has_statement:
+      - depicts
+      - copyright_status
+      - copyright_license
+      - inception
+      - media_type
+      - height
+      - width
+      - data_size
+      - checksum
+      - coordinates_of_the_point_of_view
+
+  depicts:
+    label_en: depicts
+    description_en: entity visually depicted in an image, literarily described in a work, or otherwise incorporated into an audiovisual or other medium
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P180
+    statement_type: wikibase-item
+    statement_prompt_mul: enter or choose the Wikidata item that the subject image portrays or depicts
+    statement_guidance_mul: Select the Wikidata item that the subject media object depicts
+    error_message_mul: Failure to identify a Wikidata item that is a subject of the media object will degarade the full functionallity of the information content
+    max_count: novalue
+
+  copyright_status:
+    label_en: copyright status
+    description_en: copyright status for intellectual creations like works of art, publications, software, etc.
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P6216
+    statement_type: wikibase-item
+    has_value: copyright_status_values
+    statement_prompt_mul: enter or select the Wikidata item specifying copyright status for the subject media item
+    statement_guidance_mul: Link to the Wikidata item from a controlled list representing the copyright status for the subject media item to clarify legal use of the media object
+    error_message_mul: Failure to select a valid copyright status value for a media object means the legal uses for the object will be ambiguous or unclear
+    max_count: 1
+
+  copyright_license:
+    label_en: copyright license
+    description_en: license under which this copyrighted work is released
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P275
+    statement_type: wikibase-item
+    has_value: copyright_license_values
+    statement_prompt_mul: enter or select the Wikidata item specifying the specific license the subject item is released under
+    statement_guidance_mul: Link to the Wikidata item from a controlled list representing the license governing usage of the subject item
+    error_message_mul: Failure to select a valid license designation for a media object means the legal uses for the object will be ambiguous or unclear
+    max_count: 1
+
+  inception:
+    label_en: inception
+    description_en: time when an entity begins to exist
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P571
+    statement_type: time
+    has_qualifier: datetime_precision
+    statement_prompt_mul: enter the date that the subject entity began to exist
+    statement_guidance_mul: Enter the date that the subject item came into existence or was established, citing a reliable reference.
+    error_message_mul: Without a value, the founding or creation date is unknown, making chronological ordering and timeline display impossible.
+    max_count: novalue
+
+  media_type:
+    label_en: media type
+    description_en: IANA-registered identifier for a file type
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P1163
+    statement_type: string
+    has_value: iana_media_type
+    statement_prompt_mul: specify the media type for the subject media object using an approved value from IANA
+    statement_guidance_mul: Provide the official file object type from the Internet Assigned Numbers Authority
+    error_message_mul: Failure to include a media type string may result in an inability for certain applications to use the information in the most efficient way
+    max_count: 1
+
+  height:
+    label_en: height
+    description_en: vertical length of an entity
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P2048
+    statement_type: quantity
+    has_qualifier: height_units
+    statement_prompt_mul: enter a value for height of the subject item
+    statement_guidance_mul: Enter a value for the height of the subject and specify an appropriate unit of measure
+    error_message_mul: Failure to provide a height measurement with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
+    max_count: novalue
+
+  width:
+    label_en: width
+    description_en: horizontal length of an object
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P2049
+    statement_type: quantity
+    has_qualifier: width_units
+    statement_prompt_mul: enter a value for width of the subject item
+    statement_guidance_mul: Enter a value for the width of the subject and specify an appropriate unit of measure
+    error_message_mul: Failure to provide a width measurement with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
+    max_count: novalue
+
+  data_size:
+    label_en: data size
+    description_en: size of a software, dataset, neural network, or individual file
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P3575
+    statement_type: quantity
+    has_qualifier: data_size_units
+    statement_prompt_mul: enter a value for total size of the data item
+    statement_guidance_mul: Enter a value for the data size of the subject and specify an appropriate unit of measure
+    error_message_mul: Failure to provide a data size with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information
+    max_count: novalue
+
+  checksum:
+    label_en: checksum
+    description_en: small-sized datum derived from a block of digital data for the purpose of detecting errors
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P4092
+    statement_type: string
+    has_value: checksum_format
+    statement_prompt_mul: provide the checksum string for the subject item
+    statement_guidance_mul: Provide the generated checksum and specify the determination method (e.g., sha1) in the associated qualifier
+    error_message_mul: Failure to include the checksum may result in lack of trustworthiness in the veracity of the subject data
+    max_count: 1
+
+  coordinates_of_the_point_of_view:
+    label_en: coordinates of the point of view
+    description_en: point from which the scene depicted by the element is seen (element can be a photo, a painting, etc.)
+    instance_of: entity_statement
+    kind: item
+    same_as: http://www.wikidata.org/entity/P1259
+    statement_type: globe-coordinate
+    has_qualifier: coordinate_precision
+    statement_prompt_mul: provide the coordinates from which the subject entity was observed or captured in a media object
+    statement_guidance_mul: Record the coordinates for a point on earth where an image was recorded or created
+    error_message_mul: Failure to provide the point of view location may result in reduced usability for the subject item
+    max_count: 1
+
+  datetime_precision:
+    label_en: datetime precision
+    description_en: specialized qualifier/modifier used to set the time precision value for Wikibase data representations; generally set dynamically through coercion code
+    instance_of: wikibase_statement_modifier
+    kind: item
+    has_value: time_precision_values
+    statement_prompt_mul: set the time precision value for the datetime statement
+    statement_guidance_mul: Time precision values will be computed dynamically in most cases
+    error_message_mul: Statements with time values must include a precision value or they will be rejected when submitted to a Wikibase instance
+    max_count: 1
+
+  coordinate_precision:
+    label_en: coordinate precision
+    description_en: specialized qualifier/modifier used to set the globe-coordinate precision value for Wikibase data representations; generally set dynamically through coercion code
+    instance_of: wikibase_statement_modifier
+    kind: item
+    has_value: coordinate_precision_values
+    statement_prompt_mul: set the coordinate precision value for the globe-coordinate statement
+    statement_guidance_mul: Coordinate precision values will be computed dynamically in most cases
+    error_message_mul: Statements with globe-coordinate values must include a precision value or they will be rejected when submitted to a Wikibase instance
+    max_count: 1
+
+  iana_media_type:
+    label_en: IANA media type value
+    description_en: format specification containing a regular expression that controls values applied to media type statements
+    instance_of: format_specification
+    kind: item
+    regex: '(application|audio|chemical|example|font|image|message|model|multipart|text|video)/[a-zA-Z0-9+.-]+'
+
+  checksum_format:
+    label_en: checksum string format
+    description_en: regex formatter for checksum values pulled from Wikidata property constraints
+    instance_of: format_specification
+    kind: item
+    regex: '[a-z\d]{128}|[a-z\d]{64}|[a-z\d]{40}|[a-z\d]{32}|[a-z\d]{16}|[a-z\d]{8}(-[a-z\d]{4}){3}-[a-z\d]{12}'
+
+  world_countries:
+    label_en: List of World Countries
+    description_en: SPARQL query returning list of countries of the world for country statements in items
+    instance_of: sparql_value_list
+    kind: item
+    error_message_mul: The statement being edited requires a valid link to a Wikidata item representing a world country. Please select from the list provided or consult the query source for more context.
+    refresh_policy: manual_refresh_policy
+    sparql_endpoint: https://query.wikidata.org/sparql
+    query: |
+      # Purpose: value list for country statements
+      # Expected vars: ?item ?itemLabel
+
+      PREFIX wd: <http://www.wikidata.org/entity/>
+      PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?item ?itemLabel WHERE {
+        ?item wdt:P31 wd:Q6256 ;
+              rdfs:label ?itemLabel .
+        FILTER(LANG(?itemLabel) = "en")
+      }
+      ORDER BY ?itemLabel
+
+  human_languages:
+    label_en: List of Human Languages
+    description_en: provides a listing of languages for use in qualifiers and statements
+    instance_of: sparql_value_list
+    kind: item
+    error_message_mul: The statement being edited requires a valid link to a Wikidata item representing a human language. Please select from the list provided or consult the query source for more context.
+    refresh_policy: manual_refresh_policy
+    sparql_endpoint: https://query.wikidata.org/sparql
+    query: |
+      # Purpose: list languages for "language of work or name" claims
+      # Expected vars: ?item ?itemLabel
+
+      PREFIX wd: <http://www.wikidata.org/entity/>
+      PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?item ?itemLabel
+      WHERE {
+        VALUES ?target { wd:Q17376908 wd:Q2092812 }
+        ?item wdt:P31/wdt:P279 ?target ;
+              rdfs:label ?itemLabel ;
+          wdt:P219 ?iso_code .
+        FILTER(LANG(?itemLabel) = "en")
+      }
+
+  units_of_measure:
+    label_en: Units of Measure
+    description_en: value list for primary Wikidata units used in quantity statements
+    instance_of: sparql_value_list
+    kind: item
+    error_message_mul: The quantity value requires a qualifier linking to a Wikidata item representing a unit of measure. Please select from the list provided or consult the query source for more context.
+    refresh_policy: manual_refresh_policy
+    sparql_endpoint: https://query.wikidata.org/sparql
+    query: |
+      PREFIX wd: <http://www.wikidata.org/entity/>
+      PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+      SELECT ?item ?itemLabel WHERE {
+        {
+          BIND("1" AS ?item)
+          BIND("unitless"@en AS ?itemLabel)
+        }
+        UNION
+        {
+          VALUES ?class {
+            wd:Q47574      # unit of measurement
+            wd:Q107715     # SI unit
+          }
+          ?item wdt:P31 ?class ;
+                rdfs:label ?itemLabel .
+          FILTER(LANG(?itemLabel) = "en")
+        }
+      }
+      ORDER BY ?itemLabel
+
   copyright_status_values:
-    value_list: copyright_status_values
-    storage_mode: item_talk_page
-    content_type: application/sparql-query
-    endpoint: https://query.wikidata.org/sparql
-    expected_vars:
-      - item
-      - itemLabel
+    label_en: List of Copyright Status Values
+    description_en: list of valid copyright status values from Wikidata
+    instance_of: sparql_value_list
+    kind: item
+    refresh_policy: manual_refresh_policy
+    sparql_endpoint: https://query.wikidata.org/sparql
     query: |
       # Purpose: value list for copyright status statements
       # Expected vars: ?item ?itemLabel
@@ -599,13 +681,12 @@ value_list_query_fixtures:
       }
 
   copyright_license_values:
-    value_list: copyright_license_values
-    storage_mode: item_talk_page
-    content_type: application/sparql-query
-    endpoint: https://query.wikidata.org/sparql
-    expected_vars:
-      - item
-      - itemLabel
+    label_en: List of Copyright Licenses
+    description_en: list of copyright license values from Wikidata for use in copyright license statements
+    instance_of: sparql_value_list
+    kind: item
+    refresh_policy: manual_refresh_policy
+    sparql_endpoint: https://query.wikidata.org/sparql
     query: |
       # Purpose: value list for copyright license statements
       # Expected vars: ?item ?itemLabel
@@ -625,13 +706,12 @@ value_list_query_fixtures:
       }
 
   height_units:
-    value_list: height_units
-    storage_mode: item_talk_page
-    content_type: application/sparql-query
-    endpoint: https://query.wikidata.org/sparql
-    expected_vars:
-      - item
-      - itemLabel
+    label_en: List of Units for Height
+    description_en: list of units for height statements pulled from property constraints
+    instance_of: sparql_value_list
+    kind: item
+    refresh_policy: manual_refresh_policy
+    sparql_endpoint: https://query.wikidata.org/sparql
     query: |
       # Purpose: value list from height property constraint allowed items
       # Expected vars: ?item ?itemLabel
@@ -648,13 +728,12 @@ value_list_query_fixtures:
       }
 
   width_units:
-    value_list: width_units
-    storage_mode: item_talk_page
-    content_type: application/sparql-query
-    endpoint: https://query.wikidata.org/sparql
-    expected_vars:
-      - item
-      - itemLabel
+    label_en: List of Units for Width
+    description_en: list of units for width statements pulled from Wikidata property constraints
+    instance_of: sparql_value_list
+    kind: item
+    refresh_policy: manual_refresh_policy
+    sparql_endpoint: https://query.wikidata.org/sparql
     query: |
       # Purpose: value list from width property constraint allowed items
       # Expected vars: ?item ?itemLabel
@@ -671,13 +750,12 @@ value_list_query_fixtures:
       }
 
   data_size_units:
-    value_list: data_size_units
-    storage_mode: item_talk_page
-    content_type: application/sparql-query
-    endpoint: https://query.wikidata.org/sparql
-    expected_vars:
-      - item
-      - itemLabel
+    label_en: List of Units for Data Size
+    description_en: list of units for data size statements pulled from Wikidata property constraint
+    instance_of: sparql_value_list
+    kind: item
+    refresh_policy: manual_refresh_policy
+    sparql_endpoint: https://query.wikidata.org/sparql
     query: |
       # Purpose: value list from data size property constraint allowed items
       # Expected vars: ?item ?itemLabel
@@ -694,60 +772,63 @@ value_list_query_fixtures:
       }
 
   time_precision_values:
-    value_list: time_precision_values
-    storage_mode: item_talk_page
-    content_type: application/sparql-query
-    expected_vars:
-      - item
-      - itemLabel
-    result_cast: integer
-    query: |
-      # Time Precision value list
-      # Static enumeration of Wikibase time precision codes (integer 0-14).
-      # Fermenter should cast selected item to integer for time.precision.
-
-      SELECT ?item ?itemLabel WHERE {
-        VALUES (?item ?itemLabel) {
-          ("0"  "Gigayear (10^9 years)"@en)
-          ("1"  "100 Megayears (10^8 years)"@en)
-          ("2"  "10 Megayears (10^7 years)"@en)
-          ("3"  "Megayear (10^6 years)"@en)
-          ("4"  "100 Kiloyears (10^5 years)"@en)
-          ("5"  "10 Kiloyears (10^4 years)"@en)
-          ("6"  "millennium"@en)
-          ("7"  "century"@en)
-          ("8"  "decade"@en)
-          ("9"  "year"@en)
-          ("10" "month"@en)
-          ("11" "day"@en)
-          ("12" "hour"@en)
-          ("13" "minute"@en)
-          ("14" "second"@en)
-        }
-      }
+    label_en: Time Precision Values
+    description_en: value list of time precision numerical values and labels for use in setting time precision qualifiers/modifiers
+    instance_of: embedded_value_list
+    kind: item
+    error_message_mul: The time value provided requires a qualifier specifying the precision (e.g., year, month, day, etc.). Please select from the list provided or consult the query source for more context.
+    value_list:
+    - item: '0'
+      itemLabel: Gigayear (10^9 years)
+    - item: '1'
+      itemLabel: 100 Megayears (10^8 years)
+    - item: '2'
+      itemLabel: 10 Megayears (10^7 years)
+    - item: '3'
+      itemLabel: Megayear (10^6 years)
+    - item: '4'
+      itemLabel: 100 Kiloyears (10^5 years)
+    - item: '5'
+      itemLabel: 10 Kiloyears (10^4 years)
+    - item: '6'
+      itemLabel: millennium
+    - item: '7'
+      itemLabel: century
+    - item: '8'
+      itemLabel: decade
+    - item: '9'
+      itemLabel: year
+    - item: '10'
+      itemLabel: month
+    - item: '11'
+      itemLabel: day
+    - item: '12'
+      itemLabel: hour
+    - item: '13'
+      itemLabel: minute
+    - item: '14'
+      itemLabel: second
 
   coordinate_precision_values:
-    value_list: coordinate_precision_values
-    storage_mode: item_talk_page
-    content_type: application/sparql-query
-    expected_vars:
-      - item
-      - itemLabel
-    result_cast: float
-    query: |
-      # Globe-Coordinate Precision value list
-      # Static enumeration of coordinate precision levels in decimal degrees.
-      # Fermenter should cast selected item to float for coordinate.precision.
-
-      SELECT ?item ?itemLabel WHERE {
-        VALUES (?item ?itemLabel) {
-          ("10"       "10 degrees"@en)
-          ("1"        "1 degree (~111 km)"@en)
-          ("0.1"      "0.1 degree (~11 km)"@en)
-          ("0.01667"  "1 arcminute (~1.85 km)"@en)
-          ("0.00278"  "10 arcseconds (~300 m)"@en)
-          ("0.000278" "1 arcsecond (~30 m)"@en)
-          ("0.0001"   "0.0001 degree (~11 m)"@en)
-          ("0.00001"  "0.00001 degree (~1 m)"@en)
-        }
-      }
+    label_en: Coordinate Precision Values
+    description_en: value list of time precision values and labels for use in setting globe-coordinate precision qualifiers/modifiers
+    instance_of: embedded_value_list
+    kind: item
+    error_message_mul: The geographic coordinates provided require a precision qualifier. Please select from the list provided or consult the query source for more context.
+    value_list:
+    - item: 10
+      itemLabel: 10 degrees
+    - item: 1
+      itemLabel: 1 degree (~111 km)
+    - item: 0.1
+      itemLabel: 0.1 degree (~11 km)
+    - item: 0.01667
+      itemLabel: 1 arcminute (~1.85 km)
+    - item: 0.00278
+      itemLabel: 10 arcseconds (~300 m)
+    - item: 0.000278
+      itemLabel: 1 arcsecond (~30 m)
+    - item: 0.0001
+      itemLabel: 0.0001 degree (~11 m)
+    - item: 1.0e-05
+      itemLabel: 0.00001 degree (~1 m)

--- a/gkc/runtime_config.py
+++ b/gkc/runtime_config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, TypedDict
+from typing import Literal, Optional, TypedDict
 
 import yaml
 
@@ -81,6 +81,15 @@ class SpiritSafeLayout:
 
 
 @dataclass(frozen=True)
+class ValueListTalkPageRule:
+    """Class-coupled rule for materializing value-list talk-page content."""
+
+    class_name_identifier: str
+    block_type: Literal["sparql", "json"]
+    artifact_store: Literal["value_list_queries", "value_list_cache"]
+
+
+@dataclass(frozen=True)
 class WikibaseRuntimeConfig:
     """Read-only Wikibase integration settings resolved from environment."""
 
@@ -92,6 +101,7 @@ class WikibaseRuntimeConfig:
     name_identifier_property_id: Optional[str] = None
     internal_name_identifier_prefix: Optional[str] = None
     spiritsafe_layout: SpiritSafeLayout = SpiritSafeLayout()
+    value_list_talk_page_rules: tuple[ValueListTalkPageRule, ...] = ()
 
 
 class MetaWikibaseConfigValues(TypedDict):
@@ -102,6 +112,7 @@ class MetaWikibaseConfigValues(TypedDict):
     name_identifier_property_id: Optional[str]
     internal_name_identifier_prefix: Optional[str]
     spiritsafe_layout: SpiritSafeLayout
+    value_list_talk_page_rules: tuple[ValueListTalkPageRule, ...]
 
 
 def default_meta_wikibase_config_values() -> MetaWikibaseConfigValues:
@@ -113,6 +124,7 @@ def default_meta_wikibase_config_values() -> MetaWikibaseConfigValues:
         "name_identifier_property_id": None,
         "internal_name_identifier_prefix": None,
         "spiritsafe_layout": SpiritSafeLayout(),
+        "value_list_talk_page_rules": (),
     }
 
 
@@ -144,6 +156,62 @@ def _read_optional_mapping(
     if not isinstance(value, dict):
         raise RuntimeError(f"{context} field '{key}' must be a mapping")
     return value
+
+
+def _load_value_list_talk_page_rules(
+    meta_config: dict[object, object],
+) -> tuple[ValueListTalkPageRule, ...]:
+    talk_page_config = (
+        _read_optional_mapping(
+            meta_config,
+            "value_list_talk_pages",
+            context="Meta-wikibase config field 'meta_wikibase'",
+        )
+        or {}
+    )
+
+    raw_rules = talk_page_config.get("rules")
+    if raw_rules is None:
+        return ()
+    if not isinstance(raw_rules, list):
+        raise RuntimeError(
+            "Meta-wikibase config field 'meta_wikibase.value_list_talk_pages.rules' must be a list"
+        )
+
+    parsed_rules: list[ValueListTalkPageRule] = []
+    for index, rule in enumerate(raw_rules):
+        if not isinstance(rule, dict):
+            raise RuntimeError(
+                "Meta-wikibase value-list talk-page rule "
+                f"at index {index} must be a mapping"
+            )
+
+        class_name_identifier = _read_optional_string(rule, "class_name_identifier")
+        block_type = _read_optional_string(rule, "block_type")
+        artifact_store = _read_optional_string(rule, "artifact_store")
+
+        if not class_name_identifier:
+            raise RuntimeError(
+                "Meta-wikibase value-list talk-page rules require 'class_name_identifier'"
+            )
+        if block_type not in {"sparql", "json"}:
+            raise RuntimeError(
+                "Meta-wikibase value-list talk-page rules require block_type 'sparql' or 'json'"
+            )
+        if artifact_store not in {"value_list_queries", "value_list_cache"}:
+            raise RuntimeError(
+                "Meta-wikibase value-list talk-page rules require artifact_store 'value_list_queries' or 'value_list_cache'"
+            )
+
+        parsed_rules.append(
+            ValueListTalkPageRule(
+                class_name_identifier=class_name_identifier,
+                block_type=block_type,
+                artifact_store=artifact_store,
+            )
+        )
+
+    return tuple(parsed_rules)
 
 
 def _load_spiritsafe_layout(raw_config: dict[object, object]) -> SpiritSafeLayout:
@@ -278,6 +346,7 @@ def load_meta_wikibase_config(path: Path) -> MetaWikibaseConfigValues:
             semantic_conventions, "internal_name_identifier_prefix"
         ),
         "spiritsafe_layout": _load_spiritsafe_layout(raw_config),
+        "value_list_talk_page_rules": _load_value_list_talk_page_rules(meta_config),
     }
 
 
@@ -337,4 +406,5 @@ def get_wikibase_runtime_config() -> WikibaseRuntimeConfig:
             "internal_name_identifier_prefix"
         ),
         spiritsafe_layout=config_values.get("spiritsafe_layout", SpiritSafeLayout()),
+        value_list_talk_page_rules=config_values.get("value_list_talk_page_rules", ()),
     )

--- a/gkc/shipper.py
+++ b/gkc/shipper.py
@@ -331,6 +331,7 @@ class WikibaseShipper(Shipper):
         tags: Optional[list[str]] = None,
         bot: bool = False,
         metadata: Optional[dict[str, Any]] = None,
+        base_revision_id: Optional[int] = None,
     ) -> WriteResult:
         """Create or update a Wikibase item.
 
@@ -391,6 +392,7 @@ class WikibaseShipper(Shipper):
             csrf_token=csrf_token,
             tags=tags,
             bot=bot,
+            base_revision_id=base_revision_id,
         )
 
         response = self.auth.session.post(self.api_url, data=request_data)
@@ -434,6 +436,7 @@ class WikibaseShipper(Shipper):
         tags: Optional[list[str]] = None,
         bot: bool = False,
         metadata: Optional[dict[str, Any]] = None,
+        base_revision_id: Optional[int] = None,
     ) -> WriteResult:
         """Create or update a Wikibase property.
 
@@ -500,6 +503,7 @@ class WikibaseShipper(Shipper):
             csrf_token=csrf_token,
             tags=tags,
             bot=bot,
+            base_revision_id=base_revision_id,
         )
 
         response = self.auth.session.post(self.api_url, data=request_data)
@@ -606,14 +610,15 @@ class WikibaseShipper(Shipper):
                 request_payload=None,
             )
 
-        is_valid, warnings = self._validate_payload(payload)
+        normalized_payload = self._normalize_payload(payload)
+        is_valid, warnings = self._validate_payload(normalized_payload)
         if not is_valid:
             return DiffOperation(
                 kind=kind,
                 label=label,
                 status="blocked",
                 reasons=warnings,
-                request_payload=copy.deepcopy(payload),
+                request_payload=copy.deepcopy(normalized_payload),
             )
 
         entity_type = "property" if kind == "property" else "item"
@@ -658,7 +663,7 @@ class WikibaseShipper(Shipper):
                     label=label,
                     status="blocked",
                     reasons=["datatype is required to create a property"],
-                    request_payload=copy.deepcopy(payload),
+                    request_payload=copy.deepcopy(normalized_payload),
                 )
 
             create_reasons.append("No matching entity found by exact label")
@@ -668,14 +673,14 @@ class WikibaseShipper(Shipper):
                 status="create",
                 entity_id=None,
                 reasons=create_reasons,
-                request_payload=copy.deepcopy(payload),
+                request_payload=copy.deepcopy(normalized_payload),
                 metadata={"datatype": datatype} if datatype else {},
             )
 
         existing = api.get_entity(target_id)
         patch, diff_reasons = self._build_patch_payload(
             existing=existing,
-            desired=payload,
+            desired=normalized_payload,
             language=language,
             kind=kind,
             desired_datatype=datatype,
@@ -815,16 +820,34 @@ class WikibaseShipper(Shipper):
                 patch["descriptions"] = descriptions_patch
                 reasons.append("descriptions differ")
 
-        desired_claims = desired.get("claims")
-        if isinstance(desired_claims, list) and desired_claims:
+        desired_claims = self._flatten_claims_payload(desired.get("claims"))
+        if desired_claims:
             existing_claims = existing.get("claims", {})
-            missing_claims = [
-                claim
-                for claim in desired_claims
-                if not self._entity_has_matching_claim(existing_claims, claim)
-            ]
-            if missing_claims:
-                patch["claims"] = missing_claims
+            claim_patches: list[dict[str, Any]] = []
+            for claim in desired_claims:
+                if self._entity_has_matching_claim(existing_claims, claim):
+                    continue
+
+                replacement_claim = copy.deepcopy(claim)
+                desired_property = replacement_claim.get("mainsnak", {}).get("property")
+                existing_property_claims = (
+                    existing_claims.get(desired_property, [])
+                    if isinstance(existing_claims, dict)
+                    else []
+                )
+                if isinstance(existing_property_claims, list):
+                    for existing_claim in existing_property_claims:
+                        if not isinstance(existing_claim, dict):
+                            continue
+                        existing_claim_id = existing_claim.get("id")
+                        if isinstance(existing_claim_id, str) and existing_claim_id:
+                            replacement_claim["id"] = existing_claim_id
+                            break
+
+                claim_patches.append(replacement_claim)
+
+            if claim_patches:
+                patch["claims"] = claim_patches
                 reasons.append("claims differ")
 
         if kind == "property" and desired_datatype:
@@ -856,21 +879,30 @@ class WikibaseShipper(Shipper):
         """
         desired_mainsnak = desired_claim.get("mainsnak", {})
         desired_property = desired_mainsnak.get("property")
-        desired_datavalue = desired_mainsnak.get("datavalue", {})
-        desired_value = desired_datavalue.get("value")
 
         if not desired_property:
             return False
 
+        desired_value = self._claim_comparison_value(desired_claim)
         existing_property_claims = existing_claims.get(desired_property) or []
         for existing_claim in existing_property_claims:
-            existing_value = (
-                existing_claim.get("mainsnak", {}).get("datavalue", {}).get("value")
-            )
-            if existing_value == desired_value:
+            if self._claim_comparison_value(existing_claim) == desired_value:
                 return True
 
         return False
+
+    def _claim_comparison_value(self, claim: dict[str, Any]) -> Any:
+        """Return a stable comparison value for a claim mainsnak."""
+
+        mainsnak = claim.get("mainsnak", {}) if isinstance(claim, dict) else {}
+        snaktype = mainsnak.get("snaktype")
+        if snaktype == "novalue":
+            return {"snaktype": "novalue"}
+
+        datavalue = mainsnak.get("datavalue", {})
+        if isinstance(datavalue, dict):
+            return datavalue.get("value")
+        return None
 
     def _normalize_payload(self, payload: dict) -> dict:
         """Create a deep copy of a payload for safe internal manipulation.
@@ -884,7 +916,36 @@ class WikibaseShipper(Shipper):
         Returns:
             Deep copy of the payload
         """
-        return copy.deepcopy(payload)
+        normalized = copy.deepcopy(payload)
+        claims = normalized.get("claims")
+        if isinstance(claims, dict):
+            normalized["claims"] = self._flatten_claims_payload(claims)
+        return normalized
+
+    def _flatten_claims_payload(self, claims: Any) -> list[dict[str, Any]]:
+        """Convert claim mappings or lists into the wbeditentity list format."""
+
+        if isinstance(claims, list):
+            return [copy.deepcopy(claim) for claim in claims if isinstance(claim, dict)]
+
+        if not isinstance(claims, dict):
+            return []
+
+        flattened: list[dict[str, Any]] = []
+        for property_id in sorted(claims.keys()):
+            property_claims = claims.get(property_id)
+            if not isinstance(property_claims, list):
+                continue
+            for claim in property_claims:
+                if not isinstance(claim, dict):
+                    continue
+                normalized_claim = copy.deepcopy(claim)
+                mainsnak = normalized_claim.get("mainsnak")
+                if isinstance(mainsnak, dict) and not mainsnak.get("property"):
+                    mainsnak["property"] = property_id
+                flattened.append(normalized_claim)
+
+        return flattened
 
     def _validate_payload(self, payload: dict) -> tuple[bool, list[str]]:
         """Validate a Wikibase entity payload.
@@ -931,6 +992,7 @@ class WikibaseShipper(Shipper):
         csrf_token: str,
         tags: Optional[list[str]],
         bot: bool,
+        base_revision_id: Optional[int] = None,
     ) -> dict:
         """Build MediaWiki API request parameters for item create/update.
 
@@ -972,6 +1034,9 @@ class WikibaseShipper(Shipper):
         if bot:
             request_data["bot"] = "1"
 
+        if base_revision_id is not None:
+            request_data["baserevid"] = int(base_revision_id)
+
         return request_data
 
     def _build_property_request_data(
@@ -983,6 +1048,7 @@ class WikibaseShipper(Shipper):
         csrf_token: str,
         tags: Optional[list[str]],
         bot: bool,
+        base_revision_id: Optional[int] = None,
     ) -> dict:
         """Build MediaWiki API request parameters for property create/update.
 
@@ -1027,6 +1093,9 @@ class WikibaseShipper(Shipper):
 
         if bot:
             request_data["bot"] = "1"
+
+        if base_revision_id is not None:
+            request_data["baserevid"] = int(base_revision_id)
 
         return request_data
 

--- a/gkc/spirit_safe.py
+++ b/gkc/spirit_safe.py
@@ -36,6 +36,7 @@ from gkc.runtime_config import (
     DEFAULT_META_WB_CONFIG_SEARCH_DIRS,
     MetaWikibaseConfigValues,
     SpiritSafeLayout,
+    ValueListTalkPageRule,
     default_meta_wikibase_config_values,
     discover_meta_wikibase_config_path,
     get_wikibase_runtime_config,
@@ -50,6 +51,7 @@ from gkc.wikibase import (
     get_meta_wikibase_init_contract_digest,
     normalize_meta_wikibase_current_entity_view,
     normalize_meta_wikibase_required_entity_view,
+    plan_meta_wikibase_seed_baseline,
 )
 
 RefreshPolicy = Literal["manual", "daily", "weekly", "on_release"]
@@ -759,32 +761,116 @@ class ValueListHydrationResult:
     hydrated_ids: list[str] = field(default_factory=list)
     query_files_written: list[str] = field(default_factory=list)
     cache_files_written: list[str] = field(default_factory=list)
+    query_files_deleted: list[str] = field(default_factory=list)
+    cache_files_deleted: list[str] = field(default_factory=list)
     failures: list[dict[str, Any]] = field(default_factory=list)
 
 
-def discover_value_list_ids(
+def _extract_claim_entity_ids(claims: Any) -> set[str]:
+    entity_ids: set[str] = set()
+    if not isinstance(claims, list):
+        return entity_ids
+
+    for claim in claims:
+        value = claim.get("mainsnak", {}).get("datavalue", {}).get("value", {})
+        if isinstance(value, dict):
+            entity_id = value.get("id")
+            if isinstance(entity_id, str) and entity_id:
+                entity_ids.add(entity_id)
+
+    return entity_ids
+
+
+def _optional_anchor_item_id(
+    resolver: SpiritSafeSemanticAnchorResolver,
+    anchor_name: str,
+) -> Optional[str]:
+    anchor = resolver.get(anchor_name)
+    if anchor is None:
+        return None
+    if anchor.kind != "item":
+        raise RuntimeError(
+            f"Semantic anchor '{anchor_name}' resolves to {anchor.entity_id}, expected an item"
+        )
+    return anchor.entity_id
+
+
+def _fallback_value_list_talk_page_rules(
+    resolver: SpiritSafeSemanticAnchorResolver,
+) -> tuple[ValueListTalkPageRule, ...]:
+    """Provide a compatibility fallback when YAML rules are not yet authored."""
+
+    rules: list[ValueListTalkPageRule] = []
+
+    sparql_anchor = (
+        "_sparql_value_list" if resolver.get("_sparql_value_list") else "_value_list"
+    )
+    if resolver.get(sparql_anchor) is not None:
+        rules.append(
+            ValueListTalkPageRule(
+                class_name_identifier=sparql_anchor,
+                block_type="sparql",
+                artifact_store="value_list_queries",
+            )
+        )
+
+    if resolver.get("_embedded_value_list") is not None:
+        rules.append(
+            ValueListTalkPageRule(
+                class_name_identifier="_embedded_value_list",
+                block_type="json",
+                artifact_store="value_list_cache",
+            )
+        )
+
+    return tuple(rules)
+
+
+def _resolve_value_list_talk_page_rules(
+    cache_entities_dir: Union[str, Path],
+    *,
+    resolver: SpiritSafeSemanticAnchorResolver,
+) -> tuple[ValueListTalkPageRule, ...]:
+    cache_dir = Path(cache_entities_dir).expanduser().resolve()
+    config_path = discover_meta_wikibase_config_path(start_dir=cache_dir)
+    if config_path is not None:
+        config_values = load_meta_wikibase_config(config_path)
+        configured_rules = tuple(config_values.get("value_list_talk_page_rules", ()))
+        if configured_rules:
+            return configured_rules
+
+    return _fallback_value_list_talk_page_rules(resolver)
+
+
+def _discover_value_list_artifact_kinds(
     cache_entities_dir: Union[str, Path],
     *,
     value_list_class_id: Optional[str] = None,
     semantic_anchor_document: Optional[dict[str, Any]] = None,
-) -> list[str]:
-    """Discover all value-list entity IDs from SpiritSafe cache entities.
+) -> dict[str, Literal["sparql", "json"]]:
+    """Discover value-list entities and the expected SpiritSafe artifact type."""
 
-    Value lists are identified by `P1 -> Q7` classification in cached entity claims.
-    """
     cache_dir = Path(cache_entities_dir)
-    resolved_value_list_class_id = value_list_class_id
-    instance_of_property_id: str
-
     resolver = _resolve_semantic_anchor_resolver_for_cache_entities_dir(
         cache_dir,
         semantic_anchor_document=semantic_anchor_document,
     )
     instance_of_property_id = resolver.require_property_id("_instance_of")
-    if resolved_value_list_class_id is None:
-        resolved_value_list_class_id = resolver.require_item_id("_value_list")
+    configured_rules = list(
+        _resolve_value_list_talk_page_rules(cache_dir, resolver=resolver)
+    )
 
-    discovered: list[str] = []
+    rule_class_ids: list[tuple[str, Literal["sparql", "json"]]] = []
+    if value_list_class_id:
+        rule_class_ids.append((value_list_class_id, "sparql"))
+
+    for rule in configured_rules:
+        class_id = _optional_anchor_item_id(resolver, rule.class_name_identifier)
+        if class_id is None:
+            continue
+        rule_class_ids.append((class_id, rule.block_type))
+
+    discovered: dict[str, Literal["sparql", "json"]] = {}
 
     for path in sorted(cache_dir.glob("*.json")):
         try:
@@ -797,13 +883,56 @@ def discover_value_list_ids(
             continue
 
         claims = payload.get("entity", {}).get("claims", {})
-        p1_claims = (
+        instance_of_claims = (
             claims.get(instance_of_property_id, []) if isinstance(claims, dict) else []
         )
-        if _claims_include_entity_id(p1_claims, resolved_value_list_class_id):
-            discovered.append(entity_id)
+        class_ids = _extract_claim_entity_ids(instance_of_claims)
+        if not class_ids:
+            continue
 
-    return sorted(discovered)
+        for class_id, artifact_kind in rule_class_ids:
+            if class_id in class_ids:
+                discovered[entity_id] = artifact_kind
+                break
+
+    return {entity_id: discovered[entity_id] for entity_id in sorted(discovered)}
+
+
+def discover_value_list_ids(
+    cache_entities_dir: Union[str, Path],
+    *,
+    value_list_class_id: Optional[str] = None,
+    semantic_anchor_document: Optional[dict[str, Any]] = None,
+) -> list[str]:
+    """Discover all value-list entity IDs from SpiritSafe cache entities."""
+
+    return sorted(
+        _discover_value_list_artifact_kinds(
+            cache_entities_dir,
+            value_list_class_id=value_list_class_id,
+            semantic_anchor_document=semantic_anchor_document,
+        ).keys()
+    )
+
+
+def _is_missing_value_list_talk_page_error(exc: Exception) -> bool:
+    lowered = str(exc).lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "not found",
+            "no revision content",
+            "no <sparql>",
+            "no json <syntaxhighlight>",
+        )
+    )
+
+
+def _delete_artifact_if_exists(path: Path) -> Optional[str]:
+    if not path.exists():
+        return None
+    path.unlink()
+    return str(path.resolve())
 
 
 def export_value_list_sparql_queries(
@@ -816,33 +945,48 @@ def export_value_list_sparql_queries(
 ) -> dict[str, Any]:
     """Export first `<sparql>` talk-page blocks into SpiritSafe query files.
 
-    Writes one file per value-list ID as `<queries_dir>/<QID>.sparql`.
+    Missing SPARQL blocks are treated as deletions and remove any stale local
+    `.sparql` artifact for the corresponding value-list item.
     """
-    selected_ids = sorted(
-        set(
-            value_list_ids
-            or discover_value_list_ids(
-                cache_entities_dir,
-                semantic_anchor_document=semantic_anchor_document,
-            )
-        )
+    discovered_kinds = _discover_value_list_artifact_kinds(
+        cache_entities_dir,
+        semantic_anchor_document=semantic_anchor_document,
     )
+    if value_list_ids is None:
+        selected_ids = [
+            entity_id
+            for entity_id, artifact_kind in discovered_kinds.items()
+            if artifact_kind == "sparql"
+        ]
+    else:
+        selected_ids = sorted(set(value_list_ids))
+
     out_dir = Path(queries_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     api_client = WikibaseApiClient(api_url=api_url)
     written_files: list[str] = []
+    deleted_files: list[str] = []
     failures: list[dict[str, Any]] = []
 
     for entity_id in selected_ids:
+        artifact_kind = discovered_kinds.get(entity_id, "sparql")
+        if artifact_kind != "sparql":
+            continue
+
         title = f"Item_talk:{entity_id}"
+        output_path = out_dir / f"{entity_id}.sparql"
         try:
             wikitext = fetch_mediawiki_page_wikitext(api_client=api_client, title=title)
             query_text = extract_first_sparql_block(wikitext)
-            output_path = out_dir / f"{entity_id}.sparql"
             output_path.write_text(query_text.strip() + "\n", encoding="utf-8")
             written_files.append(str(output_path.resolve()))
         except Exception as exc:
+            if _is_missing_value_list_talk_page_error(exc):
+                deleted = _delete_artifact_if_exists(output_path)
+                if deleted is not None:
+                    deleted_files.append(deleted)
+                continue
             failures.append(
                 {
                     "value_list_id": entity_id,
@@ -855,6 +999,7 @@ def export_value_list_sparql_queries(
         "value_list_ids": selected_ids,
         "queries_dir": str(out_dir.resolve()),
         "query_files_written": sorted(written_files),
+        "query_files_deleted": sorted(deleted_files),
         "failures": failures,
     }
 
@@ -935,6 +1080,107 @@ def hydrate_value_list_query_caches(
     }
 
 
+def sync_value_list_artifacts_from_cache(
+    *,
+    cache_entities_dir: Union[str, Path],
+    queries_dir: Union[str, Path],
+    cache_queries_dir: Union[str, Path],
+    api_url: str,
+    value_list_ids: Optional[list[str]] = None,
+    semantic_anchor_document: Optional[dict[str, Any]] = None,
+    fail_on_error: bool = True,
+) -> ValueListHydrationResult:
+    """Sync only the talk-page-derived SpiritSafe value-list artifacts."""
+
+    query_root = Path(queries_dir)
+    cache_root = Path(cache_queries_dir)
+    query_root.mkdir(parents=True, exist_ok=True)
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    discovered_kinds = _discover_value_list_artifact_kinds(
+        cache_entities_dir,
+        semantic_anchor_document=semantic_anchor_document,
+    )
+    selected_ids = sorted(set(value_list_ids or discovered_kinds.keys()))
+    selected_kinds = {
+        entity_id: discovered_kinds.get(entity_id, "sparql")
+        for entity_id in selected_ids
+    }
+
+    api_client = WikibaseApiClient(api_url=api_url)
+    query_files_written: list[str] = []
+    cache_files_written: list[str] = []
+    query_files_deleted: list[str] = []
+    cache_files_deleted: list[str] = []
+    sync_failures: list[dict[str, Any]] = []
+
+    for entity_id in selected_ids:
+        artifact_kind = selected_kinds.get(entity_id, "sparql")
+        title = f"Item_talk:{entity_id}"
+        try:
+            wikitext = fetch_mediawiki_page_wikitext(api_client=api_client, title=title)
+            if artifact_kind == "json":
+                payload = _extract_first_json_syntaxhighlight_block(wikitext)
+                output_path = cache_root / f"{entity_id}.json"
+                output_path.write_text(
+                    json.dumps(payload, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+                cache_files_written.append(str(output_path.resolve()))
+                deleted_query = _delete_artifact_if_exists(
+                    query_root / f"{entity_id}.sparql"
+                )
+                if deleted_query is not None:
+                    query_files_deleted.append(deleted_query)
+            else:
+                query_text = extract_first_sparql_block(wikitext)
+                output_path = query_root / f"{entity_id}.sparql"
+                output_path.write_text(query_text.strip() + "\n", encoding="utf-8")
+                query_files_written.append(str(output_path.resolve()))
+        except Exception as exc:
+            if _is_missing_value_list_talk_page_error(exc):
+                deleted_query = _delete_artifact_if_exists(
+                    query_root / f"{entity_id}.sparql"
+                )
+                if deleted_query is not None:
+                    query_files_deleted.append(deleted_query)
+
+                deleted_cache = _delete_artifact_if_exists(
+                    cache_root / f"{entity_id}.json"
+                )
+                if deleted_cache is not None:
+                    cache_files_deleted.append(deleted_cache)
+                continue
+
+            sync_failures.append(
+                {
+                    "value_list_id": entity_id,
+                    "artifact_kind": artifact_kind,
+                    "source_title": title,
+                    "error": str(exc),
+                }
+            )
+
+    if sync_failures and fail_on_error:
+        first = sync_failures[0]
+        raise RuntimeError(
+            "Failed to sync value-list artifact "
+            f"for {first.get('value_list_id')}: {first.get('error')}"
+        )
+
+    return ValueListHydrationResult(
+        queries_dir=str(query_root.resolve()),
+        cache_queries_dir=str(cache_root.resolve()),
+        discovered_ids=selected_ids,
+        hydrated_ids=[],
+        query_files_written=sorted(set(query_files_written)),
+        cache_files_written=sorted(set(cache_files_written)),
+        query_files_deleted=sorted(set(query_files_deleted)),
+        cache_files_deleted=sorted(set(cache_files_deleted)),
+        failures=sync_failures,
+    )
+
+
 def hydrate_value_lists_from_cache(
     *,
     cache_entities_dir: Union[str, Path],
@@ -948,40 +1194,44 @@ def hydrate_value_lists_from_cache(
     max_results: Optional[int] = None,
     fail_on_hydration_error: bool = True,
 ) -> ValueListHydrationResult:
-    """Export value-list SPARQL files and hydrate value-list cache artifacts."""
-    export_summary = export_value_list_sparql_queries(
+    """Sync talk-page-derived value-list artifacts and hydrate SPARQL caches."""
+
+    sync_result = sync_value_list_artifacts_from_cache(
         cache_entities_dir=cache_entities_dir,
         queries_dir=queries_dir,
+        cache_queries_dir=cache_queries_dir,
         api_url=api_url,
         value_list_ids=value_list_ids,
         semantic_anchor_document=semantic_anchor_document,
+        fail_on_error=fail_on_hydration_error,
     )
 
-    export_failures = list(export_summary.get("failures", []))
-    if export_failures and fail_on_hydration_error:
-        first = export_failures[0]
-        raise RuntimeError(
-            "Failed to export value-list SPARQL query "
-            f"for {first.get('value_list_id')}: {first.get('error')}"
-        )
-
-    eligible_ids = [
-        value_list_id
-        for value_list_id in export_summary["value_list_ids"]
-        if value_list_id not in {f.get("value_list_id") for f in export_failures}
+    query_root = Path(sync_result.queries_dir)
+    sparql_ids_for_hydration = [
+        entity_id
+        for entity_id in sync_result.discovered_ids
+        if (query_root / f"{entity_id}.sparql").exists()
     ]
 
-    hydrate_summary = hydrate_value_list_query_caches(
-        value_list_ids=eligible_ids,
-        queries_dir=queries_dir,
-        cache_queries_dir=cache_queries_dir,
-        endpoint=endpoint,
-        page_size=page_size,
-        max_results=max_results,
-        wikibase_api_url=api_url,
-    )
+    if sparql_ids_for_hydration:
+        hydrate_summary = hydrate_value_list_query_caches(
+            value_list_ids=sparql_ids_for_hydration,
+            queries_dir=sync_result.queries_dir,
+            cache_queries_dir=sync_result.cache_queries_dir,
+            endpoint=endpoint,
+            page_size=page_size,
+            max_results=max_results,
+            wikibase_api_url=api_url,
+        )
+    else:
+        hydrate_summary = {
+            "cache_queries_dir": str(Path(sync_result.cache_queries_dir).resolve()),
+            "hydrated_ids": [],
+            "cache_files_written": [],
+            "failures": [],
+        }
 
-    failures = export_failures + list(hydrate_summary.get("failures", []))
+    failures = list(sync_result.failures) + list(hydrate_summary.get("failures", []))
     if failures and fail_on_hydration_error:
         first = failures[0]
         raise RuntimeError(
@@ -990,12 +1240,17 @@ def hydrate_value_lists_from_cache(
         )
 
     return ValueListHydrationResult(
-        queries_dir=export_summary["queries_dir"],
-        cache_queries_dir=hydrate_summary["cache_queries_dir"],
-        discovered_ids=sorted(export_summary["value_list_ids"]),
+        queries_dir=sync_result.queries_dir,
+        cache_queries_dir=sync_result.cache_queries_dir,
+        discovered_ids=sync_result.discovered_ids,
         hydrated_ids=sorted(hydrate_summary["hydrated_ids"]),
-        query_files_written=sorted(export_summary["query_files_written"]),
-        cache_files_written=sorted(hydrate_summary["cache_files_written"]),
+        query_files_written=sync_result.query_files_written,
+        cache_files_written=sorted(
+            set(sync_result.cache_files_written)
+            | set(hydrate_summary.get("cache_files_written", []))
+        ),
+        query_files_deleted=sync_result.query_files_deleted,
+        cache_files_deleted=sync_result.cache_files_deleted,
         failures=failures,
     )
 
@@ -1161,8 +1416,9 @@ class EntityProfileJsonBuilder:
         self.name_identifier_property_id = (
             self.semantic_anchor_resolver.require_property_id("_name_identifier")
         )
-        self.value_list_class_id = self.semantic_anchor_resolver.require_item_id(
-            "_value_list"
+        self.value_list_class_id = _optional_anchor_item_id(
+            self.semantic_anchor_resolver,
+            "_value_list",
         )
         self.statement_modifier_class_id = (
             self.semantic_anchor_resolver.require_item_id(
@@ -1637,7 +1893,11 @@ class EntityProfileJsonBuilder:
                 continue
 
             type_ids = self._entity_type_ids(self._cache_index.get(value_list_id))
-            if type_ids and self.value_list_class_id not in type_ids:
+            if (
+                self.value_list_class_id is not None
+                and type_ids
+                and self.value_list_class_id not in type_ids
+            ):
                 continue
 
             key = (statement_entity, value_list_id)
@@ -2139,16 +2399,19 @@ class EntityProfileJsonBuilder:
             target_label = self._entity_label(target_id)
             target_entity = f"{self.entity_prefix}{target_id}"
 
-            if self.profile_class_id in type_ids and "profile" not in payload:
+            is_profile_target = self.profile_class_id in type_ids
+            is_value_list_target = (
+                self.value_list_class_id is not None
+                and self.value_list_class_id in type_ids
+            )
+
+            if is_profile_target and "profile" not in payload:
                 payload["profile"] = {"entity": target_entity, "label": target_label}
 
-            if self.value_list_class_id in type_ids and "value_list_id" not in payload:
+            if is_value_list_target and "value_list_id" not in payload:
                 payload["value_list_id"] = target_id
 
-            if (
-                self.profile_class_id not in type_ids
-                and self.value_list_class_id not in type_ids
-            ):
+            if not is_profile_target and not is_value_list_target:
                 wikidata_urls = self._dedupe_preserve_order(
                     self._entity_string_claim_values(
                         target_doc, self.same_as_property_id
@@ -3232,6 +3495,783 @@ def export_spiritsafe_semantic_anchors(
         json.dumps(semantic_anchor_document, indent=2), encoding="utf-8"
     )
     return semantic_anchor_document
+
+
+def _extract_name_identifier_values_from_cached_entity(
+    entity_payload: dict[str, Any],
+    *,
+    name_identifier_property_id: str,
+) -> set[str]:
+    """Extract internal name-identifier values from one cached entity payload."""
+
+    claims = entity_payload.get("claims")
+    if not isinstance(claims, dict):
+        return set()
+
+    raw_claims = claims.get(name_identifier_property_id)
+    if not isinstance(raw_claims, list):
+        return set()
+
+    values: set[str] = set()
+    for claim in raw_claims:
+        if not isinstance(claim, dict):
+            continue
+        datavalue = claim.get("mainsnak", {}).get("datavalue", {})
+        value = datavalue.get("value")
+        if isinstance(value, str) and value:
+            values.add(value)
+    return values
+
+
+def _meta_wikibase_payload_label(payload: dict[str, Any]) -> str:
+    """Return the best available human label from a compiled seed payload."""
+
+    labels = payload.get("labels")
+    if not isinstance(labels, dict):
+        return ""
+
+    for language_payload in labels.values():
+        if not isinstance(language_payload, dict):
+            continue
+        value = language_payload.get("value")
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _format_meta_wikibase_report_value(
+    value: Any,
+    *,
+    entity_id_to_internal_name_identifier: dict[str, str],
+    current_entity_ids_by_internal_name_identifier: dict[str, str],
+) -> Any:
+    """Format comparison values for human-facing reports with URI + name-identifier."""
+
+    if isinstance(value, list):
+        return [
+            _format_meta_wikibase_report_value(
+                item,
+                entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+            )
+            for item in value
+        ]
+
+    if isinstance(value, dict):
+        if value.get("type") == "wikibase-entityid" and isinstance(
+            value.get("value"), dict
+        ):
+            entity_value = value["value"]
+            raw_id = entity_value.get("id")
+            name_identifier = None
+            resolved_reference = raw_id
+
+            if isinstance(raw_id, str) and raw_id:
+                if raw_id.startswith("_"):
+                    name_identifier = raw_id
+                    resolved_reference = (
+                        current_entity_ids_by_internal_name_identifier.get(raw_id)
+                    )
+                else:
+                    resolved_entity_id = _entity_id_from_reference(raw_id)
+                    if resolved_entity_id is not None:
+                        name_identifier = entity_id_to_internal_name_identifier.get(
+                            resolved_entity_id
+                        )
+
+            return {
+                "type": "wikibase-entityid",
+                "value": {
+                    "entity-type": entity_value.get("entity-type"),
+                    "id": _entity_uri_from_reference(resolved_reference),
+                    "name_identifier": name_identifier,
+                },
+            }
+
+        return {
+            key: _format_meta_wikibase_report_value(
+                nested_value,
+                entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+            )
+            for key, nested_value in value.items()
+        }
+
+    return value
+
+
+def _build_meta_wikibase_report_differences(
+    *,
+    changed_fields: list[str] | None,
+    required_view: dict[str, Any],
+    current_view: dict[str, Any] | None,
+    entity_id_to_internal_name_identifier: dict[str, str],
+    current_entity_ids_by_internal_name_identifier: dict[str, str],
+) -> dict[str, dict[str, Any]]:
+    """Return field-by-field expected/current difference detail for report consumers."""
+
+    if not changed_fields:
+        return {}
+
+    expected_claims = required_view.get("claims", {})
+    current_claims = (current_view or {}).get("claims", {})
+    differences: dict[str, dict[str, Any]] = {}
+
+    for field_name in changed_fields:
+        if field_name.startswith("claims."):
+            property_id = field_name.split(".", 1)[1]
+            expected_value = expected_claims.get(property_id)
+            current_value = current_claims.get(property_id)
+        elif "." in field_name and field_name.split(".", 1)[0].startswith("_"):
+            property_id = field_name.split(".", 1)[0]
+            expected_value = expected_claims.get(property_id)
+            current_value = current_claims.get(property_id)
+        else:
+            expected_value = required_view.get(field_name)
+            current_value = (current_view or {}).get(field_name)
+
+        differences[field_name] = {
+            "expected": _format_meta_wikibase_report_value(
+                expected_value,
+                entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+            ),
+            "current": _format_meta_wikibase_report_value(
+                current_value,
+                entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+            ),
+        }
+
+    return differences
+
+
+def _normalize_meta_wikibase_talk_page_text(value: Any) -> Optional[str]:
+    """Normalize multiline talk-page text for stable comparison."""
+
+    if not isinstance(value, str):
+        return None
+
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    return "\n".join(line.rstrip() for line in stripped.splitlines())
+
+
+def _extract_first_json_syntaxhighlight_block(wikitext: str) -> Any:
+    """Return the first JSON syntaxhighlight block parsed as JSON."""
+
+    matches = re.findall(
+        r"<\s*syntaxhighlight(?:\s+[^>]*)?>(.*?)</\s*syntaxhighlight\s*>",
+        wikitext,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    for match in matches:
+        snippet = match.strip()
+        if not snippet:
+            continue
+        try:
+            return json.loads(snippet)
+        except json.JSONDecodeError:
+            continue
+
+    raise RuntimeError("No JSON <syntaxhighlight> block found in page content")
+
+
+def _normalize_meta_wikibase_value_list_content(value: Any) -> Any:
+    """Normalize value-list cache payloads for stable comparison."""
+
+    if isinstance(value, dict):
+        if isinstance(value.get("items"), list):
+            value = value["items"]
+        elif isinstance(value.get("value_list"), list):
+            value = value["value_list"]
+        else:
+            return {
+                key: _normalize_meta_wikibase_value_list_content(nested_value)
+                for key, nested_value in sorted(value.items())
+            }
+
+    if isinstance(value, list):
+        normalized_items = [
+            _normalize_meta_wikibase_value_list_content(item) for item in value
+        ]
+        return sorted(
+            normalized_items,
+            key=lambda item: json.dumps(item, sort_keys=True, ensure_ascii=False),
+        )
+
+    return value
+
+
+def _build_meta_wikibase_talk_page_contract(
+    *,
+    entity_definition: Any,
+    current_entity_id: str | None,
+) -> Optional[dict[str, Any]]:
+    """Return the authored talk-page contract for one Meta-Wikibase entity."""
+
+    attributes = entity_definition.attributes or {}
+    title = f"Item_talk:{current_entity_id}" if current_entity_id else None
+
+    query_text = _normalize_meta_wikibase_talk_page_text(attributes.get("query"))
+    if query_text is not None:
+        return {
+            "title": title,
+            "block_type": "sparql",
+            "content": query_text,
+        }
+
+    value_list = attributes.get("value_list")
+    if isinstance(value_list, (list, dict)):
+        return {
+            "title": title,
+            "block_type": "json",
+            "content": _normalize_meta_wikibase_value_list_content(
+                deepcopy(value_list)
+            ),
+        }
+
+    return None
+
+
+def _assess_meta_wikibase_talk_page_conformance(
+    *,
+    entity_definition: Any,
+    current_entity_id: str | None,
+    queries_dir: Optional[Path],
+    value_list_cache_dir: Optional[Path],
+) -> Optional[dict[str, Any]]:
+    """Compare authored talk-page contracts against materialized SpiritSafe artifacts."""
+
+    contract = _build_meta_wikibase_talk_page_contract(
+        entity_definition=entity_definition,
+        current_entity_id=current_entity_id,
+    )
+    if contract is None:
+        return None
+
+    block_type = str(contract.get("block_type") or "")
+    field_name = f"talk_page.{block_type}" if block_type else "talk_page"
+    expected = {
+        "title": contract.get("title"),
+        "block_type": block_type,
+        "content": deepcopy(contract.get("content")),
+    }
+
+    if not current_entity_id:
+        return {
+            "field": field_name,
+            "status": "planned",
+            "needs_update": False,
+            "expected": expected,
+            "current": None,
+            "details": "talk page content will need to be materialized after entity creation",
+        }
+
+    if queries_dir is None or value_list_cache_dir is None:
+        return {
+            "field": field_name,
+            "status": "unavailable",
+            "needs_update": False,
+            "expected": expected,
+            "current": None,
+            "details": "materialized SpiritSafe value-list artifact paths are unavailable",
+        }
+
+    title = str(contract.get("title") or f"Item_talk:{current_entity_id}")
+
+    try:
+        if block_type == "sparql":
+            artifact_path = queries_dir / f"{current_entity_id}.sparql"
+            if not artifact_path.exists():
+                raise FileNotFoundError(
+                    f"Missing materialized SPARQL artifact for {current_entity_id}"
+                )
+            current_content = _normalize_meta_wikibase_talk_page_text(
+                artifact_path.read_text(encoding="utf-8")
+            )
+        elif block_type == "json":
+            artifact_path = value_list_cache_dir / f"{current_entity_id}.json"
+            if not artifact_path.exists():
+                raise FileNotFoundError(
+                    f"Missing materialized JSON artifact for {current_entity_id}"
+                )
+            current_content = _normalize_meta_wikibase_value_list_content(
+                json.loads(artifact_path.read_text(encoding="utf-8"))
+            )
+        else:
+            current_content = None
+    except Exception as exc:
+        message = str(exc)
+        lowered = message.lower()
+        status = (
+            "missing"
+            if "missing materialized" in lowered or "no such file" in lowered
+            else "invalid"
+        )
+        return {
+            "field": field_name,
+            "status": status,
+            "needs_update": status in {"missing", "invalid"},
+            "expected": expected,
+            "current": None,
+            "details": message,
+        }
+
+    current = {
+        "title": title,
+        "block_type": block_type,
+        "content": deepcopy(current_content),
+    }
+    if current_content != contract.get("content"):
+        return {
+            "field": field_name,
+            "status": "drift",
+            "needs_update": True,
+            "expected": expected,
+            "current": current,
+            "details": "materialized value-list artifact differs from the authored contract",
+        }
+
+    return {
+        "field": field_name,
+        "status": "match",
+        "needs_update": False,
+        "expected": expected,
+        "current": current,
+        "details": "materialized value-list artifact matches the authored contract",
+    }
+
+
+def build_spiritsafe_meta_wikibase_conformance_report(
+    spiritsafe_root: Union[str, Path],
+    *,
+    semantic_anchor_document: Optional[dict[str, Any]] = None,
+    label_language: str = "en",
+    required_value_language: str = "mul",
+    inspect_talk_pages: bool = True,
+) -> dict[str, Any]:
+    """Evaluate cached SpiritSafe entities against the Meta-Wikibase init contract."""
+
+    root = Path(spiritsafe_root).expanduser().resolve()
+    layout = resolve_spiritsafe_layout(root)
+    cache_entities_dir = layout.entities_dir(root)
+    if not cache_entities_dir.is_dir():
+        raise FileNotFoundError(
+            f"Entity cache directory not found at {cache_entities_dir}"
+        )
+
+    config_path, meta_wikibase_config = resolve_spiritsafe_meta_wikibase_config(root)
+    _config_path, name_identifier_property_id, internal_prefix = (
+        _require_spiritsafe_meta_wikibase_semantics(root)
+    )
+    compilation = compile_meta_wikibase_seed(label_language=label_language)
+    init_index = build_meta_wikibase_init_index()
+
+    current_entities_by_internal_name_identifier: dict[str, dict[str, Any]] = {}
+    current_entity_ids_by_internal_name_identifier: dict[str, str] = {}
+    entity_id_to_internal_name_identifier: dict[str, str] = {}
+    cache_read_errors: list[str] = []
+    cache_file_count = 0
+
+    def register_current_entity(
+        internal_name_identifier: str,
+        *,
+        entity_id: str,
+        entity_payload: dict[str, Any],
+    ) -> None:
+        existing_entity_id = current_entity_ids_by_internal_name_identifier.get(
+            internal_name_identifier
+        )
+        if existing_entity_id is not None and existing_entity_id != entity_id:
+            raise RuntimeError(
+                "Multiple cached entities resolve to "
+                f"'{internal_name_identifier}': {existing_entity_id}, {entity_id}"
+            )
+        current_entity_ids_by_internal_name_identifier[internal_name_identifier] = (
+            entity_id
+        )
+        current_entities_by_internal_name_identifier[internal_name_identifier] = (
+            entity_payload
+        )
+
+    try:
+        resolver = _resolve_semantic_anchor_resolver_for_cache_entities_dir(
+            cache_entities_dir,
+            semantic_anchor_document=semantic_anchor_document,
+        )
+    except Exception:
+        resolver = None
+
+    if resolver is not None:
+        for anchor_name, anchor in resolver.anchors.items():
+            entity_id_to_internal_name_identifier[anchor.entity_id] = anchor_name
+
+    for entity_path in sorted(cache_entities_dir.glob("*.json")):
+        cache_file_count += 1
+        try:
+            entity_doc = json.loads(entity_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            cache_read_errors.append(f"{entity_path.name}: {exc}")
+            continue
+
+        entity_payload = entity_doc.get("entity")
+        if not isinstance(entity_payload, dict):
+            continue
+
+        entity_id = str(
+            entity_doc.get("entity_id") or entity_payload.get("id") or ""
+        ).strip()
+        if not entity_id:
+            continue
+
+        hinted_identifier = entity_id_to_internal_name_identifier.get(entity_id)
+        if hinted_identifier in compilation.by_internal_name_identifier:
+            register_current_entity(
+                hinted_identifier,
+                entity_id=entity_id,
+                entity_payload=entity_payload,
+            )
+
+        for value in sorted(
+            _extract_name_identifier_values_from_cached_entity(
+                entity_payload,
+                name_identifier_property_id=name_identifier_property_id,
+            )
+        ):
+            if not (internal_prefix and value.startswith(internal_prefix)):
+                continue
+            existing_value = entity_id_to_internal_name_identifier.get(entity_id)
+            if existing_value is not None and existing_value != value:
+                raise RuntimeError(
+                    f"Cached entity {entity_id} resolves to multiple internal name identifiers: {existing_value}, {value}"
+                )
+            entity_id_to_internal_name_identifier[entity_id] = value
+            if value in compilation.by_internal_name_identifier:
+                register_current_entity(
+                    value,
+                    entity_id=entity_id,
+                    entity_payload=entity_payload,
+                )
+
+    plan = plan_meta_wikibase_seed_baseline(
+        current_entities_by_internal_name_identifier=current_entities_by_internal_name_identifier,
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+        label_language=label_language,
+        required_value_language=required_value_language,
+    )
+    required_monolingualtext_properties = {
+        entity.internal_name_identifier
+        for entity in init_index.properties.values()
+        if entity.datatype == "monolingualtext"
+    }
+
+    talk_page_checked_count = 0
+    talk_page_drift_count = 0
+    talk_page_unavailable_count = 0
+    value_list_queries_dir = layout.value_list_queries_dir(root)
+    value_list_cache_dir = layout.value_list_cache_dir(root)
+
+    action_rows: list[dict[str, Any]] = []
+    for operation in plan.operations:
+        compiled_entity = compilation.by_internal_name_identifier[
+            operation.internal_name_identifier
+        ]
+        entity_definition = init_index.entities[compiled_entity.key]
+        required_view = normalize_meta_wikibase_required_entity_view(operation.payload)
+        current_view = None
+        current_entity = current_entities_by_internal_name_identifier.get(
+            operation.internal_name_identifier
+        )
+        if isinstance(current_entity, dict):
+            current_view, _issues = normalize_meta_wikibase_current_entity_view(
+                current_entity,
+                entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                label_language=label_language,
+                required_value_language=required_value_language,
+                required_monolingualtext_properties=required_monolingualtext_properties,
+                expected_property_ids=set(required_view.get("claims", {}).keys()),
+            )
+
+        changed_fields = list(operation.changed_fields or [])
+        talk_page = _assess_meta_wikibase_talk_page_conformance(
+            entity_definition=entity_definition,
+            current_entity_id=operation.current_entity_id,
+            queries_dir=value_list_queries_dir if inspect_talk_pages else None,
+            value_list_cache_dir=value_list_cache_dir if inspect_talk_pages else None,
+        )
+        if talk_page is not None:
+            talk_page_checked_count += 1
+            if talk_page.get("needs_update"):
+                talk_page_drift_count += 1
+                field_name = talk_page.get("field")
+                if isinstance(field_name, str) and field_name not in changed_fields:
+                    changed_fields.append(field_name)
+            elif talk_page.get("status") == "unavailable":
+                talk_page_unavailable_count += 1
+
+        action_name = operation.action
+        details = operation.details
+        if operation.action != "create":
+            if changed_fields:
+                action_name = "update"
+                details = "fields changed: " + ", ".join(changed_fields)
+            else:
+                action_name = "skip"
+                details = "matches current state"
+
+        differences = _build_meta_wikibase_report_differences(
+            changed_fields=changed_fields,
+            required_view=required_view,
+            current_view=current_view,
+            entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+            current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+        )
+        if (
+            talk_page is not None
+            and talk_page.get("field")
+            and talk_page.get("needs_update")
+        ):
+            differences[str(talk_page["field"])] = {
+                "expected": _format_meta_wikibase_report_value(
+                    talk_page.get("expected"),
+                    entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                    current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+                ),
+                "current": _format_meta_wikibase_report_value(
+                    talk_page.get("current"),
+                    entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                    current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+                ),
+            }
+
+        required_output = _format_meta_wikibase_report_value(
+            required_view,
+            entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+            current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+        )
+        current_output = (
+            _format_meta_wikibase_report_value(
+                current_view,
+                entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+            )
+            if current_view is not None
+            else None
+        )
+
+        if talk_page is not None:
+            required_output = dict(required_output)
+            required_output["talk_page"] = _format_meta_wikibase_report_value(
+                talk_page.get("expected"),
+                entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+            )
+            if current_output is None:
+                current_output = {}
+            else:
+                current_output = dict(current_output)
+            current_output["talk_page"] = _format_meta_wikibase_report_value(
+                talk_page.get("current"),
+                entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+                current_entity_ids_by_internal_name_identifier=current_entity_ids_by_internal_name_identifier,
+            )
+
+        action_rows.append(
+            {
+                "action": action_name,
+                "kind": operation.entity_type,
+                "label": _meta_wikibase_payload_label(compiled_entity.payload),
+                "id": _entity_uri_from_reference(operation.current_entity_id),
+                "name_identifier": operation.internal_name_identifier,
+                "details": details,
+                "changed_fields": changed_fields or None,
+                "differences": differences,
+                "required": required_output,
+                "current": current_output,
+                "key": operation.key,
+                "talk_page": talk_page,
+            }
+        )
+
+    summary = {
+        "created": sum(1 for row in action_rows if row["action"] == "create"),
+        "updated": sum(1 for row in action_rows if row["action"] == "update"),
+        "skipped": sum(1 for row in action_rows if row["action"] == "skip"),
+        "dry_run": len(action_rows),
+        "talk_page_updates": talk_page_drift_count,
+    }
+
+    return {
+        "metadata": {
+            "generated_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "contract_digest": get_meta_wikibase_init_contract_digest(),
+            "seed_entity_count": len(compilation.entities),
+            "label_language": label_language,
+            "value_language": required_value_language,
+        },
+        "comparison_source": {
+            "mode": "cache-entities",
+            "spiritsafe_root": str(root),
+            "cache_entities_dir": str(cache_entities_dir),
+            "config_path": str(config_path) if config_path is not None else None,
+            "name_identifier_property_id": name_identifier_property_id,
+            "internal_name_identifier_prefix": internal_prefix,
+            "anchor_hint_count": len(resolver.anchors) if resolver is not None else 0,
+            "cache_file_count": cache_file_count,
+            "resolved_entity_count": len(current_entities_by_internal_name_identifier),
+            "cache_read_error_count": len(cache_read_errors),
+            "value_list_queries_dir": str(value_list_queries_dir),
+            "value_list_cache_dir": str(value_list_cache_dir),
+            "talk_page_inspection_enabled": bool(inspect_talk_pages),
+            "talk_page_checked_count": talk_page_checked_count,
+            "talk_page_unavailable_count": talk_page_unavailable_count,
+        },
+        "summary": summary,
+        "actions": action_rows,
+        "cache_read_errors": cache_read_errors,
+    }
+
+
+def sync_spiritsafe_meta_wikibase_seed(
+    spiritsafe_root: Union[str, Path],
+    *,
+    shipper: Any | None = None,
+    dry_run: bool = True,
+    label_language: str = "en",
+    required_value_language: str = "mul",
+    inspect_talk_pages: bool = True,
+    summary_prefix: str = "Sync Meta-Wikibase seed",
+    tags: Optional[list[str]] = None,
+    bot: bool = False,
+) -> dict[str, Any]:
+    """Preview or execute Meta-Wikibase seed corrections through the standard write boundary."""
+
+    report = build_spiritsafe_meta_wikibase_conformance_report(
+        spiritsafe_root,
+        label_language=label_language,
+        required_value_language=required_value_language,
+        inspect_talk_pages=inspect_talk_pages,
+    )
+    compilation = compile_meta_wikibase_seed(label_language=label_language)
+
+    api_url = getattr(shipper, "api_url", None) if shipper is not None else None
+    if not api_url:
+        _config_path, meta_config = resolve_spiritsafe_meta_wikibase_config(
+            spiritsafe_root
+        )
+        api_url = meta_config.get("api_url")
+
+    fresh_api_client = (
+        WikibaseApiClient(api_url=api_url, timeout=20)
+        if isinstance(api_url, str) and api_url
+        else None
+    )
+
+    write_dry_run_count = 0
+    write_submitted_count = 0
+    write_skipped_count = 0
+    talk_page_pending_count = 0
+
+    synced_actions: list[dict[str, Any]] = []
+    for action in report.get("actions", []):
+        enriched_action = deepcopy(action)
+        changed_fields = list(action.get("changed_fields") or [])
+        write_fields = [
+            field_name
+            for field_name in changed_fields
+            if not str(field_name).startswith("talk_page.")
+        ]
+        talk_page_fields = [
+            field_name
+            for field_name in changed_fields
+            if str(field_name).startswith("talk_page.")
+        ]
+
+        if talk_page_fields:
+            enriched_action["talk_page_write_status"] = "planned"
+            talk_page_pending_count += 1
+
+        if action.get("action") == "skip" or not write_fields or shipper is None:
+            enriched_action["write_status"] = (
+                "pending" if write_fields and shipper is None else "skip"
+            )
+            write_skipped_count += 1
+            synced_actions.append(enriched_action)
+            continue
+
+        compiled_entity = compilation.by_internal_name_identifier.get(
+            str(action.get("name_identifier") or "")
+        )
+        if compiled_entity is None:
+            enriched_action["write_status"] = "error"
+            enriched_action["write_error"] = "Compiled payload not found for action"
+            synced_actions.append(enriched_action)
+            continue
+
+        entity_id = _entity_id_from_reference(action.get("id"))
+        base_revision_id = None
+        if entity_id and fresh_api_client is not None:
+            try:
+                fresh_entity = fresh_api_client.get_entity(entity_id)
+                if isinstance(fresh_entity, dict):
+                    revision_value = fresh_entity.get("lastrevid")
+                    if isinstance(revision_value, int):
+                        base_revision_id = revision_value
+            except Exception as exc:
+                enriched_action.setdefault("warnings", []).append(
+                    f"Fresh entity fetch failed: {exc}"
+                )
+
+        summary = f"{summary_prefix}: {action.get('name_identifier')}"
+        if compiled_entity.kind == "property":
+            result = shipper.write_property(
+                payload=compiled_entity.payload,
+                summary=summary,
+                datatype=str(compiled_entity.datatype or "string"),
+                entity_id=entity_id,
+                dry_run=dry_run,
+                tags=tags,
+                bot=bot,
+                metadata={"name_identifier": action.get("name_identifier")},
+                base_revision_id=base_revision_id,
+            )
+        else:
+            result = shipper.write_item(
+                payload=compiled_entity.payload,
+                summary=summary,
+                entity_id=entity_id,
+                dry_run=dry_run,
+                tags=tags,
+                bot=bot,
+                metadata={"name_identifier": action.get("name_identifier")},
+                base_revision_id=base_revision_id,
+            )
+
+        enriched_action["write_status"] = result.status
+        enriched_action["write_result"] = (
+            result.to_dict() if hasattr(result, "to_dict") else result
+        )
+
+        if result.status == "dry_run":
+            write_dry_run_count += 1
+        elif result.status == "submitted":
+            write_submitted_count += 1
+        else:
+            write_skipped_count += 1
+
+        synced_actions.append(enriched_action)
+
+    report["actions"] = synced_actions
+    report.setdefault("summary", {})["write_dry_run"] = write_dry_run_count
+    report.setdefault("summary", {})["write_submitted"] = write_submitted_count
+    report.setdefault("summary", {})["write_skipped"] = write_skipped_count
+    report.setdefault("summary", {})["talk_page_pending"] = talk_page_pending_count
+    return report
 
 
 def _statement_id_from_definition(statement: dict[str, Any]) -> Optional[str]:

--- a/gkc/wikibase.py
+++ b/gkc/wikibase.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass
 from functools import lru_cache
 from importlib.resources import files
@@ -287,49 +288,66 @@ def normalize_meta_wikibase_init_document(document: dict[str, Any]) -> dict[str,
     if not isinstance(entities, dict):
         raise RuntimeError("meta_wb_init document is missing entities")
 
-    wikibase_entities = entities.get("wikibase_entities")
-    if not isinstance(wikibase_entities, dict):
-        raise RuntimeError(
-            "meta_wb_init document is missing entities.wikibase_entities"
-        )
+    metadata_languages = _normalize_meta_wikibase_languages(metadata)
 
+    normalized_entities: dict[str, dict[str, Any]] = {}
     normalized_properties: dict[str, dict[str, Any]] = {}
-    raw_properties = wikibase_entities.get("properties", {})
-    if not isinstance(raw_properties, dict):
-        raise RuntimeError("meta_wb_init properties must be a mapping")
-    for key, payload in raw_properties.items():
-        if not isinstance(payload, dict):
-            raise RuntimeError(f"meta_wb_init property '{key}' must be a mapping")
-        normalized_payload = dict(payload)
-        normalized_payload["kind"] = "property"
-        datatype = normalized_payload.get("datatype")
-        if not isinstance(datatype, str) or not datatype.strip():
-            raise RuntimeError(f"meta_wb_init property '{key}' is missing datatype")
-        normalized_payload["datatype"] = canonicalize_wikibase_datatype(
-            datatype,
-            strict=True,
-        )
-        normalized_properties[key] = normalized_payload
 
-    normalized_items: dict[str, dict[str, Any]] = {}
-    raw_items = wikibase_entities.get("items", {})
-    if not isinstance(raw_items, dict):
-        raise RuntimeError("meta_wb_init items must be a mapping")
-    for key, payload in raw_items.items():
+    for key, payload in entities.items():
         if not isinstance(payload, dict):
-            raise RuntimeError(f"meta_wb_init item '{key}' must be a mapping")
+            raise RuntimeError(f"meta_wb_init entity '{key}' must be a mapping")
         normalized_payload = dict(payload)
-        normalized_payload["kind"] = "item"
-        normalized_items[key] = normalized_payload
+        kind = normalized_payload.get("kind")
+        if kind not in {"property", "item"}:
+            raise RuntimeError(
+                f"meta_wb_init entity '{key}' must define kind 'property' or 'item'"
+            )
+
+        normalized_payload["label"] = _normalize_meta_wikibase_authored_text(
+            normalized_payload,
+            field_name="label",
+            languages=metadata_languages,
+            entity_key=key,
+        )
+        normalized_payload["description"] = _normalize_meta_wikibase_authored_text(
+            normalized_payload,
+            field_name="description",
+            languages=metadata_languages,
+            entity_key=key,
+        )
+
+        if kind == "property":
+            datatype = normalized_payload.get("datatype")
+            if not isinstance(datatype, str) or not datatype.strip():
+                raise RuntimeError(f"meta_wb_init property '{key}' is missing datatype")
+            normalized_payload["datatype"] = canonicalize_wikibase_datatype(
+                datatype,
+                strict=True,
+            )
+            normalized_properties[key] = normalized_payload
+
+        normalized_entities[key] = normalized_payload
+
+    property_datatypes = {
+        property_key: str(property_payload["datatype"])
+        for property_key, property_payload in normalized_properties.items()
+    }
+
+    for key, payload in normalized_entities.items():
+        normalized_entities[key] = _normalize_meta_wikibase_entity_attributes(
+            payload,
+            property_datatypes=property_datatypes,
+            metadata_languages=metadata_languages,
+        )
+
+    _validate_meta_wikibase_value_list_contract(normalized_entities)
+
+    normalized_metadata = dict(metadata)
+    normalized_metadata["languages"] = metadata_languages
 
     return {
-        "metadata": dict(metadata),
-        "entities": {
-            "wikibase_entities": {
-                "properties": normalized_properties,
-                "items": normalized_items,
-            }
-        },
+        "metadata": normalized_metadata,
+        "entities": normalized_entities,
     }
 
 
@@ -354,50 +372,45 @@ def build_meta_wikibase_init_index(
         ),
     )
 
-    entities_block = normalized_document["entities"]["wikibase_entities"]
+    entities_block = normalized_document["entities"]
     entities: dict[str, MetaWikibaseInitEntity] = {}
     properties: dict[str, MetaWikibaseInitEntity] = {}
     items: dict[str, MetaWikibaseInitEntity] = {}
     by_internal_name_identifier: dict[str, MetaWikibaseInitEntity] = {}
 
-    for kind, bucket in (
-        ("property", entities_block["properties"]),
-        ("item", entities_block["items"]),
-    ):
-        for key, payload in bucket.items():
-            internal_name_identifier = (
-                f"{metadata.internal_name_identifier_prefix}{key}"
-            )
-            attributes = {
-                attr_key: attr_value
-                for attr_key, attr_value in payload.items()
-                if attr_key
-                not in {
-                    "kind",
-                    "label",
-                    "description",
-                    "datatype",
-                    "instance_of",
-                    "subclass_of",
-                }
+    for key, payload in entities_block.items():
+        kind = str(payload.get("kind", "")).strip()
+        internal_name_identifier = f"{metadata.internal_name_identifier_prefix}{key}"
+        attributes = {
+            attr_key: attr_value
+            for attr_key, attr_value in payload.items()
+            if attr_key
+            not in {
+                "kind",
+                "label",
+                "description",
+                "datatype",
+                "instance_of",
+                "subclass_of",
             }
-            entity = MetaWikibaseInitEntity(
-                key=key,
-                kind=kind,
-                label=str(payload.get("label", "")).strip(),
-                description=str(payload.get("description", "")).strip(),
-                internal_name_identifier=internal_name_identifier,
-                datatype=payload.get("datatype"),
-                instance_of=payload.get("instance_of"),
-                subclass_of=payload.get("subclass_of"),
-                attributes=attributes or None,
-            )
-            entities[key] = entity
-            by_internal_name_identifier[internal_name_identifier] = entity
-            if kind == "property":
-                properties[key] = entity
-            else:
-                items[key] = entity
+        }
+        entity = MetaWikibaseInitEntity(
+            key=key,
+            kind=kind,
+            label=str(payload.get("label", "")).strip(),
+            description=str(payload.get("description", "")).strip(),
+            internal_name_identifier=internal_name_identifier,
+            datatype=payload.get("datatype"),
+            instance_of=payload.get("instance_of"),
+            subclass_of=payload.get("subclass_of"),
+            attributes=attributes or None,
+        )
+        entities[key] = entity
+        by_internal_name_identifier[internal_name_identifier] = entity
+        if kind == "property":
+            properties[key] = entity
+        elif kind == "item":
+            items[key] = entity
 
     return MetaWikibaseInitIndex(
         metadata=metadata,
@@ -656,14 +669,15 @@ def compare_meta_wikibase_entity_views(
     """Compare canonical required and current views and return changed-field codes."""
 
     changed_fields: list[str] = []
-    for field_name in (
-        "type",
-        "datatype",
-        "labels",
-        "descriptions",
-        "aliases",
-        "claims",
-    ):
+    for field_name in _declared_meta_wikibase_fields(required_view):
+        if field_name == "claims":
+            changed_fields.extend(
+                _compare_meta_wikibase_claim_field_changes(
+                    required_view.get("claims"),
+                    current_view.get("claims"),
+                )
+            )
+            continue
         if required_view.get(field_name) != current_view.get(field_name):
             changed_fields.append(field_name)
 
@@ -672,6 +686,84 @@ def compare_meta_wikibase_entity_views(
             changed_fields.append(issue)
 
     return changed_fields
+
+
+def _declared_meta_wikibase_fields(required_view: dict[str, Any]) -> tuple[str, ...]:
+    """Return the managed fields explicitly declared by the authored contract."""
+
+    return tuple(
+        field_name
+        for field_name in (
+            "type",
+            "datatype",
+            "labels",
+            "descriptions",
+            "aliases",
+            "claims",
+        )
+        if field_name in required_view
+    )
+
+
+def _compare_meta_wikibase_claim_field_changes(
+    expected_claims: Any,
+    current_claims: Any,
+) -> list[str]:
+    """Return property-level claim difference codes for comparable claim blocks."""
+
+    expected = expected_claims if isinstance(expected_claims, dict) else {}
+    current = current_claims if isinstance(current_claims, dict) else {}
+
+    changed_fields: list[str] = []
+    for property_id in sorted(set(expected.keys()) | set(current.keys())):
+        if expected.get(property_id) != current.get(property_id):
+            changed_fields.append(f"claims.{property_id}")
+    return changed_fields
+
+
+def _restrict_expected_meta_wikibase_claims_to_resolved_properties(
+    expected: dict[str, Any],
+    *,
+    current_entity: dict[str, Any],
+    entity_id_to_internal_name_identifier: dict[str, str],
+) -> dict[str, Any]:
+    """Limit claim comparison to properties that can be resolved from current evidence."""
+
+    expected_claims = expected.get("claims")
+    current_claims = current_entity.get("claims")
+    if not isinstance(expected_claims, dict) or not expected_claims:
+        return expected
+    if not isinstance(current_claims, dict) or not current_claims:
+        normalized = dict(expected)
+        normalized.pop("claims", None)
+        return normalized
+
+    comparable_property_ids: set[str] = set()
+    for property_id in current_claims.keys():
+        if not isinstance(property_id, str) or not property_id:
+            continue
+        comparable_property_ids.add(
+            entity_id_to_internal_name_identifier.get(property_id, property_id)
+        )
+
+    comparable_property_ids.update(
+        internal_name
+        for internal_name in entity_id_to_internal_name_identifier.values()
+        if isinstance(internal_name, str) and internal_name
+    )
+
+    restricted_claims = {
+        property_id: payload
+        for property_id, payload in expected_claims.items()
+        if property_id in comparable_property_ids
+    }
+
+    normalized = dict(expected)
+    if restricted_claims:
+        normalized["claims"] = restricted_claims
+    else:
+        normalized.pop("claims", None)
+    return normalized
 
 
 def _compare_meta_wikibase_compiled_to_current(
@@ -686,6 +778,11 @@ def _compare_meta_wikibase_compiled_to_current(
     """Compare one compiled symbolic payload against one live Wikibase entity."""
 
     expected = _normalize_meta_wikibase_compiled_payload(compiled_payload)
+    expected = _restrict_expected_meta_wikibase_claims_to_resolved_properties(
+        expected,
+        current_entity=current_entity,
+        entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
+    )
     current, issues = _normalize_meta_wikibase_live_entity(
         current_entity,
         entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
@@ -696,14 +793,15 @@ def _compare_meta_wikibase_compiled_to_current(
     )
 
     changed_fields: list[str] = []
-    for field_name in (
-        "type",
-        "datatype",
-        "labels",
-        "descriptions",
-        "aliases",
-        "claims",
-    ):
+    for field_name in _declared_meta_wikibase_fields(expected):
+        if field_name == "claims":
+            changed_fields.extend(
+                _compare_meta_wikibase_claim_field_changes(
+                    expected.get("claims"),
+                    current.get("claims"),
+                )
+            )
+            continue
         if expected.get(field_name) != current.get(field_name):
             changed_fields.append(field_name)
 
@@ -926,8 +1024,29 @@ def _normalize_meta_wikibase_claim(
     if not isinstance(claim, dict):
         return None
     mainsnak = claim.get("mainsnak")
-    if not isinstance(mainsnak, dict) or mainsnak.get("snaktype") != "value":
+    if not isinstance(mainsnak, dict):
         return None
+
+    snaktype = mainsnak.get("snaktype")
+    if snaktype == "novalue":
+        normalized_claim = {
+            "mainsnak": {
+                "snaktype": "novalue",
+                "property": symbolic_property_id,
+            },
+            "type": claim.get("type", "statement"),
+            "rank": claim.get("rank", "normal"),
+        }
+        datatype = mainsnak.get("datatype")
+        if isinstance(datatype, str) and datatype:
+            normalized_claim["mainsnak"]["datatype"] = canonicalize_wikibase_datatype(
+                datatype
+            )
+        return normalized_claim
+
+    if snaktype != "value":
+        return None
+
     datavalue = mainsnak.get("datavalue")
     if not isinstance(datavalue, dict):
         return None
@@ -1045,7 +1164,11 @@ def _compile_meta_wikibase_entity_claims(
         ),
     )
 
-    if isinstance(entity.instance_of, str) and entity.instance_of:
+    if (
+        isinstance(entity.instance_of, str)
+        and entity.instance_of
+        and entity.instance_of != "novalue"
+    ):
         _append_meta_wikibase_claim(
             claims,
             index.properties["instance_of"].internal_name_identifier,
@@ -1059,7 +1182,11 @@ def _compile_meta_wikibase_entity_claims(
             ),
         )
 
-    if isinstance(entity.subclass_of, str) and entity.subclass_of:
+    if (
+        isinstance(entity.subclass_of, str)
+        and entity.subclass_of
+        and entity.subclass_of != "novalue"
+    ):
         _append_meta_wikibase_claim(
             claims,
             index.properties["subclass_of"].internal_name_identifier,
@@ -1103,6 +1230,12 @@ def _build_meta_wikibase_attribute_claim(
 ) -> dict[str, Any] | None:
     """Compile one authored attribute into a symbolic claim when supported."""
 
+    if attribute_value == "novalue":
+        return _build_meta_wikibase_novalue_claim(
+            property_id=property_entity.internal_name_identifier,
+            datatype=property_entity.datatype,
+        )
+
     if property_entity.datatype == "wikibase-item":
         if (
             not isinstance(attribute_value, str)
@@ -1139,6 +1272,27 @@ def _build_meta_wikibase_attribute_claim(
     return None
 
 
+def _build_meta_wikibase_novalue_claim(
+    *,
+    property_id: str,
+    datatype: str | None,
+) -> dict[str, Any]:
+    """Build a claim payload for authored novalue requirements."""
+
+    mainsnak: dict[str, Any] = {
+        "snaktype": "novalue",
+        "property": property_id,
+    }
+    if isinstance(datatype, str) and datatype:
+        mainsnak["datatype"] = datatype
+
+    return {
+        "mainsnak": mainsnak,
+        "type": "statement",
+        "rank": "normal",
+    }
+
+
 def _build_symbolic_entity_reference_claim(
     claim_builder: Any,
     *,
@@ -1168,6 +1322,142 @@ def _append_meta_wikibase_claim(
     """Append one compiled claim to the per-property claim bucket."""
 
     claims.setdefault(property_id, []).append(claim)
+
+
+def _normalize_meta_wikibase_languages(metadata: dict[str, Any]) -> list[str]:
+    raw_languages = metadata.get("languages")
+    if not isinstance(raw_languages, list) or not raw_languages:
+        return ["en"]
+
+    normalized_languages: list[str] = []
+    for language in raw_languages:
+        if not isinstance(language, str) or not language.strip():
+            continue
+        normalized_languages.append(language.strip())
+
+    return normalized_languages or ["en"]
+
+
+def _normalize_meta_wikibase_authored_text(
+    payload: dict[str, Any],
+    *,
+    field_name: str,
+    languages: list[str],
+    entity_key: str,
+) -> str:
+    direct_value = payload.get(field_name)
+    if isinstance(direct_value, str) and direct_value.strip():
+        return direct_value.strip()
+
+    for language in languages:
+        localized_key = f"{field_name}_{language}"
+        localized_value = payload.get(localized_key)
+        if isinstance(localized_value, str) and localized_value.strip():
+            return localized_value.strip()
+
+    raise RuntimeError(
+        f"meta_wb_init entity '{entity_key}' is missing {field_name} text"
+    )
+
+
+def _normalize_meta_wikibase_entity_attributes(
+    payload: dict[str, Any],
+    *,
+    property_datatypes: dict[str, str],
+    metadata_languages: list[str],
+) -> dict[str, Any]:
+    skipped_keys = {
+        "kind",
+        "label",
+        "description",
+        "datatype",
+        "instance_of",
+        "subclass_of",
+    }
+    skipped_keys.update(f"label_{language}" for language in metadata_languages)
+    skipped_keys.update(f"description_{language}" for language in metadata_languages)
+
+    grouped_localized: dict[str, dict[str, Any]] = {}
+    passthrough: dict[str, Any] = {}
+
+    for key, value in payload.items():
+        if key in skipped_keys:
+            continue
+
+        match = re.match(r"^(?P<base>.+)_(?P<lang>[a-z]{2,3}(?:-[a-z0-9]+)*)$", key)
+        if match:
+            base_key = str(match.group("base"))
+            language = str(match.group("lang"))
+            if language in metadata_languages and base_key in property_datatypes:
+                grouped_localized.setdefault(base_key, {})[language] = value
+                continue
+
+        passthrough[key] = value
+
+    normalized_payload: dict[str, Any] = {}
+    for key in (
+        "kind",
+        "label",
+        "description",
+        "datatype",
+        "instance_of",
+        "subclass_of",
+    ):
+        if key in payload:
+            normalized_payload[key] = payload[key]
+
+    for key, value in passthrough.items():
+        normalized_payload[key] = value
+
+    for base_key, localized_values in grouped_localized.items():
+        _ = property_datatypes.get(base_key)
+        for language in metadata_languages:
+            if language in localized_values:
+                localized_value = localized_values[language]
+                if isinstance(localized_value, str):
+                    normalized_payload[base_key] = localized_value.strip()
+                else:
+                    normalized_payload[base_key] = localized_value
+                break
+
+    return normalized_payload
+
+
+def _validate_meta_wikibase_value_list_contract(
+    entities: dict[str, dict[str, Any]],
+) -> None:
+    for entity_key, payload in entities.items():
+        if not isinstance(payload, dict):
+            continue
+
+        instance_of = payload.get("instance_of")
+        if instance_of == "sparql_value_list":
+            sparql_endpoint = payload.get("sparql_endpoint")
+            query = payload.get("query")
+            if not isinstance(sparql_endpoint, str) or not sparql_endpoint.strip():
+                raise RuntimeError(
+                    f"meta_wb_init entity '{entity_key}' requires 'sparql_endpoint' and 'query'"
+                )
+            if not isinstance(query, str) or not query.strip():
+                raise RuntimeError(
+                    f"meta_wb_init entity '{entity_key}' requires 'sparql_endpoint' and 'query'"
+                )
+
+        if instance_of == "embedded_value_list":
+            value_list = payload.get("value_list")
+            if not isinstance(value_list, list) or not value_list:
+                raise RuntimeError(
+                    f"meta_wb_init entity '{entity_key}' requires 'value_list'"
+                )
+            for row in value_list:
+                if not isinstance(row, dict):
+                    raise RuntimeError(
+                        f"meta_wb_init entity '{entity_key}' requires 'value_list' rows with 'item' and 'itemLabel'"
+                    )
+                if "item" not in row or "itemLabel" not in row:
+                    raise RuntimeError(
+                        f"meta_wb_init entity '{entity_key}' requires 'value_list' rows with 'item' and 'itemLabel'"
+                    )
 
 
 def _normalize_meta_wikibase_monolingualtext(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1354,6 +1354,89 @@ meta_wikibase:
     assert exported_payload["entity"].endswith("/Q4")
 
 
+def test_profile_value_lists_sync_local_source_defaults(monkeypatch, capsys, tmp_path):
+    """profile value-lists sync resolves local default directories."""
+
+    local_root = tmp_path / "SpiritSafe"
+    (local_root / "config").mkdir(parents=True, exist_ok=True)
+    (local_root / "still" / "entities").mkdir(parents=True, exist_ok=True)
+    (local_root / "config" / "dd-wikibase.yaml").write_text(
+        """
+meta_wikibase:
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+spiritsafe:
+  layout_version: 2
+  roots:
+    materialized: still
+    partners: partners
+  paths:
+    entities: still/entities
+    profiles: still/profiles
+    value_list_queries: still/value_lists/queries
+    value_list_cache: still/value_lists/cache
+    semantic_anchors: config/semantic_anchors.json
+    logs: still/logs
+    wikimedia_sites: partners/wikimedia_sites.json
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fake_discover_value_list_ids(cache_entities_dir):
+        assert str(cache_entities_dir).endswith("SpiritSafe/still/entities")
+        return ["Q4"]
+
+    def fake_sync_value_list_artifacts_from_cache(**kwargs):
+        assert str(kwargs["cache_entities_dir"]).endswith("SpiritSafe/still/entities")
+        assert str(kwargs["queries_dir"]).endswith(
+            "SpiritSafe/still/value_lists/queries"
+        )
+        assert str(kwargs["cache_queries_dir"]).endswith(
+            "SpiritSafe/still/value_lists/cache"
+        )
+        assert kwargs["value_list_ids"] == ["Q4"]
+        return gkc.ValueListHydrationResult(
+            queries_dir=str(local_root / "still" / "value_lists" / "queries"),
+            cache_queries_dir=str(local_root / "still" / "value_lists" / "cache"),
+            discovered_ids=["Q4"],
+            query_files_written=[
+                str(local_root / "still" / "value_lists" / "queries" / "Q4.sparql")
+            ],
+            cache_files_deleted=[
+                str(local_root / "still" / "value_lists" / "cache" / "Q4.json")
+            ],
+            failures=[],
+        )
+
+    monkeypatch.setattr("gkc.discover_value_list_ids", fake_discover_value_list_ids)
+    monkeypatch.setattr(
+        "gkc.sync_value_list_artifacts_from_cache",
+        fake_sync_value_list_artifacts_from_cache,
+    )
+
+    exit_code = cli.main(
+        [
+            "--json",
+            "profile",
+            "value-lists",
+            "sync",
+            "--source",
+            "local",
+            "--local-root",
+            str(local_root),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["command"] == "profile.value_lists.sync"
+    assert payload["ok"] is True
+    assert payload["details"]["discovered_count"] == 1
+    assert len(payload["details"]["cache_files_deleted"]) == 1
+
+
 def test_profile_value_lists_hydrate_local_source_defaults(
     monkeypatch, capsys, tmp_path
 ):

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -73,6 +73,14 @@ meta_wikibase:
   semantic_conventions:
     name_identifier_property_id: P214
     internal_name_identifier_prefix: "_"
+  value_list_talk_pages:
+    rules:
+      - class_name_identifier: _sparql_value_list
+        block_type: sparql
+        artifact_store: value_list_queries
+      - class_name_identifier: _embedded_value_list
+        block_type: json
+        artifact_store: value_list_cache
 spiritsafe:
     layout_version: 2
     roots:
@@ -116,6 +124,19 @@ spiritsafe:
     assert (
         config.spiritsafe_layout.wikimedia_sites_path == "partners/wikimedia_sites.json"
     )
+    assert len(config.value_list_talk_page_rules) == 2
+    assert (
+        config.value_list_talk_page_rules[0].class_name_identifier
+        == "_sparql_value_list"
+    )
+    assert config.value_list_talk_page_rules[0].block_type == "sparql"
+    assert config.value_list_talk_page_rules[0].artifact_store == "value_list_queries"
+    assert (
+        config.value_list_talk_page_rules[1].class_name_identifier
+        == "_embedded_value_list"
+    )
+    assert config.value_list_talk_page_rules[1].block_type == "json"
+    assert config.value_list_talk_page_rules[1].artifact_store == "value_list_cache"
 
 
 def test_runtime_config_autodiscovers_config_file(monkeypatch, tmp_path):

--- a/tests/test_shipper.py
+++ b/tests/test_shipper.py
@@ -145,6 +145,7 @@ def test_wikibase_shipper_write_item_submit():
         dry_run=False,
         tags=["gkc"],
         bot=True,
+        base_revision_id=41,
     )
 
     assert auth.login_called
@@ -159,6 +160,7 @@ def test_wikibase_shipper_write_item_submit():
     assert sent_data["summary"] == "Submit"
     assert sent_data["tags"] == "gkc"
     assert sent_data["bot"] == "1"
+    assert sent_data["baserevid"] == 41
     assert "data" in sent_data
 
 
@@ -226,6 +228,38 @@ def test_wikibase_shipper_write_property_canonicalizes_datatype_alias():
     sent_data = auth.session.post.call_args[1]["data"]
     posted_entity_data = json.loads(sent_data["data"])
     assert posted_entity_data["datatype"] == "wikibase-item"
+
+
+def test_wikibase_shipper_write_item_accepts_claim_dict_payload():
+    """Dry-run item writes should accept wbgetentities-style claim mappings."""
+    auth = FakeAuth()
+    shipper = WikibaseShipper(auth=auth)
+
+    payload = {
+        "labels": {"en": {"language": "en", "value": "Entity"}},
+        "claims": {
+            "P31": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P31",
+                        "datavalue": {
+                            "type": "wikibase-entityid",
+                            "value": {"entity-type": "item", "id": "Q1"},
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ]
+        },
+    }
+
+    result = shipper.write_item(payload, summary="Claim dict payload", dry_run=True)
+
+    assert result.status == "dry_run"
+    assert isinstance(result.request_payload["claims"], list)
+    assert result.request_payload["claims"][0]["mainsnak"]["property"] == "P31"
 
 
 # ============================================================================
@@ -352,6 +386,78 @@ def test_wikibase_shipper_plan_batch_update_and_noop(monkeypatch):
         "descriptions": {"en": {"language": "en", "value": "New desc"}}
     }
     assert plan.operations[1].status == "noop"
+
+
+def test_wikibase_shipper_plan_batch_replaces_wrong_claim_value(monkeypatch):
+    """Plan should patch wrong claims in place instead of only appending duplicates."""
+
+    class FakeApiClient:
+        def __init__(self, api_url, session=None, timeout=20):
+            pass
+
+        def search_entities(self, label, entity_type, language):
+            return [{"id": "Q10", "label": label}]
+
+        def get_entity(self, entity_id):
+            return {
+                "id": entity_id,
+                "labels": {"en": {"language": "en", "value": "Entity"}},
+                "claims": {
+                    "P31": [
+                        {
+                            "id": "Q10$claim-1",
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P31",
+                                "datavalue": {
+                                    "type": "wikibase-entityid",
+                                    "value": {"entity-type": "item", "id": "Q5"},
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ]
+                },
+            }
+
+    monkeypatch.setattr(shipper_module, "WikibaseApiClient", FakeApiClient)
+
+    auth = FakeAuth()
+    shipper = WikibaseShipper(auth=auth)
+    plan = shipper.plan_batch(
+        [
+            {
+                "kind": "item",
+                "label": "Entity",
+                "payload": {
+                    "labels": {"en": {"language": "en", "value": "Entity"}},
+                    "claims": {
+                        "P31": [
+                            {
+                                "mainsnak": {
+                                    "snaktype": "value",
+                                    "property": "P31",
+                                    "datavalue": {
+                                        "type": "wikibase-entityid",
+                                        "value": {"entity-type": "item", "id": "Q1"},
+                                    },
+                                },
+                                "type": "statement",
+                                "rank": "normal",
+                            }
+                        ]
+                    },
+                },
+            }
+        ]
+    )
+
+    assert plan.summary["update"] == 1
+    patch_claims = plan.operations[0].request_payload["claims"]
+    assert len(patch_claims) == 1
+    assert patch_claims[0]["id"] == "Q10$claim-1"
+    assert patch_claims[0]["mainsnak"]["datavalue"]["value"]["id"] == "Q1"
 
 
 def test_wikibase_shipper_plan_batch_property_requires_datatype(monkeypatch):

--- a/tests/test_spirit_safe_runtime_artifacts.py
+++ b/tests/test_spirit_safe_runtime_artifacts.py
@@ -6,13 +6,16 @@ from shutil import copytree
 
 import pytest
 
+from gkc.shipper import WriteResult
 from gkc.spirit_safe import (
+    build_spiritsafe_meta_wikibase_conformance_report,
     build_spiritsafe_semantic_anchor_document,
     export_spiritsafe_semantic_anchors,
     load_profile,
     load_profile_package,
     resolve_profile_link,
     set_spirit_safe_source,
+    sync_spiritsafe_meta_wikibase_seed,
     validate_packet_structure,
 )
 from gkc.still_charger import create_curation_packet
@@ -180,6 +183,368 @@ spiritsafe:
     assert isinstance(anchors["entities"]["_time"]["resolved"], dict)
 
 
+def test_build_spiritsafe_meta_wikibase_conformance_report_flags_missing_sparql_talk_page(
+    tmp_path: Path, fixture_root: Path, monkeypatch
+):
+    """Conformance report should flag missing SPARQL talk-page content."""
+
+    root = tmp_path / "spiritsafe"
+    copytree(fixture_root, root)
+    config_dir = root / "config"
+    (config_dir / "dd-wikibase.yaml").write_text(
+        """
+meta_wikibase:
+  api_url: https://example.test/w/api.php
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+spiritsafe:
+    layout_version: 2
+    roots:
+        materialized: still
+        partners: partners
+    paths:
+        entities: still/entities
+        profiles: still/profiles
+        value_list_queries: still/value_lists/queries
+        value_list_cache: still/value_lists/cache
+        semantic_anchors: config/semantic_anchors.json
+        logs: still/logs
+        wikimedia_sites: partners/wikimedia_sites.json
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    item_path = root / "still" / "entities" / "Q43.json"
+    item_doc = {
+        "entity_id": "Q43",
+        "entity": {
+            "id": "Q43",
+            "type": "item",
+            "labels": {"en": {"language": "en", "value": "List of World Countries"}},
+            "descriptions": {
+                "en": {
+                    "language": "en",
+                    "value": "SPARQL query returning list of countries of the world for country statements in items",
+                }
+            },
+            "claims": {
+                "P214": [
+                    {
+                        "id": "Q43$internal-name",
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P214",
+                            "datavalue": {
+                                "type": "string",
+                                "value": "_world_countries",
+                            },
+                        },
+                        "type": "statement",
+                        "rank": "normal",
+                    }
+                ]
+            },
+        },
+    }
+    item_path.write_text(json.dumps(item_doc, indent=2), encoding="utf-8")
+
+    class FakeApiClient:
+        def __init__(self, api_url, session=None, timeout=20):
+            self.api_url = api_url
+
+        def request(self, params):
+            return {
+                "query": {"pages": [{"title": params.get("titles"), "missing": True}]}
+            }
+
+    monkeypatch.setattr("gkc.spirit_safe.WikibaseApiClient", FakeApiClient)
+
+    report = build_spiritsafe_meta_wikibase_conformance_report(root)
+    row = next(
+        action
+        for action in report["actions"]
+        if action["name_identifier"] == "_world_countries"
+    )
+
+    assert row["action"] == "update"
+    assert "talk_page.sparql" in (row["changed_fields"] or [])
+    assert row["talk_page"]["status"] == "missing"
+    assert (
+        row["differences"]["talk_page.sparql"]["expected"]["title"] == "Item_talk:Q43"
+    )
+
+
+def test_build_spiritsafe_meta_wikibase_conformance_report_uses_materialized_cache_artifacts(
+    tmp_path: Path, fixture_root: Path, monkeypatch
+):
+    """Conformance should compare against SpiritSafe files, not live talk pages."""
+
+    root = tmp_path / "spiritsafe"
+    copytree(fixture_root, root)
+    config_dir = root / "config"
+    (config_dir / "dd-wikibase.yaml").write_text(
+        """
+meta_wikibase:
+  api_url: https://example.test/w/api.php
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+spiritsafe:
+    layout_version: 2
+    roots:
+        materialized: still
+        partners: partners
+    paths:
+        entities: still/entities
+        profiles: still/profiles
+        value_list_queries: still/value_lists/queries
+        value_list_cache: still/value_lists/cache
+        semantic_anchors: config/semantic_anchors.json
+        logs: still/logs
+        wikimedia_sites: partners/wikimedia_sites.json
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    item_path = root / "still" / "entities" / "Q43.json"
+    item_doc = {
+        "entity_id": "Q43",
+        "entity": {
+            "id": "Q43",
+            "type": "item",
+            "labels": {"en": {"language": "en", "value": "List of World Countries"}},
+            "descriptions": {
+                "en": {
+                    "language": "en",
+                    "value": "SPARQL query returning list of countries of the world for country statements in items",
+                }
+            },
+            "claims": {
+                "P1": [
+                    {
+                        "id": "Q43$instance-of",
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P1",
+                            "datavalue": {
+                                "type": "wikibase-entityid",
+                                "value": {"id": "Q7", "entity-type": "item"},
+                            },
+                        },
+                        "type": "statement",
+                        "rank": "normal",
+                    }
+                ],
+                "P214": [
+                    {
+                        "id": "Q43$internal-name",
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P214",
+                            "datavalue": {
+                                "type": "string",
+                                "value": "_world_countries",
+                            },
+                        },
+                        "type": "statement",
+                        "rank": "normal",
+                    }
+                ],
+            },
+        },
+    }
+    item_path.write_text(json.dumps(item_doc, indent=2), encoding="utf-8")
+
+    queries_dir = root / "still" / "value_lists" / "queries"
+    queries_dir.mkdir(parents=True, exist_ok=True)
+    (queries_dir / "Q43.sparql").write_text(
+        "SELECT ?item WHERE { ?item wdt:P31 wd:Q5 }\n",
+        encoding="utf-8",
+    )
+
+    def _unexpected_fetch(*args, **kwargs):
+        raise AssertionError("Conformance should not call the live talk-page API")
+
+    monkeypatch.setattr(
+        "gkc.spirit_safe.fetch_mediawiki_page_wikitext", _unexpected_fetch
+    )
+
+    report = build_spiritsafe_meta_wikibase_conformance_report(root)
+    row = next(
+        action
+        for action in report["actions"]
+        if action["name_identifier"] == "_world_countries"
+    )
+
+    assert row["action"] == "update"
+    assert "talk_page.sparql" in (row["changed_fields"] or [])
+    assert row["talk_page"]["status"] == "drift"
+    assert (
+        "SELECT ?item WHERE"
+        in row["differences"]["talk_page.sparql"]["current"]["content"]
+    )
+
+
+def test_sync_spiritsafe_meta_wikibase_seed_routes_updates_through_shipper(
+    tmp_path: Path, fixture_root: Path, monkeypatch
+):
+    """Sync helper should turn cache drift into shipper dry-run calls."""
+
+    root = tmp_path / "spiritsafe"
+    copytree(fixture_root, root)
+    config_dir = root / "config"
+    (config_dir / "dd-wikibase.yaml").write_text(
+        """
+meta_wikibase:
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+spiritsafe:
+    layout_version: 2
+    roots:
+        materialized: still
+        partners: partners
+    paths:
+        entities: still/entities
+        profiles: still/profiles
+        value_list_queries: still/value_lists/queries
+        value_list_cache: still/value_lists/cache
+        semantic_anchors: config/semantic_anchors.json
+        logs: still/logs
+        wikimedia_sites: partners/wikimedia_sites.json
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    property_path = root / "still" / "entities" / "P1.json"
+    property_doc = {
+        "entity_id": "P1",
+        "entity": {
+            "id": "P1",
+            "type": "property",
+            "datatype": "wikibase-item",
+            "lastrevid": 321,
+            "labels": {"en": {"language": "en", "value": "instance of"}},
+            "descriptions": {"en": {"language": "en", "value": "wrong description"}},
+            "claims": {
+                "P214": [
+                    {
+                        "id": "P1$internal-name",
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P214",
+                            "datavalue": {
+                                "type": "string",
+                                "value": "_instance_of",
+                            },
+                        },
+                        "type": "statement",
+                        "rank": "normal",
+                    }
+                ]
+            },
+        },
+    }
+    property_path.write_text(json.dumps(property_doc, indent=2), encoding="utf-8")
+
+    class FakeApiClient:
+        def __init__(self, api_url, session=None, timeout=20):
+            self.api_url = api_url
+
+        def get_entity(self, entity_id):
+            return json.loads(property_path.read_text(encoding="utf-8"))["entity"]
+
+    monkeypatch.setattr("gkc.spirit_safe.WikibaseApiClient", FakeApiClient)
+
+    class FakeShipper:
+        def __init__(self):
+            self.api_url = "https://example.test/w/api.php"
+            self.auth = None
+            self.calls = []
+
+        def write_property(
+            self,
+            payload,
+            summary,
+            datatype,
+            entity_id=None,
+            dry_run=None,
+            validate_only=False,
+            tags=None,
+            bot=False,
+            metadata=None,
+            base_revision_id=None,
+        ):
+            self.calls.append(
+                {
+                    "kind": "property",
+                    "payload": payload,
+                    "entity_id": entity_id,
+                    "datatype": datatype,
+                    "dry_run": dry_run,
+                    "base_revision_id": base_revision_id,
+                    "summary": summary,
+                }
+            )
+            return WriteResult(
+                entity_id=entity_id,
+                revision_id=base_revision_id,
+                status="dry_run" if dry_run else "submitted",
+                request_payload=payload,
+            )
+
+        def write_item(
+            self,
+            payload,
+            summary,
+            entity_id=None,
+            dry_run=None,
+            validate_only=False,
+            tags=None,
+            bot=False,
+            metadata=None,
+            base_revision_id=None,
+        ):
+            self.calls.append(
+                {
+                    "kind": "item",
+                    "payload": payload,
+                    "entity_id": entity_id,
+                    "dry_run": dry_run,
+                    "base_revision_id": base_revision_id,
+                    "summary": summary,
+                }
+            )
+            return WriteResult(
+                entity_id=entity_id,
+                revision_id=base_revision_id,
+                status="dry_run" if dry_run else "submitted",
+                request_payload=payload,
+            )
+
+    fake_shipper = FakeShipper()
+    result = sync_spiritsafe_meta_wikibase_seed(
+        root, shipper=fake_shipper, dry_run=True
+    )
+
+    assert result["summary"]["dry_run"] > 0
+    assert any(call["entity_id"] == "P1" for call in fake_shipper.calls)
+    assert any(
+        call["base_revision_id"] == 321
+        for call in fake_shipper.calls
+        if call["entity_id"] == "P1"
+    )
+    assert any(
+        action["write_status"] == "dry_run"
+        for action in result["actions"]
+        if action["action"] != "skip"
+    )
+
+
 def test_build_spiritsafe_semantic_anchor_document_marks_internal_entries(
     tmp_path: Path, fixture_root: Path
 ):
@@ -238,6 +603,366 @@ spiritsafe:
     assert anchors["metadata"]["item_count"] == 0
     assert anchors["entities"]["_entity"]["id"] is None
     assert anchors["entities"]["_entity"]["resolved"] is None
+
+
+def test_build_spiritsafe_meta_wikibase_conformance_report_uses_entity_cache(
+    tmp_path: Path, fixture_root: Path
+):
+    """Cache report should compare current cached entities against the seed contract."""
+
+    root = tmp_path / "spiritsafe"
+    copytree(fixture_root, root)
+    config_dir = root / "config"
+    (config_dir / "dd-wikibase.yaml").write_text(
+        """
+meta_wikibase:
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+spiritsafe:
+    layout_version: 2
+    roots:
+        materialized: still
+        partners: partners
+    paths:
+        entities: still/entities
+        profiles: still/profiles
+        value_list_queries: still/value_lists/queries
+        value_list_cache: still/value_lists/cache
+        semantic_anchors: config/semantic_anchors.json
+        logs: still/logs
+        wikimedia_sites: partners/wikimedia_sites.json
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entity_docs = {
+        "P1": {
+            "entity_id": "P1",
+            "entity": {
+                "id": "P1",
+                "type": "property",
+                "datatype": "wikibase-item",
+                "labels": {"en": {"language": "en", "value": "instance of"}},
+                "descriptions": {
+                    "en": {
+                        "language": "en",
+                        "value": "type to which this subject belongs or corresponds",
+                    }
+                },
+                "claims": {
+                    "P214": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P214",
+                                "datavalue": {
+                                    "type": "string",
+                                    "value": "_instance_of",
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ]
+                },
+            },
+        },
+        "P168": {
+            "entity_id": "P168",
+            "entity": {
+                "id": "P168",
+                "type": "property",
+                "datatype": "monolingualtext",
+                "labels": {"en": {"language": "en", "value": "error message"}},
+                "descriptions": {
+                    "en": {
+                        "language": "en",
+                        "value": "monolingual text template for error presentation with placeholders resolved by fermenter",
+                    }
+                },
+                "claims": {
+                    "P214": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P214",
+                                "datavalue": {
+                                    "type": "string",
+                                    "value": "_error_message",
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ]
+                },
+            },
+        },
+        "P214": {
+            "entity_id": "P214",
+            "entity": {
+                "id": "P214",
+                "type": "property",
+                "datatype": "string",
+                "labels": {"en": {"language": "en", "value": "name identifier"}},
+                "descriptions": {
+                    "en": {
+                        "language": "en",
+                        "value": "human-readable identifier for entities in this Wikibase used as a unique identifier in the JSON translations used by and within the SpiritSafe and gkc software package",
+                    }
+                },
+                "claims": {
+                    "P214": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P214",
+                                "datavalue": {
+                                    "type": "string",
+                                    "value": "_name_identifier",
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ]
+                },
+            },
+        },
+        "Q99": {
+            "entity_id": "Q99",
+            "entity": {
+                "id": "Q99",
+                "type": "item",
+                "labels": {
+                    "en": {"language": "en", "value": "Wikibase Statement Type"}
+                },
+                "descriptions": {
+                    "en": {
+                        "language": "en",
+                        "value": "classification of items describing the basic data type aligned with the Wikibase framework",
+                    }
+                },
+                "claims": {
+                    "P214": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P214",
+                                "datavalue": {
+                                    "type": "string",
+                                    "value": "_wikibase_statement_type",
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ],
+                    "P1": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P1",
+                                "datavalue": {
+                                    "type": "wikibase-entityid",
+                                    "value": {
+                                        "entity-type": "item",
+                                        "id": "Q4",
+                                        "numeric-id": 4,
+                                    },
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ],
+                },
+            },
+        },
+        "Q50": {
+            "entity_id": "Q50",
+            "entity": {
+                "id": "Q50",
+                "type": "item",
+                "labels": {"en": {"language": "en", "value": "wikibase-item"}},
+                "descriptions": {
+                    "en": {
+                        "language": "en",
+                        "value": "wikibase item property template used to set a data type for a statement, reference, or qualifier and any additional specifications",
+                    }
+                },
+                "claims": {
+                    "P1": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P1",
+                                "datavalue": {
+                                    "type": "wikibase-entityid",
+                                    "value": {
+                                        "entity-type": "item",
+                                        "id": "Q99",
+                                        "numeric-id": 99,
+                                    },
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ],
+                    "P214": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P214",
+                                "datavalue": {
+                                    "type": "string",
+                                    "value": "_wikibase-item",
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ],
+                    "P168": [
+                        {
+                            "mainsnak": {
+                                "snaktype": "value",
+                                "property": "P168",
+                                "datavalue": {
+                                    "type": "monolingualtext",
+                                    "value": {
+                                        "language": "mul",
+                                        "text": "Item must be or resolve to a valid QID identifier.",
+                                    },
+                                },
+                            },
+                            "type": "statement",
+                            "rank": "normal",
+                        }
+                    ],
+                },
+            },
+        },
+    }
+
+    entities_dir = root / "still" / "entities"
+    for entity_id, entity_doc in entity_docs.items():
+        (entities_dir / f"{entity_id}.json").write_text(
+            json.dumps(entity_doc, indent=2), encoding="utf-8"
+        )
+
+    report = build_spiritsafe_meta_wikibase_conformance_report(root)
+
+    assert report["comparison_source"]["mode"] == "cache-entities"
+    assert report["summary"]["skipped"] >= 1
+    assert report["summary"]["created"] >= 1
+    wikibase_item = next(
+        action
+        for action in report["actions"]
+        if action["name_identifier"] == "_wikibase-item"
+    )
+    assert wikibase_item["action"] == "skip"
+    assert wikibase_item["id"] == "https://datadistillery.wikibase.cloud/entity/Q50"
+    assert (
+        wikibase_item["required"]["claims"]["_instance_of"][0]["mainsnak"]["datavalue"][
+            "value"
+        ]["name_identifier"]
+        == "_wikibase_statement_type"
+    )
+    assert (
+        wikibase_item["current"]["claims"]["_instance_of"][0]["mainsnak"]["datavalue"][
+            "value"
+        ]["id"]
+        == "https://datadistillery.wikibase.cloud/entity/Q99"
+    )
+
+
+def test_build_spiritsafe_meta_wikibase_conformance_report_rejects_ambiguous_cache_matches(
+    tmp_path: Path, fixture_root: Path
+):
+    """Cache conformance should hard-stop when two entities claim the same internal name identifier."""
+
+    root = tmp_path / "spiritsafe"
+    copytree(fixture_root, root)
+    config_dir = root / "config"
+    (config_dir / "dd-wikibase.yaml").write_text(
+        """
+meta_wikibase:
+  semantic_conventions:
+    name_identifier_property_id: P214
+    internal_name_identifier_prefix: "_"
+spiritsafe:
+    layout_version: 2
+    roots:
+        materialized: still
+        partners: partners
+    paths:
+        entities: still/entities
+        profiles: still/profiles
+        value_list_queries: still/value_lists/queries
+        value_list_cache: still/value_lists/cache
+        semantic_anchors: config/semantic_anchors.json
+        logs: still/logs
+        wikimedia_sites: partners/wikimedia_sites.json
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    duplicate_payload = {
+        "type": "item",
+        "labels": {"en": {"language": "en", "value": "wikibase-item"}},
+        "descriptions": {
+            "en": {
+                "language": "en",
+                "value": "duplicate cache test entity",
+            }
+        },
+        "claims": {
+            "P214": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P214",
+                        "datavalue": {
+                            "type": "string",
+                            "value": "_wikibase-item",
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ]
+        },
+    }
+
+    entities_dir = root / "still" / "entities"
+    (entities_dir / "Q50.json").write_text(
+        json.dumps(
+            {
+                "entity_id": "Q50",
+                "entity": {"id": "Q50", **duplicate_payload},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (entities_dir / "Q51.json").write_text(
+        json.dumps(
+            {
+                "entity_id": "Q51",
+                "entity": {"id": "Q51", **duplicate_payload},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="Multiple cached entities resolve"):
+        build_spiritsafe_meta_wikibase_conformance_report(root)
 
 
 def test_build_spiritsafe_semantic_anchor_document_requires_config(

--- a/tests/test_spirit_safe_value_lists.py
+++ b/tests/test_spirit_safe_value_lists.py
@@ -22,6 +22,8 @@ def _value_list_semantic_anchor_document() -> dict:
         "entities": {
             "_instance_of": {"id": "P1", "datatype": "wikibase-item"},
             "_value_list": {"id": "Q7"},
+            "_sparql_value_list": {"id": "Q7"},
+            "_embedded_value_list": {"id": "Q97"},
         }
     }
 
@@ -172,6 +174,127 @@ def test_hydrate_value_lists_keeps_existing_cache_on_failure(monkeypatch, tmp_pa
 
     payload = json.loads((cache_queries_dir / "Q4.json").read_text(encoding="utf-8"))
     assert payload == existing_payload
+
+
+def test_hydrate_value_lists_exports_embedded_json_without_hydration(
+    monkeypatch, tmp_path
+):
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    queries_dir = tmp_path / "queries"
+    cache_queries_dir = tmp_path / "cache" / "queries"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+
+    (cache_entities_dir / "Q60.json").write_text(
+        json.dumps(
+            {
+                "entity_id": "Q60",
+                "entity": {
+                    "claims": {
+                        "P1": [_claim_entity_id("Q97")],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "gkc.spirit_safe.fetch_mediawiki_page_wikitext",
+        lambda api_client, title: (
+            '<syntaxhighlight lang="json">'
+            '[{"item": "0.1", "itemLabel": "0.1 degree"}]'
+            "</syntaxhighlight>"
+        ),
+    )
+
+    def _unexpected_paginate(**kwargs):
+        raise AssertionError("SPARQL hydration should not run for embedded lists")
+
+    monkeypatch.setattr("gkc.spirit_safe.paginate_query", _unexpected_paginate)
+
+    result = gkc.hydrate_value_lists_from_cache(
+        cache_entities_dir=cache_entities_dir,
+        queries_dir=queries_dir,
+        cache_queries_dir=cache_queries_dir,
+        api_url="https://datadistillery.wikibase.cloud/w/api.php",
+        endpoint="https://datadistillery.wikibase.cloud/query/sparql",
+        semantic_anchor_document=_value_list_semantic_anchor_document(),
+        fail_on_hydration_error=True,
+    )
+
+    assert result.discovered_ids == ["Q60"]
+    assert result.hydrated_ids == []
+    assert result.failures == []
+    assert not (queries_dir / "Q60.sparql").exists()
+
+    cache_file = cache_queries_dir / "Q60.json"
+    assert cache_file.exists()
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == [
+        {"item": "0.1", "itemLabel": "0.1 degree"}
+    ]
+
+
+def test_hydrate_value_lists_removes_deleted_talk_page_artifacts(monkeypatch, tmp_path):
+    cache_entities_dir = tmp_path / "cache" / "entities"
+    queries_dir = tmp_path / "queries"
+    cache_queries_dir = tmp_path / "cache" / "queries"
+    cache_entities_dir.mkdir(parents=True, exist_ok=True)
+    queries_dir.mkdir(parents=True, exist_ok=True)
+    cache_queries_dir.mkdir(parents=True, exist_ok=True)
+
+    (cache_entities_dir / "Q4.json").write_text(
+        json.dumps(
+            {
+                "entity_id": "Q4",
+                "entity": {
+                    "claims": {
+                        "P1": [_claim_entity_id("Q7")],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (cache_entities_dir / "Q60.json").write_text(
+        json.dumps(
+            {
+                "entity_id": "Q60",
+                "entity": {
+                    "claims": {
+                        "P1": [_claim_entity_id("Q97")],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (queries_dir / "Q4.sparql").write_text("SELECT * WHERE {}\n", encoding="utf-8")
+    (cache_queries_dir / "Q60.json").write_text(
+        json.dumps([{"item": "old", "itemLabel": "Old"}], indent=2),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "gkc.spirit_safe.fetch_mediawiki_page_wikitext",
+        lambda api_client, title: "No relevant block here",
+    )
+
+    result = gkc.hydrate_value_lists_from_cache(
+        cache_entities_dir=cache_entities_dir,
+        queries_dir=queries_dir,
+        cache_queries_dir=cache_queries_dir,
+        api_url="https://datadistillery.wikibase.cloud/w/api.php",
+        endpoint="https://datadistillery.wikibase.cloud/query/sparql",
+        semantic_anchor_document=_value_list_semantic_anchor_document(),
+        fail_on_hydration_error=True,
+    )
+
+    assert result.discovered_ids == ["Q4", "Q60"]
+    assert result.hydrated_ids == []
+    assert result.failures == []
+    assert not (queries_dir / "Q4.sparql").exists()
+    assert not (cache_queries_dir / "Q60.json").exists()
 
 
 def test_hydrate_value_lists_fails_on_duplicate_non_core_conflict(

--- a/tests/test_wikibase.py
+++ b/tests/test_wikibase.py
@@ -99,48 +99,123 @@ def test_load_wikibase_datatype_registry_json_round_trips_shape():
 def test_load_meta_wikibase_init_document_uses_canonical_datatypes():
     document = load_meta_wikibase_init_document()
 
-    properties = document["entities"]["wikibase_entities"]["properties"]
-    assert properties["instance_of"]["datatype"] == "wikibase-item"
-    assert properties["name_identifier"]["datatype"] == "string"
-    assert properties["see_also"]["datatype"] == "url"
+    entities = document["entities"]
+    assert entities["instance_of"]["datatype"] == "wikibase-item"
+    assert entities["name_identifier"]["datatype"] == "string"
+    assert entities["see_also"]["datatype"] == "url"
 
 
 def test_normalize_meta_wikibase_init_document_transforms_prototype_datatypes():
     prototype = {
-        "metadata": {"internal_name_identifier_prefix": "_"},
+        "metadata": {
+            "internal_name_identifier_prefix": "_",
+            "languages": ["en"],
+        },
         "entities": {
-            "wikibase_entities": {
-                "properties": {
-                    "instance_of": {
-                        "label": "instance of",
-                        "description": "type relation",
-                        "datatype": "WikibaseItem",
-                    },
-                    "same_as": {
-                        "label": "same as",
-                        "description": "identity relation",
-                        "datatype": "http://wikiba.se/ontology#Url",
-                    },
-                },
-                "items": {
-                    "entity": {
-                        "label": "entity",
-                        "description": "root entity",
-                    }
-                },
-            }
+            "instance_of": {
+                "kind": "property",
+                "label_en": "instance of",
+                "description_en": "type relation",
+                "datatype": "WikibaseItem",
+            },
+            "same_as": {
+                "kind": "property",
+                "label_en": "same as",
+                "description_en": "identity relation",
+                "datatype": "http://wikiba.se/ontology#Url",
+            },
+            "entity": {
+                "kind": "item",
+                "label_en": "entity",
+                "description_en": "root entity",
+            },
+            "error_message": {
+                "kind": "property",
+                "label_en": "error message",
+                "description_en": "message",
+                "datatype": "monolingualtext",
+            },
+            "wikibase-item": {
+                "kind": "item",
+                "label_en": "wikibase-item",
+                "description_en": "type item",
+                "error_message_en": "Item must be or resolve to a valid QID identifier.",
+            },
         },
     }
 
     normalized = normalize_meta_wikibase_init_document(prototype)
 
-    properties = normalized["entities"]["wikibase_entities"]["properties"]
-    assert properties["instance_of"]["datatype"] == "wikibase-item"
-    assert properties["same_as"]["datatype"] == "url"
-    assert properties["instance_of"]["kind"] == "property"
+    entities = normalized["entities"]
+    assert entities["instance_of"]["datatype"] == "wikibase-item"
+    assert entities["same_as"]["datatype"] == "url"
+    assert entities["instance_of"]["kind"] == "property"
+    assert entities["entity"]["kind"] == "item"
     assert (
-        normalized["entities"]["wikibase_entities"]["items"]["entity"]["kind"] == "item"
+        entities["wikibase-item"]["error_message"]
+        == "Item must be or resolve to a valid QID identifier."
     )
+
+
+def test_normalize_meta_wikibase_init_document_requires_authored_text():
+    prototype = {
+        "metadata": {"internal_name_identifier_prefix": "_", "languages": ["en"]},
+        "entities": {
+            "instance_of": {
+                "kind": "property",
+                "description_en": "type relation",
+                "datatype": "wikibase-item",
+            }
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="missing label text"):
+        normalize_meta_wikibase_init_document(prototype)
+
+
+def test_normalize_meta_wikibase_init_document_requires_sparql_fields():
+    prototype = {
+        "metadata": {"internal_name_identifier_prefix": "_", "languages": ["en"]},
+        "entities": {
+            "sparql_value_list": {
+                "kind": "item",
+                "label_en": "SPARQL-backed Value List",
+                "description_en": "list",
+            },
+            "example_values": {
+                "kind": "item",
+                "instance_of": "sparql_value_list",
+                "label_en": "Example values",
+                "description_en": "example",
+                "refresh_policy": "manual_refresh_policy",
+            },
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="requires 'sparql_endpoint' and 'query'"):
+        normalize_meta_wikibase_init_document(prototype)
+
+
+def test_normalize_meta_wikibase_init_document_requires_embedded_value_list():
+    prototype = {
+        "metadata": {"internal_name_identifier_prefix": "_", "languages": ["en"]},
+        "entities": {
+            "embedded_value_list": {
+                "kind": "item",
+                "label_en": "Embedded Value List",
+                "description_en": "list",
+            },
+            "example_values": {
+                "kind": "item",
+                "instance_of": "embedded_value_list",
+                "label_en": "Example values",
+                "description_en": "example",
+            },
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="requires 'value_list'"):
+        normalize_meta_wikibase_init_document(prototype)
 
 
 def test_build_meta_wikibase_init_index_provides_typed_entity_access():
@@ -161,7 +236,7 @@ def test_get_meta_wikibase_init_entity_returns_one_entry():
     assert entity.kind == "item"
     assert entity.instance_of == "wikibase_statement_type"
     assert entity.attributes == {
-        "error_message": "Item must be or resolve to a valid QID identifier."
+        "error_message_mul": "Item must be or resolve to a valid QID identifier."
     }
 
 
@@ -209,11 +284,17 @@ def test_compile_meta_wikibase_seed_builds_symbolic_payloads():
         ]
     )
 
-    error_message_claim = compilation.entities["wikibase-item"].payload["claims"][
-        "_error_message"
+    wikibase_item_claims = compilation.entities["wikibase-item"].payload["claims"]
+    assert sorted(wikibase_item_claims.keys()) == [
+        "_instance_of",
+        "_name_identifier",
+    ]
+
+    data_size_max_count = compilation.entities["data_size"].payload["claims"][
+        "_max_count"
     ][0]
-    assert error_message_claim["mainsnak"]["datavalue"]["type"] == "monolingualtext"
-    assert error_message_claim["mainsnak"]["datavalue"]["value"]["language"] == "mul"
+    assert data_size_max_count["mainsnak"]["snaktype"] == "novalue"
+    assert "datavalue" not in data_size_max_count["mainsnak"]
 
 
 def test_compile_meta_wikibase_seed_uses_package_language_for_display_text(
@@ -241,6 +322,14 @@ def test_plan_meta_wikibase_seed_baseline_compares_live_state_and_requires_mul()
                     "language": "en",
                     "value": "wikibase item property template used to set a data type for a statement, reference, or qualifier and any additional specifications",
                 }
+            },
+            "aliases": {
+                "en": [
+                    {
+                        "language": "en",
+                        "value": "_wikibase-item",
+                    }
+                ]
             },
             "claims": {
                 "P1": [
@@ -315,22 +404,205 @@ def test_plan_meta_wikibase_seed_baseline_compares_live_state_and_requires_mul()
     assert matching_entry.action == "skip"
     assert matching_entry.current_entity_id == "Q50"
 
-    invalid_current_entities = deepcopy(current_entities)
-    invalid_current_entities["_wikibase-item"]["claims"]["P168"][0]["mainsnak"][
-        "datavalue"
-    ]["value"]["language"] = "en"
+    data_size_entity = {
+        "id": "Q91",
+        "type": "item",
+        "labels": {"en": {"language": "en", "value": "data size"}},
+        "descriptions": {
+            "en": {
+                "language": "en",
+                "value": "size of a software, dataset, neural network, or individual file",
+            }
+        },
+        "claims": {
+            "P1": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P1",
+                        "datavalue": {
+                            "type": "wikibase-entityid",
+                            "value": {
+                                "entity-type": "item",
+                                "id": "Q5",
+                                "numeric-id": 5,
+                            },
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+            "P214": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P214",
+                        "datavalue": {
+                            "type": "string",
+                            "value": "_data_size",
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+            "P215": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P215",
+                        "datavalue": {
+                            "type": "wikibase-entityid",
+                            "value": {
+                                "entity-type": "item",
+                                "id": "Q71",
+                                "numeric-id": 71,
+                            },
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+            "P182": [
+                {
+                    "mainsnak": {
+                        "snaktype": "novalue",
+                        "property": "P182",
+                        "datatype": "quantity",
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+            "P158": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P158",
+                        "datavalue": {
+                            "type": "wikibase-entityid",
+                            "value": {
+                                "entity-type": "item",
+                                "id": "Q90",
+                                "numeric-id": 90,
+                            },
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+            "P171": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P171",
+                        "datavalue": {
+                            "type": "monolingualtext",
+                            "value": {
+                                "language": "mul",
+                                "text": "enter a value for total size of the data item",
+                            },
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+            "P169": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P169",
+                        "datavalue": {
+                            "type": "monolingualtext",
+                            "value": {
+                                "language": "mul",
+                                "text": "Enter a value for the data size of the subject and specify an appropriate unit of measure",
+                            },
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+            "P168": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P168",
+                        "datavalue": {
+                            "type": "monolingualtext",
+                            "value": {
+                                "language": "mul",
+                                "text": "Failure to provide a data size with the appropriate unit of measure may result in a reduced ability to determine appropriate use of the information",
+                            },
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+            "P5": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P5",
+                        "datavalue": {
+                            "type": "string",
+                            "value": "http://www.wikidata.org/entity/P3575",
+                        },
+                    },
+                    "type": "statement",
+                    "rank": "normal",
+                }
+            ],
+        },
+    }
+    novalue_entities = dict(current_entities)
+    novalue_entities["_data_size"] = data_size_entity
+    novalue_entity_id_to_internal_name_identifier = {
+        **entity_id_to_internal_name_identifier,
+        "P5": "_same_as",
+        "P158": "_has_qualifier",
+        "P168": "_error_message",
+        "P169": "_statement_guidance",
+        "P171": "_statement_prompt",
+        "P182": "_max_count",
+        "P215": "_statement_type",
+        "Q5": "_entity_statement",
+        "Q71": "_quantity",
+        "Q90": "_data_size_units",
+    }
+    novalue_plan = plan_meta_wikibase_seed_baseline(
+        current_entities_by_internal_name_identifier=novalue_entities,
+        entity_id_to_internal_name_identifier=novalue_entity_id_to_internal_name_identifier,
+    )
+    novalue_entry = next(
+        operation
+        for operation in novalue_plan.operations
+        if operation.internal_name_identifier == "_data_size"
+    )
+    assert novalue_entry.action == "skip"
 
-    invalid_plan = plan_meta_wikibase_seed_baseline(
-        current_entities_by_internal_name_identifier=invalid_current_entities,
+    invalid_claim_entities = deepcopy(current_entities)
+    invalid_claim_entities["_wikibase-item"]["claims"]["P1"][0]["mainsnak"][
+        "datavalue"
+    ]["value"]["id"] = "Q100"
+
+    invalid_claim_plan = plan_meta_wikibase_seed_baseline(
+        current_entities_by_internal_name_identifier=invalid_claim_entities,
         entity_id_to_internal_name_identifier=entity_id_to_internal_name_identifier,
     )
-    invalid_entry = next(
+    invalid_claim_entry = next(
         operation
-        for operation in invalid_plan.operations
+        for operation in invalid_claim_plan.operations
         if operation.internal_name_identifier == "_wikibase-item"
     )
-    assert invalid_entry.action == "update"
-    assert "_error_message.language" in (invalid_entry.changed_fields or [])
+    assert invalid_claim_entry.action == "update"
+    assert "claims._instance_of" in (invalid_claim_entry.changed_fields or [])
 
 
 def test_compile_meta_wikibase_seed_uses_bottler_primitives(monkeypatch):


### PR DESCRIPTION
## Summary

- align Meta-Wikibase conformance with cache-backed SpiritSafe artifacts
- add a sync-only value-list CLI path separate from SPARQL hydration
- move talk-page value-list classification rules into runtime config and SpiritSafe YAML
- expand regression coverage for cache sync, talk-page drift, and shipper safety

## Verification

- poetry run ruff check gkc tests
- poetry run black --check gkc tests
- poetry run pytest --cov=gkc --cov-report=xml --cov-report=term
